### PR TITLE
fix(security): replace math/rand with crypto/rand for password generation

### DIFF
--- a/src/cli/network.go
+++ b/src/cli/network.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	crypto_rand "crypto/rand"
 	"fmt"
+	"math/big"
 	"os/exec"
 	"strings"
 	"time"
@@ -294,7 +296,6 @@ func (s *CLIServer) handlePrivateNetworkSetPassword(newPassword string) CLIRespo
 
 // generateRandomPassword generates a human-readable random password
 func generateRandomPassword() (string, error) {
-	// Use the same word list as the shell script
 	words := []string{
 		"alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
 		"golf", "hotel", "india", "juliet", "kilo", "lima",
@@ -303,17 +304,23 @@ func generateRandomPassword() (string, error) {
 		"yankee", "zulu",
 	}
 
-	// Generate 3 random words using time-based randomness
-	word1 := words[time.Now().UnixNano()%int64(len(words))]
-	time.Sleep(1 * time.Millisecond)
-	word2 := words[time.Now().UnixNano()%int64(len(words))]
-	time.Sleep(1 * time.Millisecond)
-	word3 := words[time.Now().UnixNano()%int64(len(words))]
+	word1, err := randomWord(words)
+	if err != nil {
+		return "", err
+	}
+	word2, err := randomWord(words)
+	if err != nil {
+		return "", err
+	}
+	word3, err := randomWord(words)
+	if err != nil {
+		return "", err
+	}
+	num, err := crypto_rand.Int(crypto_rand.Reader, big.NewInt(100))
+	if err != nil {
+		return "", err
+	}
 
-	// Add a random 2-digit number
-	num := time.Now().UnixNano() % 100
-
-	// Capitalize first letter of each word
 	capitalize := func(s string) string {
 		if len(s) == 0 {
 			return s
@@ -321,7 +328,15 @@ func generateRandomPassword() (string, error) {
 		return strings.ToUpper(string(s[0])) + s[1:]
 	}
 
-	return fmt.Sprintf("%s-%s-%s-%02d", capitalize(word1), capitalize(word2), capitalize(word3), num), nil
+	return fmt.Sprintf("%s-%s-%s-%02d", capitalize(word1), capitalize(word2), capitalize(word3), num.Int64()), nil
+}
+
+func randomWord(words []string) (string, error) {
+	n, err := crypto_rand.Int(crypto_rand.Reader, big.NewInt(int64(len(words))))
+	if err != nil {
+		return "", err
+	}
+	return words[n.Int64()], nil
 }
 
 // getUCIValue retrieves a UCI configuration value

--- a/src/cli/network.go
+++ b/src/cli/network.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"crypto/rand"
 	"fmt"
+	"math/big"
 	"os/exec"
 	"strings"
 	"time"
@@ -294,7 +296,6 @@ func (s *CLIServer) handlePrivateNetworkSetPassword(newPassword string) CLIRespo
 
 // generateRandomPassword generates a human-readable random password
 func generateRandomPassword() (string, error) {
-	// Use the same word list as the shell script
 	words := []string{
 		"alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
 		"golf", "hotel", "india", "juliet", "kilo", "lima",
@@ -303,17 +304,23 @@ func generateRandomPassword() (string, error) {
 		"yankee", "zulu",
 	}
 
-	// Generate 3 random words using time-based randomness
-	word1 := words[time.Now().UnixNano()%int64(len(words))]
-	time.Sleep(1 * time.Millisecond)
-	word2 := words[time.Now().UnixNano()%int64(len(words))]
-	time.Sleep(1 * time.Millisecond)
-	word3 := words[time.Now().UnixNano()%int64(len(words))]
+	word1, err := randomWord(words)
+	if err != nil {
+		return "", err
+	}
+	word2, err := randomWord(words)
+	if err != nil {
+		return "", err
+	}
+	word3, err := randomWord(words)
+	if err != nil {
+		return "", err
+	}
+	num, err := rand.Int(rand.Reader, big.NewInt(100))
+	if err != nil {
+		return "", err
+	}
 
-	// Add a random 2-digit number
-	num := time.Now().UnixNano() % 100
-
-	// Capitalize first letter of each word
 	capitalize := func(s string) string {
 		if len(s) == 0 {
 			return s
@@ -321,7 +328,15 @@ func generateRandomPassword() (string, error) {
 		return strings.ToUpper(string(s[0])) + s[1:]
 	}
 
-	return fmt.Sprintf("%s-%s-%s-%02d", capitalize(word1), capitalize(word2), capitalize(word3), num), nil
+	return fmt.Sprintf("%s-%s-%s-%02d", capitalize(word1), capitalize(word2), capitalize(word3), num.Int64()), nil
+}
+
+func randomWord(words []string) (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(words))))
+	if err != nil {
+		return "", err
+	}
+	return words[n.Int64()], nil
 }
 
 // getUCIValue retrieves a UCI configuration value


### PR DESCRIPTION
## Summary

Replaces predictable `time.Now().UnixNano()`-based randomness with `crypto/rand` in `generateRandomPassword()`. The previous implementation:

- Used `time.Now().UnixNano() % len(words)` to pick words — deterministic if called in quick succession
- Inserted `time.Sleep(1ms)` between selections to work around the predictability
- Used modulo bias (`% 100`) for the numeric suffix

The new implementation uses `crypto/rand.Int` for all random selections, removing the timing dependency and modulo bias.

## Test plan

- [x] Existing password format unchanged: `Word-Word-Word-NN`
- [x] Passwords remain WPA2-compliant (8+ chars, mixed case + digits)
- [ ] Verify on-device: `tollgate network set-private-network` generates unique passwords across rapid invocations