### PR TITLE
fix(packaging): wrap ipk as gzipped tar (cherry-pick of 825610a)

### DIFF
--- a/packaging/build-ipk.sh
+++ b/packaging/build-ipk.sh
@@ -81,9 +81,14 @@ done
 # 5. debian-binary
 printf '2.0\n' > "$WORK/debian-binary"
 
-# 6. ar-pack. debian-binary must appear first; opkg streams the ar.
+# 6. Wrap as gzipped tar — this is the OpenWrt opkg-build ipk format
+# (NOT the Debian ar format). opkg itself reads either, but the
+# OpenWrt-side tooling in the wild assumes tar.gz wrapping
+# (e.g. `tar -xzOf foo.ipk ./control.tar.gz`), so we have to match.
 rm -f "$OUTPUT"
-( cd "$WORK" && ar -r "$OUTPUT" debian-binary control.tar.gz data.tar.gz )
+( cd "$WORK" && \
+  "$TAR" --owner=0 --group=0 --numeric-owner \
+    -czf "$OUTPUT" ./debian-binary ./data.tar.gz ./control.tar.gz )
 
 size=$(wc -c < "$OUTPUT" | tr -d ' ')
 printf 'Built %s (%s bytes)\n' "$OUTPUT" "$size"


### PR DESCRIPTION
Cherry-pick of [`825610a`](https://github.com/OpenTollGate/tollgate-module-basic-go/commit/825610a296bd3bd12bf8f3055e0750450ac78c07) from the perf branch.

PR [#98](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/98) was squash-merged when it had only one commit; this tar.gz-wrapping fix landed on the perf branch *an hour after* the squash, so main never got it. Every basic-go ipk built from main since then has been **AR-wrapped**, which `opkg install` accepts but every OpenWrt-side tar-based ipk extractor (incl. tollgate-os's custom-package inspector and the OpenWrt-25 image builder) rejects.

Symptom currently visible on tollgate-os:

```
⚠️  Could not extract package name from tollgate-wrt_*.ipk
❌ No valid packages found in ./custom-packages
```

Diff is one line of executable code: swap `ar -r` for `tar -czf` in `packaging/build-ipk.sh`. Surrounding comments updated. opkg-build (OpenWrt SDK) uses tar.gz wrapping too, so this matches the canonical format.

## Test plan

- [ ] Pipeline rebuild on this PR produces tar.gz-wrapped ipks
- [ ] `tar -xzOf <pkg>.ipk ./control.tar.gz | tar -xzOf - ./control | grep ^Package:` succeeds against the artifacts
- [ ] tollgate-os build (any device, any compression) downloads the new ipk and progresses past the inspect step