### PR TITLE
fix(scripts/build-sdk-apk): forward host SHA and preserve source-URL default

### DIFF
--- a/scripts/build-sdk-apk.sh
+++ b/scripts/build-sdk-apk.sh
@@ -13,28 +13,50 @@ mkdir -p "$ARTIFACT_DIR"
 # Anchor to repo root so the docker mount is correct regardless of CWD.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Resolve the source SHA on the host, where git works. The Makefile's
+# $(shell git rev-parse HEAD) runs at parse time inside the SDK container
+# with cwd=/builder (not a git repo), so it returns empty and the SDK
+# silently writes a zero-byte source tarball. Override on the make command
+# line so the SDK clones the right commit from TOLLGATE_PKG_SOURCE_URL.
+if ! PKG_SOURCE_VERSION="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)"; then
+    printf 'error: %s is not a git checkout — cannot determine PKG_SOURCE_VERSION\n' "$REPO_ROOT" >&2
+    exit 1
+fi
+
 printf 'Using SDK_TAG=%s\n' "$SDK_TAG"
 printf 'Using PACKAGE_VERSION=%s\n' "$PACKAGE_VERSION"
+printf 'Using PKG_SOURCE_VERSION=%s\n' "$PKG_SOURCE_VERSION"
 if [ -n "$TOLLGATE_PKG_SOURCE_URL" ]; then
     printf 'Using TOLLGATE_PKG_SOURCE_URL=%s\n' "$TOLLGATE_PKG_SOURCE_URL"
 fi
 
+# Only forward TOLLGATE_PKG_SOURCE_URL when the caller actually set it.
+# Forwarding it as an empty string defeats the Makefile's ?= default and
+# leaves PKG_SOURCE_URL empty, which silently breaks the SDK source fetch.
+docker_env_args="-e PACKAGE_VERSION=$PACKAGE_VERSION"
+if [ -n "$TOLLGATE_PKG_SOURCE_URL" ]; then
+    docker_env_args="$docker_env_args -e TOLLGATE_PKG_SOURCE_URL=$TOLLGATE_PKG_SOURCE_URL"
+fi
+
+# Use a double-quoted sh -lc string so the host shell expands
+# $PKG_SOURCE_VERSION into a literal SHA in the command. Make's command-
+# line override only takes effect at parse time when the value is a real
+# string, not an env-var reference resolved later inside the container.
 docker run --rm -u root \
     -v "$REPO_ROOT":/builder/package/tollgate-wrt \
     -v "$ARTIFACT_DIR":/artifacts \
-    -e PACKAGE_VERSION="$PACKAGE_VERSION" \
-    -e TOLLGATE_PKG_SOURCE_URL="$TOLLGATE_PKG_SOURCE_URL" \
+    $docker_env_args \
     "openwrt/sdk:${SDK_TAG}" \
-    sh -lc '
-        printf "deb https://deb.debian.org/debian bookworm-backports main\n" > /etc/apt/sources.list.d/backports.list &&
+    sh -lc "
+        printf 'deb https://deb.debian.org/debian bookworm-backports main\n' > /etc/apt/sources.list.d/backports.list &&
         apt-get update &&
         apt-get install -y -t bookworm-backports golang-go &&
         cd /builder &&
         make defconfig &&
-        printf "CONFIG_USE_APK=y\nCONFIG_PACKAGE_tollgate-wrt=y\nCONFIG_PACKAGE_nodogsplash=y\nCONFIG_PACKAGE_luci=y\nCONFIG_PACKAGE_jq=y\n" >> .config &&
+        printf 'CONFIG_USE_APK=y\nCONFIG_PACKAGE_tollgate-wrt=y\nCONFIG_PACKAGE_nodogsplash=y\nCONFIG_PACKAGE_luci=y\nCONFIG_PACKAGE_jq=y\n' >> .config &&
         make defconfig &&
-        env PACKAGE_VERSION="$PACKAGE_VERSION" TOLLGATE_PKG_SOURCE_URL="$TOLLGATE_PKG_SOURCE_URL" make -j1 V=s package/tollgate-wrt/compile &&
+        make -j1 V=s PKG_SOURCE_VERSION=$PKG_SOURCE_VERSION package/tollgate-wrt/compile &&
         rm -rf /artifacts/apk-25_12 &&
         mkdir -p /artifacts/apk-25_12 &&
         cp -R /builder/bin/packages/. /artifacts/apk-25_12/
-    '
+    "


### PR DESCRIPTION
## Summary

The `scripts/build-sdk-apk.sh` helper that ships in [#81](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/81) (and predates it) doesn't actually work — running it as documented produces no apk and exits with a confusing source-fetch error. Two stacked flaws:

### 1. `PKG_SOURCE_VERSION` was never forwarded
The Makefile resolves it via `$(shell git rev-parse HEAD)` at parse time. Inside the SDK container, that runs with `cwd=/builder` — which isn't a git repo — so it returns an empty string. The SDK then writes a zero-byte source tarball at `/builder/dl/tollgate-wrt-<version>.tar.zst`, `Build/Prepare` can't extract it, and you get:
```
zstd: can't stat /builder/dl/tollgate-wrt-0.0.0-r0.tar.zst : No such file or directory -- ignored
/builder/staging_dir/host/bin/tar: This does not look like a tar archive
ERROR: package/tollgate-wrt failed to build.
```

Fix: resolve the SHA on the host with `git -C $REPO_ROOT rev-parse HEAD`, embed it as a make command-line override (`PKG_SOURCE_VERSION=$sha`). Switch the inner `sh -lc` to double quotes so the SHA is a literal at host expansion time — make's CLI override only takes effect at parse time, before env-var substitution inside the container would matter.

### 2. Empty `TOLLGATE_PKG_SOURCE_URL` defeated the Makefile default
The script always passed `-e TOLLGATE_PKG_SOURCE_URL=""` to docker. The Makefile has `TOLLGATE_PKG_SOURCE_URL?=https://github.com/OpenTollGate/tollgate-module-basic-go.git`, but `?=` only substitutes a default when the variable is **unset** — an empty value still counts as set, so `PKG_SOURCE_URL` ended up blank and the SDK had nothing to clone.

Fix: only forward `TOLLGATE_PKG_SOURCE_URL` when the caller actually set it.

## Test plan
- [x] On the cleanup branch (sha `0286d2a`):
  ```
  SDK_TAG=mediatek-filogic-25.12.0 ARTIFACT_DIR=/tmp/foo bash scripts/build-sdk-apk.sh
  ```
  produces `/tmp/foo/apk-25_12/aarch64_cortex-a53/base/tollgate-wrt-0.0.0-r0.apk` (6.1 MB).
- [ ] Default invocation `bash scripts/build-sdk-apk.sh` (mips_24kc target) — not exercised here, but uses the same code paths.
- [ ] Override `TOLLGATE_PKG_SOURCE_URL=...` to build from a fork — not exercised, follows the same conditional.

## Notes
Branched off `cleanup/dead-code-and-docs` because the script was moved into `scripts/` there. Targets that branch as the base; will rebase if [#81](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/81) is squashed.