### PR TITLE
feat: HTTPS reverse proxy for LuCI with TLS termination

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -33,6 +33,7 @@ jobs:
               { "compile_key": "arm64",           "goarch": "arm64" },
               { "compile_key": "armv7",           "goarch": "arm",    "goarm": "7" },
               { "compile_key": "mipsle-softfloat","goarch": "mipsle", "gomips": "softfloat" },
+              { "compile_key": "amd64",           "goarch": "amd64" }
               { "compile_key": "mips-softfloat",  "goarch": "mips",   "gomips": "softfloat" }
             ]
           }
@@ -67,6 +68,7 @@ jobs:
               { "architecture": "arm_cortex-a7",      "compile_key": "armv7",            "sdk": "bcm27xx-bcm2709",  "ipk": true, "apk": false, "compression": "upx-ultra-brute" },
               { "architecture": "mipsel_24kc",        "compile_key": "mipsle-softfloat", "sdk": "ramips-mt7621",    "ipk": true, "apk": false },
               { "architecture": "mipsel_24kc",        "compile_key": "mipsle-softfloat", "sdk": "ramips-mt7621",    "ipk": true, "apk": false, "compression": "upx-ultra-brute" },
+              { "architecture": "x86_64",             "compile_key": "amd64",            "sdk": "x86-64",           "ipk": true, "apk": false }
               { "architecture": "mips_24kc",          "compile_key": "mips-softfloat",   "sdk": "ath79-generic",    "ipk": true, "apk": false },
               { "architecture": "mips_24kc",          "compile_key": "mips-softfloat",   "sdk": "ath79-generic",    "ipk": true, "apk": false, "compression": "upx-fast" },
               { "architecture": "mips_24kc",          "compile_key": "mips-softfloat",   "sdk": "ath79-generic",    "ipk": true, "apk": false, "compression": "upx-best" },

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -33,7 +33,7 @@ jobs:
               { "compile_key": "arm64",           "goarch": "arm64" },
               { "compile_key": "armv7",           "goarch": "arm",    "goarm": "7" },
               { "compile_key": "mipsle-softfloat","goarch": "mipsle", "gomips": "softfloat" },
-              { "compile_key": "amd64",           "goarch": "amd64" }
+              { "compile_key": "amd64",           "goarch": "amd64" },
               { "compile_key": "mips-softfloat",  "goarch": "mips",   "gomips": "softfloat" }
             ]
           }
@@ -68,7 +68,7 @@ jobs:
               { "architecture": "arm_cortex-a7",      "compile_key": "armv7",            "sdk": "bcm27xx-bcm2709",  "ipk": true, "apk": false, "compression": "upx-ultra-brute" },
               { "architecture": "mipsel_24kc",        "compile_key": "mipsle-softfloat", "sdk": "ramips-mt7621",    "ipk": true, "apk": false },
               { "architecture": "mipsel_24kc",        "compile_key": "mipsle-softfloat", "sdk": "ramips-mt7621",    "ipk": true, "apk": false, "compression": "upx-ultra-brute" },
-              { "architecture": "x86_64",             "compile_key": "amd64",            "sdk": "x86-64",           "ipk": true, "apk": false }
+              { "architecture": "x86_64",             "compile_key": "amd64",            "sdk": "x86-64",           "ipk": true, "apk": false },
               { "architecture": "mips_24kc",          "compile_key": "mips-softfloat",   "sdk": "ath79-generic",    "ipk": true, "apk": false },
               { "architecture": "mips_24kc",          "compile_key": "mips-softfloat",   "sdk": "ath79-generic",    "ipk": true, "apk": false, "compression": "upx-fast" },
               { "architecture": "mips_24kc",          "compile_key": "mips-softfloat",   "sdk": "ath79-generic",    "ipk": true, "apk": false, "compression": "upx-best" },

--- a/docs/captive-portal.md
+++ b/docs/captive-portal.md
@@ -128,7 +128,7 @@ The `99-tollgate-setup` script only enables HTTPS on uhttpd if cert and key
 files already exist at `/etc/uhttpd.crt` and `/etc/uhttpd.key`. On a fresh
 firmware flash, these files don't exist, so uhttpd runs HTTP only on port 8080.
 
-### Enabling SSL
+### Enabling SSL (Real Certificate)
 
 ```
 tollgate-apply-ssl <cert-file> [key-file]
@@ -147,10 +147,30 @@ This script:
    clients can reach uhttpd HTTPS
 8. **Reloads** all services
 
-After applying SSL:
+After applying SSL with a real cert:
 - `http://example.com/` → captive portal (NoDogSplash, HTTP)
 - `https://example.com/` → LuCI admin (uhttpd, HTTPS)
 - `http://example.com:8080/` → LuCI admin (uhttpd, HTTP, still available)
+
+### Enabling SSL (Self-Signed)
+
+```
+tollgate-apply-ssl
+```
+
+When called with no arguments, the script generates a self-signed certificate
+for the router's hostname (e.g. `TollGate.lan`). This mode:
+
+- Generates a 2048-bit RSA cert valid for 10 years using openssl (or px5g fallback)
+- Configures uhttpd to serve HTTPS on port 443
+- Allows port 443 through NoDogSplash firewall
+- Does **not** change dnsmasq or NoDogSplash domain (hostname already resolves)
+
+Self-signed HTTPS is intended for encrypted LuCI admin access on the local
+network. Browsers will display a certificate warning that users must accept.
+
+**Self-signed certs do NOT provide RFC 8908 compliance.** See
+[Standards Compliance](#standards-compliance) below.
 
 ### Disabling SSL
 
@@ -160,17 +180,22 @@ tollgate-remove-ssl
 
 Reverts all changes made by `tollgate-apply-ssl`:
 - Removes installed cert+key
-- Restores uhttpd to default cert configuration
-- Removes dnsmasq domain entry
-- Reverts NoDogSplash to original `gatewaydomainname` and `gatewayport`
+- Restores uhttpd to previous cert configuration
+- Removes dnsmasq domain entry (real-cert mode only)
+- Reverts NoDogSplash `gatewaydomainname` (real-cert mode only)
+- Removes port 443 firewall allow rule
 - Reloads all services
 
-### Self-Signed Certificates (Not Yet Implemented)
+### Script Interaction with First-Boot Setup
 
-Planned: when `tollgate-apply-ssl` is called without a cert file, it should
-generate a self-signed certificate for local use. This would enable LuCI
-HTTPS on the local network but does **not** provide RFC 8908 compliance
-(browsers will show certificate warnings).
+`99-tollgate-setup` runs once on first boot. `tollgate-apply-ssl` runs
+manually afterward. They don't conflict because:
+
+- Setup configures uhttpd HTTPS only if `/etc/uhttpd.crt` + `/etc/uhttpd.key`
+  already exist (firmware-provided certs)
+- `tollgate-apply-ssl` overwrites cert/key paths and backs up current values
+- `tollgate-remove-ssl` restores from backup — reverts to pre-SSL state
+- Re-running setup (removing setup flag) resets everything to defaults
 
 ## Standards Compliance
 
@@ -205,18 +230,38 @@ Response: { "captive": true, "user-portal-url": "https://..." }
 ```
 
 Requirements for compliance:
-- **HTTPS with publicly trusted certificate** — self-signed does not qualify
+- **HTTPS with validated certificate** — client MUST validate cert per RFC 6125
 - Content-Type: `application/captive+json`
-- Cache-Control: `no-store`
+- Cache-Control: `no-store` or `private`
 - Per-client state (must know if the requesting client is authenticated)
+- OCSP stapling SHOULD be supported
+- Network SHOULD allow access to OCSP/CRL/NTP servers
 
-Implementation options:
-- Add to Go API (`tollgate-basic` on port 2121) — would need TLS support
-- Add to uhttpd via CGI script — simpler but less flexible
+#### Self-Signed Certificates and RFC 8908
 
-**Why not yet**: Requires a publicly trusted cert and integration with
-NoDogSplash's client auth state. The current HTTP interception approach
-works on all platforms.
+The RFC does **not** explicitly require a publicly trusted CA certificate. It
+requires that clients successfully validate the certificate. However, in
+practice:
+
+- A plain self-signed cert will **fail validation** on unmanaged devices
+  (consumers) because it's not in their trust store
+- A private CA root works if you **control the client devices** (enterprise)
+- **Best interoperability**: real domain + publicly trusted cert
+
+RFC 8908 Section 4.1 includes a **graceful degradation clause**:
+
+> *"If the client is unable to validate the certificate presented by the API
+> server, it MUST NOT proceed with any of the behavior for API interaction
+> described in this document. The client will proceed to interact with the
+> captive network as if the API capabilities were not present."*
+
+This means clients fall back to legacy HTTP interception when cert validation
+fails. Our current captive portal (NoDogSplash on port 80) works correctly as
+this fallback.
+
+**Why not yet**: Requires a publicly trusted cert on a real domain + integration
+with NoDogSplash's client auth state. Self-signed certs provide HTTPS for LuCI
+admin but cannot serve as an RFC 8908 endpoint for unmanaged devices.
 
 ### RFC 8952 — CAPPORT Architecture
 

--- a/docs/captive-portal.md
+++ b/docs/captive-portal.md
@@ -1,0 +1,257 @@
+# Captive Portal Architecture
+
+## Overview
+
+The TollGate captive portal intercepts HTTP traffic from unauthenticated WiFi
+clients and presents a splash page where they can pay for internet access. It
+uses **NoDogSplash** for traffic interception and client auth, a **React SPA**
+for the splash page, and a **Go API** for payment processing.
+
+## Service Layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    TollGate Router                       │
+│                                                         │
+│  Port 80   ─ NoDogSplash (captive portal gateway)       │
+│  Port 443  ─ uhttpd (LuCI admin, HTTPS)                 │
+│  Port 8080 ─ uhttpd (LuCI admin, HTTP)                  │
+│  Port 2121 ─ tollgate-basic (Go API, HTTP)              │
+│                                                         │
+│  dnsmasq   ─ DNS resolver (TollGate.lan → LAN IP)      │
+│  iptables  ─ HTTP interception for unauthenticated      │
+│              clients on br-lan                          │
+└─────────────────────────────────────────────────────────┘
+```
+
+| Port | Service | Protocol | Purpose |
+|------|---------|----------|---------|
+| 80 | NoDogSplash | HTTP | Captive portal gateway — intercepts traffic, serves splash page |
+| 443 | uhttpd | HTTPS | LuCI admin interface (when SSL cert is installed) |
+| 8080 | uhttpd | HTTP | LuCI admin interface (always available) |
+| 2121 | tollgate-basic | HTTP | Go API — payment processing, wallet, config |
+
+## Hostname and DNS
+
+### Default Behavior (first boot)
+
+The `99-tollgate-setup` uci-defaults script (installed by the `tollgate-wrt`
+package) configures:
+
+1. **Hostname**: `TollGate` (only if current hostname is `OpenWrt`)
+2. **NoDogSplash**: `gatewaydomainname='TollGate.lan'`, `gatewayport='80'`
+3. **dnsmasq**: resolves `TollGate.lan` to the LAN IP via the hostname
+4. **uhttpd**: `commonname='$hostname'` (used for self-signed cert generation)
+
+### DNS Resolution
+
+| Client Location | Query | Resolves To | How |
+|----------------|-------|-------------|-----|
+| WiFi client on LAN | `TollGate.lan` | `172.24.193.1` (LAN IP) | dnsmasq on router |
+| Device on WAN network | `TollGate.lan` | `192.168.x.x` (WAN IP) | Router's DHCP hostname registration |
+
+### WAN-side Access
+
+The router registers its hostname via DHCP on the WAN interface. Any device on
+the same upstream network can reach it as `TollGate.lan`. This works for:
+- Accessing LuCI admin from the upstream network
+- Accessing the Go API from the upstream network
+
+The captive portal itself only applies to WiFi clients on br-lan interfaces.
+
+## Captive Portal Detection (CPD)
+
+NoDogSplash uses **iptables HTTP interception** on port 80. When an
+unauthenticated client makes an HTTP request, iptables redirects it to
+NoDogSplash which serves the splash page.
+
+### Platform CPD Behavior
+
+| Platform | Detection Method | Works With Our Setup |
+|----------|-----------------|---------------------|
+| iOS (Apple CNA) | HTTP probe to `captive.apple.com` | ✅ Intercepted → splash page |
+| Android | HTTP probe to `connectivitycheck.gstatic.com` | ✅ Intercepted → splash page |
+| Windows (NCSI) | HTTP probe to `www.msftconnecttest.com` | ✅ Intercepted → splash page |
+| macOS | HTTP probe to `captive.apple.com` | ✅ Intercepted → splash page |
+
+All major platforms detect the captive portal via HTTP probes. NoDogSplash
+intercepts these probes and redirects to the splash page. This is the legacy
+method and works reliably on all current OS versions.
+
+## Splash Page Flow
+
+```
+1. Client connects to WiFi (br-lan)
+2. Client sends HTTP request (any URL)
+3. iptables REDIRECT → NoDogSplash on port 80
+4. NoDogSplash checks client MAC:
+   - Authenticated → allow traffic through
+   - Not authenticated → serve splash page
+5. Splash page (React SPA) loads, shows payment options
+6. Client pays via Go API (port 2121)
+7. Go API calls `ndsctl auth <MAC> <token>`
+8. Client is authenticated → internet access granted
+```
+
+### Splash Page Location
+
+- Source: [OpenTollGate/tollgate-captive-portal-site](https://github.com/OpenTollGate/tollgate-captive-portal-site)
+- Installed to: `/etc/tollgate/tollgate-captive-portal-site/`
+- Symlinked from: `/etc/nodogsplash/htdocs/` (via `90-tollgate-captive-portal-symlink`)
+
+The splash page uses `window.location.hostname` to discover the router
+address and communicates with the Go API at `http://<hostname>:2121`.
+
+## SSL/HTTPS
+
+### Architecture Decision: Captive Portal Stays HTTP
+
+NoDogSplash **cannot serve HTTPS**. It is built on libmicrohttpd without
+`MHD_USE_TLS` support. This is not a limitation we can work around without
+forking NoDogSplash.
+
+Additionally, captive portal detection on all platforms uses **plain HTTP
+probes**. iOS, Android, and Windows all send HTTP (not HTTPS) requests to
+detect the portal. Switching the captive portal to HTTPS would break CPD.
+
+**Port 443 is served by uhttpd for LuCI admin only.**
+
+### Default State (no SSL)
+
+On a fresh install, the router serves everything over HTTP:
+
+- `http://TollGate.lan/` → captive portal (NoDogSplash)
+- `http://TollGate.lan:8080/` → LuCI admin (uhttpd)
+- `http://TollGate.lan:2121/` → Go API
+
+The `99-tollgate-setup` script only enables HTTPS on uhttpd if cert and key
+files already exist at `/etc/uhttpd.crt` and `/etc/uhttpd.key`. On a fresh
+firmware flash, these files don't exist, so uhttpd runs HTTP only on port 8080.
+
+### Enabling SSL
+
+```
+tollgate-apply-ssl <cert-file> [key-file]
+```
+
+This script:
+
+1. **Validates** the certificate (PEM format, not expired)
+2. **Extracts domain** from SAN or CN
+3. **Installs** cert+key to `/etc/tollgate/ssl/`
+4. **Configures uhttpd** to serve HTTPS on port 443 using the cert
+5. **Adds dnsmasq entry** so the cert's domain resolves to the LAN IP
+6. **Updates NoDogSplash** `gatewaydomainname` to the cert's domain (portal
+   stays on HTTP port 80)
+7. **Allows port 443** through NoDogSplash's `users_to_router` firewall so
+   clients can reach uhttpd HTTPS
+8. **Reloads** all services
+
+After applying SSL:
+- `http://example.com/` → captive portal (NoDogSplash, HTTP)
+- `https://example.com/` → LuCI admin (uhttpd, HTTPS)
+- `http://example.com:8080/` → LuCI admin (uhttpd, HTTP, still available)
+
+### Disabling SSL
+
+```
+tollgate-remove-ssl
+```
+
+Reverts all changes made by `tollgate-apply-ssl`:
+- Removes installed cert+key
+- Restores uhttpd to default cert configuration
+- Removes dnsmasq domain entry
+- Reverts NoDogSplash to original `gatewaydomainname` and `gatewayport`
+- Reloads all services
+
+### Self-Signed Certificates (Not Yet Implemented)
+
+Planned: when `tollgate-apply-ssl` is called without a cert file, it should
+generate a self-signed certificate for local use. This would enable LuCI
+HTTPS on the local network but does **not** provide RFC 8908 compliance
+(browsers will show certificate warnings).
+
+## Standards Compliance
+
+### RFC 8910 — DHCP Captive Portal Option
+
+**Status: Not implemented**
+
+RFC 8910 defines DHCP Option 114 which advertises a captive portal URI via
+DHCP or Router Advertisements. Modern clients (iOS 14+, Android 11+,
+Windows 11+) can use this for faster portal detection without relying on
+HTTP interception.
+
+Implementation would require:
+- `dhcp-option=114,<API-URI>` in dnsmasq config
+- An RFC 8908 compliant API endpoint (see below)
+- Only advertised when a valid HTTPS cert is installed
+
+**Why not yet**: Option 114 should point to an RFC 8908 API endpoint served
+over HTTPS with a publicly trusted certificate. `.lan` domains cannot get
+public CA certificates. This requires a real domain + cert.
+
+### RFC 8908 — Captive Portal API
+
+**Status: Not implemented**
+
+RFC 8908 defines a JSON API for captive portal state. The endpoint would be:
+```
+GET /.well-known/captive-portal
+Accept: application/captive+json
+
+Response: { "captive": true, "user-portal-url": "https://..." }
+```
+
+Requirements for compliance:
+- **HTTPS with publicly trusted certificate** — self-signed does not qualify
+- Content-Type: `application/captive+json`
+- Cache-Control: `no-store`
+- Per-client state (must know if the requesting client is authenticated)
+
+Implementation options:
+- Add to Go API (`tollgate-basic` on port 2121) — would need TLS support
+- Add to uhttpd via CGI script — simpler but less flexible
+
+**Why not yet**: Requires a publicly trusted cert and integration with
+NoDogSplash's client auth state. The current HTTP interception approach
+works on all platforms.
+
+### RFC 8952 — CAPPORT Architecture
+
+**Status: Partially compliant**
+
+RFC 8952 establishes that captive portal solutions:
+- ✅ MUST NOT require forging DNS responses — we use HTTP interception, not DNS forgery
+- ✅ MUST allow DNSSEC validation — dnsmasq passes through DNS queries without modification
+- ✅ SHOULD support incremental deployment — our HTTP interception is backward-compatible
+- ❌ SHOULD provide a HTTPS API for portal state — not yet implemented (RFC 8908)
+
+### Compliance Summary
+
+| Standard | Status | Requirement | Blocker |
+|----------|--------|-------------|---------|
+| RFC 8910 | ❌ Not impl | DHCP Option 114 | Needs RFC 8908 API first |
+| RFC 8908 | ❌ Not impl | Captive Portal API | Needs public cert + client state |
+| RFC 8952 | ⚠️ Partial | CAPPORT Architecture | Needs RFC 8908 for full compliance |
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `/etc/config/nodogsplash` | NoDogSplash config — `gatewaydomainname`, `gatewayport`, `users_to_router` |
+| `/etc/config/uhttpd` | LuCI web server — `cert`, `key`, `listen_https`, `commonname` |
+| `/etc/config/dhcp` | dnsmasq config — domain entries for cert domain → LAN IP |
+| `/etc/tollgate/ssl/` | Installed SSL certificates (by `tollgate-apply-ssl`) |
+| `/etc/tollgate/ssl/backup/` | Backup of pre-SSL UCI values (for `tollgate-remove-ssl`) |
+| `/etc/nodogsplash/htdocs/` | Splash page files (symlink to `/etc/tollgate/tollgate-captive-portal-site/`) |
+
+## Key Scripts
+
+| Script | Location | Purpose |
+|--------|----------|---------|
+| `99-tollgate-setup` | `/etc/uci-defaults/` | First-boot setup: hostname, uhttpd, DNS, NoDogSplash |
+| `tollgate-apply-ssl` | `/usr/bin/` | Install SSL cert and configure HTTPS |
+| `tollgate-remove-ssl` | `/usr/bin/` | Revert SSL configuration back to HTTP |
+| `90-tollgate-captive-portal-symlink` | `/etc/uci-defaults/` | Symlink splash page on first boot |

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -33,7 +33,7 @@ define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=TollGate Basic Module
-	DEPENDS:=+nodogsplash +luci +jq
+	DEPENDS:=+nodogsplash +luci +jq +px5g-mbedtls
 	PROVIDES:=nodogsplash-files
 	CONFLICTS:=
 	REPLACES:=nodogsplash base-files

--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -39,6 +39,7 @@ setup_uhttpd() {
     uci set uhttpd.main.network_timeout='30'
     uci set uhttpd.main.http_keepalive='20'
     uci set uhttpd.main.tcp_keepalive='1'
+    uci set uhttpd.main.commonname='TollGate'
 }
 
 setup_dns_dnsmasq() {
@@ -90,6 +91,17 @@ setup_public_wifi() {
     uci -q get wireless.radio1 >/dev/null && uci set wireless.radio1.disabled='0'
 }
 
+setup_hostname() {
+    local current_hostname
+    current_hostname=$(uci -q get system.@system[0].hostname)
+    if [ "$current_hostname" = "OpenWrt" ]; then
+        uci set system.@system[0].hostname='TollGate'
+        log "Hostname changed to TollGate (was OpenWrt default)"
+    else
+        log "Hostname '${current_hostname}' preserved (not default OpenWrt)"
+    fi
+}
+
 setup_nodogsplash() {
     [ -f /etc/config/nodogsplash ] || touch /etc/config/nodogsplash
     if ! uci -q get nodogsplash.@nodogsplash[0] >/dev/null 2>&1; then
@@ -100,6 +112,8 @@ setup_nodogsplash() {
     uci set nodogsplash.@nodogsplash[0].gatewayinterface='br-lan'
     uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 2121'
     uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 8080'
+    uci set nodogsplash.@nodogsplash[0].gatewaydomainname='TollGate.lan'
+    uci set nodogsplash.@nodogsplash[0].gatewayport='80'
 }
 
 setup_tollgate_firewall_rules() {
@@ -216,6 +230,7 @@ setup_private_network() {
 }
 
 commit_all() {
+    uci commit system
     uci commit network
     uci commit wireless
     uci commit dhcp
@@ -232,6 +247,7 @@ log "Starting TollGate configuration"
 setup_firewall_include
 setup_uhttpd
 setup_dns_dnsmasq
+setup_hostname
 setup_public_wifi            # exports RANDOM_SUFFIX, GATEWAY_NAME
 setup_nodogsplash
 setup_tollgate_firewall_rules

--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -111,7 +111,10 @@ setup_hostname() {
     local final_hostname
     final_hostname=$(uci -q get system.@system[0].hostname)
     uci set uhttpd.main.commonname="$final_hostname"
-    log "uhttpd cert commonname set to ${final_hostname}"
+    # Apply to running kernel immediately so /proc/sys/kernel/hostname
+    # reflects the new value without requiring a reboot.
+    hostname "$final_hostname"
+    log "Hostname applied to running kernel: ${final_hostname}"
 }
 
 setup_nodogsplash() {

--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -28,8 +28,16 @@ setup_uhttpd() {
     uci add_list uhttpd.main.listen_http='0.0.0.0:8080'
     uci add_list uhttpd.main.listen_http='[::]:8080'
     uci -q delete uhttpd.main.listen_https
-    uci add_list uhttpd.main.listen_https='0.0.0.0:443'
-    uci add_list uhttpd.main.listen_https='[::]:443'
+    uci -q delete uhttpd.main.cert
+    uci -q delete uhttpd.main.key
+    # Only enable HTTPS if cert and key files exist; otherwise uhttpd
+    # crash-loops because it sees listen_https but has no TLS config.
+    if [ -f /etc/uhttpd.crt ] && [ -f /etc/uhttpd.key ]; then
+        uci add_list uhttpd.main.listen_https='0.0.0.0:443'
+        uci add_list uhttpd.main.listen_https='[::]:443'
+        uci set uhttpd.main.cert='/etc/uhttpd.crt'
+        uci set uhttpd.main.key='/etc/uhttpd.key'
+    fi
     uci set uhttpd.main.redirect_https='0'
     uci set uhttpd.main.home='/www'
     uci set uhttpd.main.rfc1918_filter='1'

--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -122,8 +122,15 @@ setup_nodogsplash() {
     uci set nodogsplash.@nodogsplash[0].enabled='1'
     uci set nodogsplash.@nodogsplash[0].gatewayname="${GATEWAY_NAME} Portal"
     uci set nodogsplash.@nodogsplash[0].gatewayinterface='br-lan'
-    uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 2121'
-    uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 8080'
+    # Add firewall allow rules only if not already present (idempotent).
+    local nds_users
+    nds_users=$(uci -q get nodogsplash.@nodogsplash[0].users_to_router 2>/dev/null || echo "")
+    if ! echo "$nds_users" | grep -q "port 2121"; then
+        uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 2121'
+    fi
+    if ! echo "$nds_users" | grep -q "port 8080"; then
+        uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 8080'
+    fi
     uci set nodogsplash.@nodogsplash[0].gatewaydomainname='TollGate.lan'
     uci set nodogsplash.@nodogsplash[0].gatewayport='80'
 }

--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -25,19 +25,10 @@ setup_firewall_include() {
 setup_uhttpd() {
     uci -q get uhttpd.main >/dev/null 2>&1 || uci set uhttpd.main=uhttpd
     uci -q delete uhttpd.main.listen_http
-    uci add_list uhttpd.main.listen_http='0.0.0.0:8080'
-    uci add_list uhttpd.main.listen_http='[::]:8080'
+    uci add_list uhttpd.main.listen_http='127.0.0.1:8080'
     uci -q delete uhttpd.main.listen_https
     uci -q delete uhttpd.main.cert
     uci -q delete uhttpd.main.key
-    # Only enable HTTPS if cert and key files exist; otherwise uhttpd
-    # crash-loops because it sees listen_https but has no TLS config.
-    if [ -f /etc/uhttpd.crt ] && [ -f /etc/uhttpd.key ]; then
-        uci add_list uhttpd.main.listen_https='0.0.0.0:443'
-        uci add_list uhttpd.main.listen_https='[::]:443'
-        uci set uhttpd.main.cert='/etc/uhttpd.crt'
-        uci set uhttpd.main.key='/etc/uhttpd.key'
-    fi
     uci set uhttpd.main.redirect_https='0'
     uci set uhttpd.main.home='/www'
     uci set uhttpd.main.rfc1918_filter='1'
@@ -113,7 +104,8 @@ setup_hostname() {
     uci set uhttpd.main.commonname="$final_hostname"
     # Apply to running kernel immediately so /proc/sys/kernel/hostname
     # reflects the new value without requiring a reboot.
-    hostname "$final_hostname"
+    hostname "$final_hostname" 2>/dev/null || echo "$final_hostname" > /proc/sys/kernel/hostname
+    uci set uhttpd.defaults.commonname="$final_hostname"
     log "Hostname applied to running kernel: ${final_hostname}"
 }
 
@@ -133,6 +125,9 @@ setup_nodogsplash() {
     fi
     if ! echo "$nds_users" | grep -q "port 8080"; then
         uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 8080'
+    fi
+    if ! echo "$nds_users" | grep -q "port 443"; then
+        uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443'
     fi
     uci set nodogsplash.@nodogsplash[0].gatewaydomainname='TollGate.lan'
     uci set nodogsplash.@nodogsplash[0].gatewayport='80'
@@ -267,9 +262,9 @@ commit_all() {
 log "Starting TollGate configuration"
 
 setup_firewall_include
-setup_uhttpd
 setup_dns_dnsmasq
 setup_hostname
+setup_uhttpd
 setup_public_wifi            # exports RANDOM_SUFFIX, GATEWAY_NAME
 setup_nodogsplash
 setup_tollgate_firewall_rules

--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -39,7 +39,6 @@ setup_uhttpd() {
     uci set uhttpd.main.network_timeout='30'
     uci set uhttpd.main.http_keepalive='20'
     uci set uhttpd.main.tcp_keepalive='1'
-    uci set uhttpd.main.commonname='TollGate'
 }
 
 setup_dns_dnsmasq() {
@@ -100,6 +99,11 @@ setup_hostname() {
     else
         log "Hostname '${current_hostname}' preserved (not default OpenWrt)"
     fi
+    # TLS cert CN should match whatever hostname is active after the check above.
+    local final_hostname
+    final_hostname=$(uci -q get system.@system[0].hostname)
+    uci set uhttpd.main.commonname="$final_hostname"
+    log "uhttpd cert commonname set to ${final_hostname}"
 }
 
 setup_nodogsplash() {

--- a/packaging/files/usr/bin/tollgate-apply-ssl
+++ b/packaging/files/usr/bin/tollgate-apply-ssl
@@ -152,8 +152,8 @@ if [ "$SELF_SIGN" = true ]; then
 
     echo "Changes to apply:"
     echo "  [1] Install self-signed cert+key to ${SSL_DIR}/"
-    echo "  [2] uhttpd: set cert='${CERT_DEST}' key='${KEY_DEST}'"
-    echo "  [3] nodogsplash: allow tcp port 443 so clients can reach uhttpd HTTPS"
+    echo "  [2] tollgate-wrt: restart to enable HTTPS"
+    echo "  [3] nodogsplash: allow tcp port 443 so clients can reach HTTPS"
     echo ""
     printf "Apply all? [y/N] "
     read -r CONFIRM
@@ -189,17 +189,9 @@ if [ "$SELF_SIGN" = true ]; then
 
     # ── Configure uhttpd (self-signed) ───────────────────────────────────────
 
-    uci set uhttpd.main.cert="$CERT_DEST"
-    uci set uhttpd.main.key="$KEY_DEST"
-    current_https=$(uci -q get uhttpd.main.listen_https 2>/dev/null || echo "")
-    if ! echo "$current_https" | grep -q "0.0.0.0:443"; then
-        uci add_list uhttpd.main.listen_https='0.0.0.0:443'
-    fi
-    if ! echo "$current_https" | grep -q '\[::\]:443'; then
-        uci add_list uhttpd.main.listen_https='[::]:443'
-    fi
-    uci commit uhttpd
-    echo "[2] uhttpd configured."
+    # No uhttpd changes needed — Go binary handles TLS directly.
+    # uhttpd stays on 127.0.0.1:8080 (HTTP) for LuCI backend.
+    echo "[2] No uhttpd changes needed (Go binary handles TLS)."
 
     # ── Allow port 443 through NoDogSplash (self-signed) ─────────────────────
 
@@ -212,14 +204,14 @@ if [ "$SELF_SIGN" = true ]; then
 
     # ── Reload services (self-signed) ────────────────────────────────────────
 
-    /etc/init.d/uhttpd reload
+    /etc/init.d/tollgate-wrt restart
     /etc/init.d/nodogsplash restart
 
     echo ""
     echo "Done. Self-signed HTTPS enabled for ${DOMAIN}"
     echo ""
     echo "  Portal URL: http://${DOMAIN}/ (NoDogSplash, HTTP only)"
-    echo "  LuCI URL:   https://${DOMAIN}/ (uhttpd, HTTPS, self-signed)"
+    echo "  LuCI URL:   https://${DOMAIN}/ (Go reverse proxy, HTTPS, self-signed)"
     echo ""
     echo "To revert: tollgate-remove-ssl"
     exit 0
@@ -280,10 +272,10 @@ echo ""
 
 echo "Changes to apply:"
 echo "  [1] Install cert+key to ${SSL_DIR}/"
-echo "  [2] uhttpd: set cert='${CERT_DEST}' key='${KEY_DEST}'"
+echo "  [2] tollgate-wrt: restart to enable HTTPS"
 echo "  [3] dnsmasq: resolve ${DOMAIN} → ${LAN_IP}"
 echo "  [4] nodogsplash: gatewaydomainname='${DOMAIN}' (portal stays on HTTP port 80)"
-echo "  [5] nodogsplash: allow tcp port 443 so clients can reach uhttpd HTTPS"
+echo "  [5] nodogsplash: allow tcp port 443 so clients can reach HTTPS"
 echo ""
 printf "Apply all? [y/N] "
 read -r CONFIRM
@@ -318,17 +310,9 @@ echo "[1] Certificate installed."
 
 # ── Configure uhttpd ───────────────────────────────────────────────────────
 
-uci set uhttpd.main.cert="$CERT_DEST"
-uci set uhttpd.main.key="$KEY_DEST"
-current_https=$(uci -q get uhttpd.main.listen_https 2>/dev/null || echo "")
-if ! echo "$current_https" | grep -q "0.0.0.0:443"; then
-    uci add_list uhttpd.main.listen_https='0.0.0.0:443'
-fi
-if ! echo "$current_https" | grep -q '\[::\]:443'; then
-    uci add_list uhttpd.main.listen_https='[::]:443'
-fi
-uci commit uhttpd
-echo "[2] uhttpd configured."
+# No uhttpd changes needed — Go binary handles TLS directly.
+# uhttpd stays on 127.0.0.1:8080 (HTTP) for LuCI backend.
+echo "[2] No uhttpd changes needed (Go binary handles TLS)."
 
 # ── Configure dnsmasq ──────────────────────────────────────────────────────
 
@@ -351,9 +335,9 @@ echo "[3] dnsmasq configured: ${DOMAIN} → ${LAN_IP}"
 
 uci set nodogsplash.@nodogsplash[0].gatewaydomainname="$DOMAIN"
 # Keep NoDogSplash on port 80 — it cannot do TLS (built on libmicrohttpd without MHD_USE_TLS).
-# The captive portal uses HTTP interception, not HTTPS. Port 443 is served by uhttpd for LuCI.
+# The captive portal uses HTTP interception, not HTTPS. Port 443 is served by the Go reverse proxy.
 
-# Allow port 443 through nodogsplash so clients can reach uhttpd HTTPS (LuCI)
+# Allow port 443 through nodogsplash so clients can reach the Go reverse proxy (HTTPS)
 nds_users=$(uci -q get nodogsplash.@nodogsplash[0].users_to_router 2>/dev/null || echo "")
 if ! echo "$nds_users" | grep -q "port 443"; then
     uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443'
@@ -363,7 +347,7 @@ echo "[4] nodogsplash configured."
 
 # ── Reload services ────────────────────────────────────────────────────────
 
-/etc/init.d/uhttpd reload
+/etc/init.d/tollgate-wrt restart
 /etc/init.d/dnsmasq reload
 /etc/init.d/nodogsplash restart
 
@@ -371,6 +355,6 @@ echo ""
 echo "Done. HTTPS enabled for ${DOMAIN}"
 echo ""
 echo "  Portal URL: http://${DOMAIN}/ (NoDogSplash, HTTP only)"
-echo "  LuCI URL:   https://${DOMAIN}/ (uhttpd, HTTPS)"
+echo "  LuCI URL:   https://${DOMAIN}/ (Go reverse proxy, HTTPS)"
 echo ""
 echo "To revert: tollgate-remove-ssl"

--- a/packaging/files/usr/bin/tollgate-apply-ssl
+++ b/packaging/files/usr/bin/tollgate-apply-ssl
@@ -1,0 +1,248 @@
+#!/bin/sh
+# tollgate-apply-ssl — Install an SSL certificate and configure HTTPS
+#
+# Usage: tollgate-apply-ssl <cert-file> [key-file]
+#
+# If only one file is given and it contains both CERTIFICATE and PRIVATE KEY
+# PEM blocks, the file is split automatically. If two files are given, the
+# first is the certificate chain and the second is the private key.
+#
+# The script:
+#   1. Validates the certificate (PEM, not expired)
+#   2. Extracts the domain from SAN or CN
+#   3. Shows each config change and asks for confirmation
+#   4. Installs cert+key to /etc/tollgate/ssl/
+#   5. Configures uhttpd for HTTPS
+#   6. Adds dnsmasq DNS entry for the domain
+#   7. Updates captive portal URLs to https://
+#   8. Reloads uhttpd, dnsmasq, nodogsplash
+#
+# Revert with: tollgate-remove-ssl
+
+set -euo pipefail
+
+SSL_DIR="/etc/tollgate/ssl"
+BACKUP_DIR="${SSL_DIR}/backup"
+CERT_DEST="${SSL_DIR}/server.crt"
+KEY_DEST="${SSL_DIR}/server.key"
+LAN_IP=$(uci -q get network.lan.ipaddr || echo "")
+
+# ── Dependency check ────────────────────────────────────────────────────────
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "ERROR: openssl is not installed."
+    echo "  opkg update && opkg install openssl-util"
+    exit 1
+fi
+
+if [ -z "$LAN_IP" ]; then
+    echo "ERROR: cannot determine LAN IP (network.lan.ipaddr)."
+    exit 1
+fi
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+CERT_FILE=""
+KEY_FILE=""
+WORK_DIR=$(mktemp -d)
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+if [ $# -eq 0 ] || [ $# -gt 2 ]; then
+    echo "Usage: tollgate-apply-ssl <cert-file> [key-file]"
+    echo ""
+    echo "  cert-file  PEM file with the certificate (and optionally the private key)"
+    echo "  key-file   PEM file with the private key (if not included in cert-file)"
+    exit 1
+fi
+
+if [ $# -eq 1 ]; then
+    INPUT="$1"
+    if [ ! -f "$INPUT" ]; then
+        echo "ERROR: file not found: $INPUT"
+        exit 1
+    fi
+
+    has_cert=$(grep -c "BEGIN CERTIFICATE" "$INPUT" 2>/dev/null || echo 0)
+    has_key=$(grep -c "BEGIN PRIVATE KEY\|BEGIN RSA PRIVATE KEY\|BEGIN EC PRIVATE KEY" "$INPUT" 2>/dev/null || echo 0)
+
+    if [ "$has_cert" -gt 0 ] && [ "$has_key" -gt 0 ]; then
+        # Split combined PEM
+        echo "Detected combined PEM (cert + key in one file). Splitting..."
+        awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' "$INPUT" > "$WORK_DIR/cert.pem"
+        awk '/BEGIN PRIVATE KEY/,/END PRIVATE KEY/; /BEGIN RSA PRIVATE KEY/,/END RSA PRIVATE KEY/; /BEGIN EC PRIVATE KEY/,/END EC PRIVATE KEY/' "$INPUT" > "$WORK_DIR/key.pem"
+        CERT_FILE="$WORK_DIR/cert.pem"
+        KEY_FILE="$WORK_DIR/key.pem"
+    elif [ "$has_cert" -gt 0 ]; then
+        echo "ERROR: certificate file found but no private key."
+        echo "  Provide a key file as the second argument."
+        exit 1
+    elif [ "$has_key" -gt 0 ]; then
+        echo "ERROR: private key found but no certificate."
+        echo "  Provide a cert file as the first argument."
+        exit 1
+    else
+        echo "ERROR: no PEM certificate or key blocks found in: $INPUT"
+        exit 1
+    fi
+else
+    CERT_FILE="$1"
+    KEY_FILE="$2"
+    if [ ! -f "$CERT_FILE" ]; then
+        echo "ERROR: cert file not found: $CERT_FILE"
+        exit 1
+    fi
+    if [ ! -f "$KEY_FILE" ]; then
+        echo "ERROR: key file not found: $KEY_FILE"
+        exit 1
+    fi
+fi
+
+# ── Validate certificate ───────────────────────────────────────────────────
+
+if ! openssl x509 -in "$CERT_FILE" -noout >/dev/null 2>&1; then
+    echo "ERROR: not a valid PEM certificate: $CERT_FILE"
+    exit 1
+fi
+
+if openssl x509 -in "$CERT_FILE" -checkend 0 -noout 2>/dev/null; then
+    :
+else
+    echo "WARNING: certificate has expired!"
+    echo "  Continuing anyway — the cert will be installed but browsers will reject it."
+fi
+
+# ── Extract domain ─────────────────────────────────────────────────────────
+
+DOMAIN=""
+
+# Try SAN first
+SAN=$(openssl x509 -in "$CERT_FILE" -noout -ext subjectAltName 2>/dev/null || true)
+if [ -n "$SAN" ]; then
+    # Parse "DNS:example.com, DNS:www.example.com, IP:1.2.3.4"
+    # Pick the first DNS entry
+    DOMAIN=$(echo "$SAN" | sed 's/.*Subject Alternative Name//' | tr ',' '\n' | grep -i 'DNS:' | head -1 | sed 's/.*DNS://' | tr -d ' ')
+fi
+
+# Fall back to CN
+if [ -z "$DOMAIN" ]; then
+    SUBJECT=$(openssl x509 -in "$CERT_FILE" -noout -subject 2>/dev/null || true)
+    DOMAIN=$(echo "$SUBJECT" | sed 's/.*CN\s*=\s*//' | sed 's/\/.*//' | tr -d ' ')
+fi
+
+if [ -z "$DOMAIN" ]; then
+    echo "ERROR: could not extract domain from certificate (no SAN or CN found)."
+    exit 1
+fi
+
+EXPIRY=$(openssl x509 -in "$CERT_FILE" -noout -enddate 2>/dev/null | sed 's/notAfter=//' || echo "unknown")
+
+echo ""
+echo "Certificate details:"
+echo "  Domain : $DOMAIN"
+echo "  Expires: $EXPIRY"
+echo "  LAN IP : $LAN_IP"
+echo ""
+
+# ── Show plan and confirm ──────────────────────────────────────────────────
+
+echo "Changes to apply:"
+echo "  [1] Install cert+key to ${SSL_DIR}/"
+echo "  [2] uhttpd: set cert='${CERT_DEST}' key='${KEY_DEST}'"
+echo "  [3] dnsmasq: resolve ${DOMAIN} → ${LAN_IP}"
+echo "  [4] nodogsplash: gatewaydomainname='${DOMAIN}', gatewayport='443'"
+echo "  [5] nodogsplash: allow tcp port 443 (if not already allowed)"
+echo ""
+printf "Apply all? [y/N] "
+read -r CONFIRM
+case "$CONFIRM" in
+    [yY]|[yY][eE][sS]) ;;
+    *) echo "Aborted."; exit 0 ;;
+esac
+
+# ── Backup current state ───────────────────────────────────────────────────
+
+mkdir -p "$BACKUP_DIR"
+
+# Save current UCI values for revert
+uci get uhttpd.main.cert 2>/dev/null > "${BACKUP_DIR}/uhttpd.cert" || true
+uci get uhttpd.main.key 2>/dev/null > "${BACKUP_DIR}/uhttpd.key" || true
+uci get nodogsplash.@nodogsplash[0].gatewaydomainname 2>/dev/null > "${BACKUP_DIR}/nds.gatewaydomainname" || true
+uci get nodogsplash.@nodogsplash[0].gatewayport 2>/dev/null > "${BACKUP_DIR}/nds.gatewayport" || true
+echo "$DOMAIN" > "${BACKUP_DIR}/ssl.domain"
+echo "$LAN_IP" > "${BACKUP_DIR}/ssl.lan_ip"
+# Save dnsmasq domain entries for this domain if any
+uci show dhcp 2>/dev/null | grep "=domain" > "${BACKUP_DIR}/dnsmasq.domains" || true
+
+echo "Backup saved to ${BACKUP_DIR}/"
+
+# ── Install cert ───────────────────────────────────────────────────────────
+
+mkdir -p "$SSL_DIR"
+cp "$CERT_FILE" "$CERT_DEST"
+cp "$KEY_FILE" "$KEY_DEST"
+chmod 600 "$KEY_DEST"
+chmod 644 "$CERT_DEST"
+echo "[1] Certificate installed."
+
+# ── Configure uhttpd ───────────────────────────────────────────────────────
+
+uci set uhttpd.main.cert="$CERT_DEST"
+uci set uhttpd.main.key="$KEY_DEST"
+# Ensure HTTPS listeners are present
+current_https=$(uci -q get uhttpd.main.listen_https 2>/dev/null || echo "")
+if ! echo "$current_https" | grep -q "0.0.0.0:443"; then
+    uci add_list uhttpd.main.listen_https='0.0.0.0:443'
+fi
+if ! echo "$current_https" | grep -q '\[::\]:443'; then
+    uci add_list uhttpd.main.listen_https='[::]:443'
+fi
+uci commit uhttpd
+echo "[2] uhttpd configured."
+
+# ── Configure dnsmasq ──────────────────────────────────────────────────────
+
+# Remove any existing domain entry for this domain to avoid duplicates
+existing=$(uci show dhcp 2>/dev/null | grep "=domain" | while read -r line; do
+    idx=$(echo "$line" | cut -d. -f2 | cut -d= -f1)
+    name=$(uci -q get "dhcp.${idx}.name" 2>/dev/null || echo "")
+    if [ "$name" = "$DOMAIN" ]; then echo "$idx"; break; fi
+done || true)
+if [ -n "$existing" ]; then
+    uci -q delete "dhcp.${existing}" 2>/dev/null || true
+fi
+
+# Add dnsmasq address entry: /domain/IP
+# Use a UCI config section so it survives reboots
+uci add dhcp domain >/dev/null
+uci set dhcp.@domain[-1].name="$DOMAIN"
+uci set dhcp.@domain[-1].ip="$LAN_IP"
+uci commit dhcp
+echo "[3] dnsmasq configured: ${DOMAIN} → ${LAN_IP}"
+
+# ── Configure nodogsplash ──────────────────────────────────────────────────
+
+uci set nodogsplash.@nodogsplash[0].gatewaydomainname="$DOMAIN"
+uci set nodogsplash.@nodogsplash[0].gatewayport='443'
+
+# Allow port 443 through nodogsplash (so clients can reach the HTTPS portal)
+nds_users=$(uci -q get nodogsplash.@nodogsplash[0].users_to_router 2>/dev/null || echo "")
+if ! echo "$nds_users" | grep -q "port 443"; then
+    uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443'
+fi
+uci commit nodogsplash
+echo "[4] nodogsplash configured."
+
+# ── Reload services ────────────────────────────────────────────────────────
+
+/etc/init.d/uhttpd reload
+/etc/init.d/dnsmasq reload
+/etc/init.d/nodogsplash restart
+
+echo ""
+echo "Done. HTTPS enabled for ${DOMAIN}"
+echo ""
+echo "  Portal URL: https://${DOMAIN}/"
+echo "  LuCI URL:   https://${DOMAIN}/"
+echo ""
+echo "To revert: tollgate-remove-ssl"

--- a/packaging/files/usr/bin/tollgate-apply-ssl
+++ b/packaging/files/usr/bin/tollgate-apply-ssl
@@ -14,7 +14,7 @@
 #   4. Installs cert+key to /etc/tollgate/ssl/
 #   5. Configures uhttpd for HTTPS
 #   6. Adds dnsmasq DNS entry for the domain
-#   7. Updates captive portal URLs to https://
+#   7. Updates captive portal domain name (keeps HTTP port 80)
 #   8. Reloads uhttpd, dnsmasq, nodogsplash
 #
 # Revert with: tollgate-remove-ssl
@@ -150,8 +150,8 @@ echo "Changes to apply:"
 echo "  [1] Install cert+key to ${SSL_DIR}/"
 echo "  [2] uhttpd: set cert='${CERT_DEST}' key='${KEY_DEST}'"
 echo "  [3] dnsmasq: resolve ${DOMAIN} → ${LAN_IP}"
-echo "  [4] nodogsplash: gatewaydomainname='${DOMAIN}', gatewayport='443'"
-echo "  [5] nodogsplash: allow tcp port 443 (if not already allowed)"
+echo "  [4] nodogsplash: gatewaydomainname='${DOMAIN}' (portal stays on HTTP port 80)"
+echo "  [5] nodogsplash: allow tcp port 443 so clients can reach uhttpd HTTPS"
 echo ""
 printf "Apply all? [y/N] "
 read -r CONFIRM
@@ -223,9 +223,10 @@ echo "[3] dnsmasq configured: ${DOMAIN} → ${LAN_IP}"
 # ── Configure nodogsplash ──────────────────────────────────────────────────
 
 uci set nodogsplash.@nodogsplash[0].gatewaydomainname="$DOMAIN"
-uci set nodogsplash.@nodogsplash[0].gatewayport='443'
+# Keep NoDogSplash on port 80 — it cannot do TLS (built on libmicrohttpd without MHD_USE_TLS).
+# The captive portal uses HTTP interception, not HTTPS. Port 443 is served by uhttpd for LuCI.
 
-# Allow port 443 through nodogsplash (so clients can reach the HTTPS portal)
+# Allow port 443 through nodogsplash so clients can reach uhttpd HTTPS (LuCI)
 nds_users=$(uci -q get nodogsplash.@nodogsplash[0].users_to_router 2>/dev/null || echo "")
 if ! echo "$nds_users" | grep -q "port 443"; then
     uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443'
@@ -242,7 +243,7 @@ echo "[4] nodogsplash configured."
 echo ""
 echo "Done. HTTPS enabled for ${DOMAIN}"
 echo ""
-echo "  Portal URL: https://${DOMAIN}/"
-echo "  LuCI URL:   https://${DOMAIN}/"
+echo "  Portal URL: http://${DOMAIN}/ (NoDogSplash, HTTP only)"
+echo "  LuCI URL:   https://${DOMAIN}/ (uhttpd, HTTPS)"
 echo ""
 echo "To revert: tollgate-remove-ssl"

--- a/packaging/files/usr/bin/tollgate-apply-ssl
+++ b/packaging/files/usr/bin/tollgate-apply-ssl
@@ -1,21 +1,19 @@
 #!/bin/sh
-# tollgate-apply-ssl — Install an SSL certificate and configure HTTPS
+# tollgate-apply-ssl — Enable HTTPS for LuCI admin interface
 #
-# Usage: tollgate-apply-ssl <cert-file> [key-file]
+# Usage:
+#   tollgate-apply-ssl                 # Self-signed cert for current hostname
+#   tollgate-apply-ssl <cert-file>     # Combined PEM (cert + key)
+#   tollgate-apply-ssl <cert> <key>    # Separate cert and key files
 #
-# If only one file is given and it contains both CERTIFICATE and PRIVATE KEY
-# PEM blocks, the file is split automatically. If two files are given, the
-# first is the certificate chain and the second is the private key.
+# Self-signed mode generates a cert for the router's hostname (e.g. TollGate.lan).
+# This is useful for encrypted LuCI admin access on the local network but does NOT
+# provide RFC 8908 captive portal API compliance (clients will reject self-signed certs).
 #
-# The script:
-#   1. Validates the certificate (PEM, not expired)
-#   2. Extracts the domain from SAN or CN
-#   3. Shows each config change and asks for confirmation
-#   4. Installs cert+key to /etc/tollgate/ssl/
-#   5. Configures uhttpd for HTTPS
-#   6. Adds dnsmasq DNS entry for the domain
-#   7. Updates captive portal domain name (keeps HTTP port 80)
-#   8. Reloads uhttpd, dnsmasq, nodogsplash
+# With a real cert, the script also:
+#   - Adds a dnsmasq DNS entry so the cert domain resolves to the LAN IP
+#   - Updates NoDogSplash gatewaydomainname to match the cert domain
+#   - Allows port 443 through NoDogSplash firewall
 #
 # Revert with: tollgate-remove-ssl
 
@@ -26,14 +24,8 @@ BACKUP_DIR="${SSL_DIR}/backup"
 CERT_DEST="${SSL_DIR}/server.crt"
 KEY_DEST="${SSL_DIR}/server.key"
 LAN_IP=$(uci -q get network.lan.ipaddr || echo "")
-
-# ── Dependency check ────────────────────────────────────────────────────────
-
-if ! command -v openssl >/dev/null 2>&1; then
-    echo "ERROR: openssl is not installed."
-    echo "  opkg update && opkg install openssl-util"
-    exit 1
-fi
+SELF_SIGN=false
+DOMAIN=""
 
 if [ -z "$LAN_IP" ]; then
     echo "ERROR: cannot determine LAN IP (network.lan.ipaddr)."
@@ -48,15 +40,17 @@ WORK_DIR=$(mktemp -d)
 cleanup() { rm -rf "$WORK_DIR"; }
 trap cleanup EXIT
 
-if [ $# -eq 0 ] || [ $# -gt 2 ]; then
-    echo "Usage: tollgate-apply-ssl <cert-file> [key-file]"
+if [ $# -eq 0 ]; then
+    # No arguments → self-signed mode
+    SELF_SIGN=true
+elif [ $# -gt 2 ]; then
+    echo "Usage: tollgate-apply-ssl [<cert-file> [key-file]]"
     echo ""
-    echo "  cert-file  PEM file with the certificate (and optionally the private key)"
-    echo "  key-file   PEM file with the private key (if not included in cert-file)"
+    echo "  (no args)   Generate a self-signed certificate for the current hostname"
+    echo "  cert-file   PEM file with the certificate (and optionally the private key)"
+    echo "  key-file    PEM file with the private key (if not included in cert-file)"
     exit 1
-fi
-
-if [ $# -eq 1 ]; then
+elif [ $# -eq 1 ]; then
     INPUT="$1"
     if [ ! -f "$INPUT" ]; then
         echo "ERROR: file not found: $INPUT"
@@ -67,7 +61,6 @@ if [ $# -eq 1 ]; then
     has_key=$(grep -c "BEGIN PRIVATE KEY\|BEGIN RSA PRIVATE KEY\|BEGIN EC PRIVATE KEY" "$INPUT" 2>/dev/null || echo 0)
 
     if [ "$has_cert" -gt 0 ] && [ "$has_key" -gt 0 ]; then
-        # Split combined PEM
         echo "Detected combined PEM (cert + key in one file). Splitting..."
         awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' "$INPUT" > "$WORK_DIR/cert.pem"
         awk '/BEGIN PRIVATE KEY/,/END PRIVATE KEY/; /BEGIN RSA PRIVATE KEY/,/END RSA PRIVATE KEY/; /BEGIN EC PRIVATE KEY/,/END EC PRIVATE KEY/' "$INPUT" > "$WORK_DIR/key.pem"
@@ -98,6 +91,149 @@ else
     fi
 fi
 
+# ── Self-signed certificate generation ──────────────────────────────────────
+
+if [ "$SELF_SIGN" = true ]; then
+    # Need openssl or px5g for cert generation
+    if ! command -v openssl >/dev/null 2>&1 && ! command -v px5g >/dev/null 2>&1; then
+        echo "ERROR: openssl or px5g is required for self-signed cert generation."
+        echo "  opkg update && opkg install openssl-util"
+        exit 1
+    fi
+
+    # Use current hostname as the domain
+    DOMAIN=$(uci -q get system.@system[0].hostname || echo "TollGate")
+    DOMAIN="${DOMAIN}.lan"
+
+    echo "Generating self-signed certificate for ${DOMAIN}..."
+
+    if command -v openssl >/dev/null 2>&1; then
+        openssl req -x509 -newkey rsa:2048 -keyout "$WORK_DIR/key.pem" \
+            -out "$WORK_DIR/cert.pem" -days 3650 -nodes \
+            -subj "/CN=${DOMAIN}" \
+            -addext "subjectAltName=DNS:${DOMAIN},DNS:$(uci -q get system.@system[0].hostname || echo TollGate)" \
+            2>/dev/null
+    else
+        # px5g fallback (OpenWrt built-in, but limited — no SAN support)
+        px5g selfsigned -der -days 3650 -newkey rsa:2048 \
+            -keyout "$WORK_DIR/key.pem" -out "$WORK_DIR/cert.pem" \
+            -subject "/CN=${DOMAIN}" 2>/dev/null
+        # Convert DER to PEM if px5g produced DER
+        if ! grep -q "BEGIN CERTIFICATE" "$WORK_DIR/cert.pem" 2>/dev/null; then
+            openssl x509 -inform DER -in "$WORK_DIR/cert.pem" -out "$WORK_DIR/cert_pem.pem" 2>/dev/null \
+                && mv "$WORK_DIR/cert_pem.pem" "$WORK_DIR/cert.pem"
+        fi
+        if ! grep -q "BEGIN PRIVATE KEY\|BEGIN RSA PRIVATE KEY" "$WORK_DIR/key.pem" 2>/dev/null; then
+            openssl rsa -inform DER -in "$WORK_DIR/key.pem" -out "$WORK_DIR/key_pem.pem" 2>/dev/null \
+                && mv "$WORK_DIR/key_pem.pem" "$WORK_DIR/key.pem"
+        fi
+    fi
+
+    if [ ! -f "$WORK_DIR/cert.pem" ] || [ ! -f "$WORK_DIR/key.pem" ]; then
+        echo "ERROR: failed to generate self-signed certificate."
+        exit 1
+    fi
+
+    CERT_FILE="$WORK_DIR/cert.pem"
+    KEY_FILE="$WORK_DIR/key.pem"
+
+    echo ""
+    echo "Certificate details:"
+    echo "  Domain : $DOMAIN (self-signed)"
+    echo "  Expires: 10 years"
+    echo "  LAN IP : $LAN_IP"
+    echo ""
+    echo "  NOTE: Self-signed certs are NOT trusted by browsers or RFC 8908 clients."
+    echo "  The captive portal will continue using HTTP interception."
+    echo "  LuCI admin will be accessible via HTTPS with a browser warning."
+    echo ""
+
+    # ── Show plan and confirm (self-signed) ──────────────────────────────────
+
+    echo "Changes to apply:"
+    echo "  [1] Install self-signed cert+key to ${SSL_DIR}/"
+    echo "  [2] uhttpd: set cert='${CERT_DEST}' key='${KEY_DEST}'"
+    echo "  [3] nodogsplash: allow tcp port 443 so clients can reach uhttpd HTTPS"
+    echo ""
+    printf "Apply all? [y/N] "
+    read -r CONFIRM
+    case "$CONFIRM" in
+        [yY]|[yY][eE][sS]) ;;
+        *) echo "Aborted."; exit 0 ;;
+    esac
+
+    # ── Backup current state (self-signed) ───────────────────────────────────
+
+    mkdir -p "$BACKUP_DIR"
+
+    uci get uhttpd.main.cert 2>/dev/null > "${BACKUP_DIR}/uhttpd.cert" || true
+    uci get uhttpd.main.key 2>/dev/null > "${BACKUP_DIR}/uhttpd.key" || true
+    uci get nodogsplash.@nodogsplash[0].gatewaydomainname 2>/dev/null > "${BACKUP_DIR}/nds.gatewaydomainname" || true
+    uci get nodogsplash.@nodogsplash[0].gatewayport 2>/dev/null > "${BACKUP_DIR}/nds.gatewayport" || true
+    echo "$DOMAIN" > "${BACKUP_DIR}/ssl.domain"
+    echo "$LAN_IP" > "${BACKUP_DIR}/ssl.lan_ip"
+    echo "self-signed" > "${BACKUP_DIR}/ssl.mode"
+    # No dnsmasq changes needed — hostname already resolves via dnsmasq hostname
+    uci show dhcp 2>/dev/null | grep "=domain" > "${BACKUP_DIR}/dnsmasq.domains" || true
+
+    echo "Backup saved to ${BACKUP_DIR}/"
+
+    # ── Install cert (self-signed) ───────────────────────────────────────────
+
+    mkdir -p "$SSL_DIR"
+    cp "$CERT_FILE" "$CERT_DEST"
+    cp "$KEY_FILE" "$KEY_DEST"
+    chmod 600 "$KEY_DEST"
+    chmod 644 "$CERT_DEST"
+    echo "[1] Self-signed certificate installed."
+
+    # ── Configure uhttpd (self-signed) ───────────────────────────────────────
+
+    uci set uhttpd.main.cert="$CERT_DEST"
+    uci set uhttpd.main.key="$KEY_DEST"
+    current_https=$(uci -q get uhttpd.main.listen_https 2>/dev/null || echo "")
+    if ! echo "$current_https" | grep -q "0.0.0.0:443"; then
+        uci add_list uhttpd.main.listen_https='0.0.0.0:443'
+    fi
+    if ! echo "$current_https" | grep -q '\[::\]:443'; then
+        uci add_list uhttpd.main.listen_https='[::]:443'
+    fi
+    uci commit uhttpd
+    echo "[2] uhttpd configured."
+
+    # ── Allow port 443 through NoDogSplash (self-signed) ─────────────────────
+
+    nds_users=$(uci -q get nodogsplash.@nodogsplash[0].users_to_router 2>/dev/null || echo "")
+    if ! echo "$nds_users" | grep -q "port 443"; then
+        uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443'
+    fi
+    uci commit nodogsplash
+    echo "[3] nodogsplash firewall updated."
+
+    # ── Reload services (self-signed) ────────────────────────────────────────
+
+    /etc/init.d/uhttpd reload
+    /etc/init.d/nodogsplash restart
+
+    echo ""
+    echo "Done. Self-signed HTTPS enabled for ${DOMAIN}"
+    echo ""
+    echo "  Portal URL: http://${DOMAIN}/ (NoDogSplash, HTTP only)"
+    echo "  LuCI URL:   https://${DOMAIN}/ (uhttpd, HTTPS, self-signed)"
+    echo ""
+    echo "To revert: tollgate-remove-ssl"
+    exit 0
+fi
+
+# ── Real certificate mode ───────────────────────────────────────────────────
+
+# Need openssl for cert validation
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "ERROR: openssl is not installed."
+    echo "  opkg update && opkg install openssl-util"
+    exit 1
+fi
+
 # ── Validate certificate ───────────────────────────────────────────────────
 
 if ! openssl x509 -in "$CERT_FILE" -noout >/dev/null 2>&1; then
@@ -114,13 +250,9 @@ fi
 
 # ── Extract domain ─────────────────────────────────────────────────────────
 
-DOMAIN=""
-
 # Try SAN first
 SAN=$(openssl x509 -in "$CERT_FILE" -noout -ext subjectAltName 2>/dev/null || true)
 if [ -n "$SAN" ]; then
-    # Parse "DNS:example.com, DNS:www.example.com, IP:1.2.3.4"
-    # Pick the first DNS entry
     DOMAIN=$(echo "$SAN" | sed 's/.*Subject Alternative Name//' | tr ',' '\n' | grep -i 'DNS:' | head -1 | sed 's/.*DNS://' | tr -d ' ')
 fi
 
@@ -164,14 +296,13 @@ esac
 
 mkdir -p "$BACKUP_DIR"
 
-# Save current UCI values for revert
 uci get uhttpd.main.cert 2>/dev/null > "${BACKUP_DIR}/uhttpd.cert" || true
 uci get uhttpd.main.key 2>/dev/null > "${BACKUP_DIR}/uhttpd.key" || true
 uci get nodogsplash.@nodogsplash[0].gatewaydomainname 2>/dev/null > "${BACKUP_DIR}/nds.gatewaydomainname" || true
 uci get nodogsplash.@nodogsplash[0].gatewayport 2>/dev/null > "${BACKUP_DIR}/nds.gatewayport" || true
 echo "$DOMAIN" > "${BACKUP_DIR}/ssl.domain"
 echo "$LAN_IP" > "${BACKUP_DIR}/ssl.lan_ip"
-# Save dnsmasq domain entries for this domain if any
+echo "real-cert" > "${BACKUP_DIR}/ssl.mode"
 uci show dhcp 2>/dev/null | grep "=domain" > "${BACKUP_DIR}/dnsmasq.domains" || true
 
 echo "Backup saved to ${BACKUP_DIR}/"
@@ -189,7 +320,6 @@ echo "[1] Certificate installed."
 
 uci set uhttpd.main.cert="$CERT_DEST"
 uci set uhttpd.main.key="$KEY_DEST"
-# Ensure HTTPS listeners are present
 current_https=$(uci -q get uhttpd.main.listen_https 2>/dev/null || echo "")
 if ! echo "$current_https" | grep -q "0.0.0.0:443"; then
     uci add_list uhttpd.main.listen_https='0.0.0.0:443'
@@ -202,7 +332,6 @@ echo "[2] uhttpd configured."
 
 # ── Configure dnsmasq ──────────────────────────────────────────────────────
 
-# Remove any existing domain entry for this domain to avoid duplicates
 existing=$(uci show dhcp 2>/dev/null | grep "=domain" | while read -r line; do
     idx=$(echo "$line" | cut -d. -f2 | cut -d= -f1)
     name=$(uci -q get "dhcp.${idx}.name" 2>/dev/null || echo "")
@@ -212,8 +341,6 @@ if [ -n "$existing" ]; then
     uci -q delete "dhcp.${existing}" 2>/dev/null || true
 fi
 
-# Add dnsmasq address entry: /domain/IP
-# Use a UCI config section so it survives reboots
 uci add dhcp domain >/dev/null
 uci set dhcp.@domain[-1].name="$DOMAIN"
 uci set dhcp.@domain[-1].ip="$LAN_IP"

--- a/packaging/files/usr/bin/tollgate-remove-ssl
+++ b/packaging/files/usr/bin/tollgate-remove-ssl
@@ -1,0 +1,95 @@
+#!/bin/sh
+# tollgate-remove-ssl — Revert HTTPS configuration back to HTTP
+#
+# Usage: tollgate-remove-ssl
+#
+# Undoes the changes made by tollgate-apply-ssl:
+#   1. Removes the installed cert+key
+#   2. Restores uhttpd to auto-generated self-signed cert
+#   3. Removes the dnsmasq DNS entry for the SSL domain
+#   4. Reverts nodogsplash to HTTP (TollGate.lan, port 80)
+#   5. Reloads uhttpd, dnsmasq, nodogsplash
+
+set -euo pipefail
+
+SSL_DIR="/etc/tollgate/ssl"
+BACKUP_DIR="${SSL_DIR}/backup"
+
+if [ ! -d "$BACKUP_DIR" ]; then
+    echo "ERROR: no SSL backup found at ${BACKUP_DIR}/"
+    echo "  Either SSL was never applied, or the backup was deleted."
+    exit 1
+fi
+
+DOMAIN=$(cat "${BACKUP_DIR}/ssl.domain" 2>/dev/null || echo "")
+LAN_IP=$(cat "${BACKUP_DIR}/ssl.lan_ip" 2>/dev/null || echo "")
+
+echo "Reverting SSL configuration for: ${DOMAIN:-unknown}"
+echo ""
+echo "Changes to revert:"
+echo "  [1] Remove cert+key from ${SSL_DIR}/"
+echo "  [2] uhttpd: restore default self-signed cert"
+echo "  [3] dnsmasq: remove DNS entry for ${DOMAIN}"
+echo "  [4] nodogsplash: revert to TollGate.lan port 80"
+echo ""
+printf "Revert all? [y/N] "
+read -r CONFIRM
+case "$CONFIRM" in
+    [yY]|[yY][eE][sS]) ;;
+    *) echo "Aborted."; exit 0 ;;
+esac
+
+# ── Restore uhttpd ─────────────────────────────────────────────────────────
+
+# Remove custom cert and point uhttpd back to the default self-signed ones
+rm -f "${SSL_DIR}/server.crt" "${SSL_DIR}/server.key"
+
+if [ -f /etc/uhttpd.crt ] && [ -f /etc/uhttpd.key ]; then
+    uci set uhttpd.main.cert='/etc/uhttpd.crt'
+    uci set uhttpd.main.key='/etc/uhttpd.key'
+else
+    # Remove cert/key references; uhttpd will auto-generate on next start
+    uci -q delete uhttpd.main.cert
+    uci -q delete uhttpd.main.key
+fi
+echo "[1] uhttpd cert reverted."
+
+# ── Remove dnsmasq DNS entry ───────────────────────────────────────────────
+
+if [ -n "$DOMAIN" ]; then
+    # Remove the domain section we added
+    for idx in $(uci show dhcp 2>/dev/null | grep "=domain" | cut -d. -f2 | cut -d= -f1); do
+        name=$(uci -q get "dhcp.${idx}.name" 2>/dev/null || echo "")
+        if [ "$name" = "$DOMAIN" ]; then
+            uci delete "dhcp.${idx}"
+            echo "[2] Removed dnsmasq entry for ${DOMAIN}"
+            break
+        fi
+    done
+fi
+
+# ── Restore nodogsplash ────────────────────────────────────────────────────
+
+ORIGINAL_DOMAIN=$(cat "${BACKUP_DIR}/nds.gatewaydomainname" 2>/dev/null || echo "TollGate.lan")
+ORIGINAL_PORT=$(cat "${BACKUP_DIR}/nds.gatewayport" 2>/dev/null || echo "80")
+
+uci set nodogsplash.@nodogsplash[0].gatewaydomainname="$ORIGINAL_DOMAIN"
+uci set nodogsplash.@nodogsplash[0].gatewayport="$ORIGINAL_PORT"
+echo "[3] nodogsplash reverted to ${ORIGINAL_DOMAIN}:${ORIGINAL_PORT}"
+
+# ── Commit and reload ──────────────────────────────────────────────────────
+
+uci commit uhttpd
+uci commit dhcp
+uci commit nodogsplash
+
+/etc/init.d/uhttpd reload
+/etc/init.d/dnsmasq reload
+/etc/init.d/nodogsplash restart
+
+# Clean up backup
+rm -rf "$BACKUP_DIR"
+
+echo ""
+echo "Done. HTTPS removed. Portal now served over HTTP."
+echo "  Portal URL: http://${ORIGINAL_DOMAIN}/"

--- a/packaging/files/usr/bin/tollgate-remove-ssl
+++ b/packaging/files/usr/bin/tollgate-remove-ssl
@@ -5,10 +5,11 @@
 #
 # Undoes the changes made by tollgate-apply-ssl:
 #   1. Removes the installed cert+key
-#   2. Restores uhttpd to auto-generated self-signed cert
-#   3. Removes the dnsmasq DNS entry for the SSL domain
-#   4. Reverts nodogsplash to HTTP (TollGate.lan, port 80)
-#   5. Reloads uhttpd, dnsmasq, nodogsplash
+#   2. Restores uhttpd cert/key to pre-SSL state
+#   3. Removes the dnsmasq DNS entry (real-cert mode only)
+#   4. Reverts nodogsplash gatewaydomainname (real-cert mode only)
+#   5. Removes port 443 allow from nodogsplash if present
+#   6. Reloads uhttpd, dnsmasq, nodogsplash
 
 set -euo pipefail
 
@@ -22,15 +23,89 @@ if [ ! -d "$BACKUP_DIR" ]; then
 fi
 
 DOMAIN=$(cat "${BACKUP_DIR}/ssl.domain" 2>/dev/null || echo "")
-LAN_IP=$(cat "${BACKUP_DIR}/ssl.lan_ip" 2>/dev/null || echo "")
+MODE=$(cat "${BACKUP_DIR}/ssl.mode" 2>/dev/null || echo "unknown")
+
+if [ "$MODE" = "self-signed" ]; then
+    echo "Reverting self-signed SSL configuration for: ${DOMAIN:-unknown}"
+    echo ""
+    echo "Changes to revert:"
+    echo "  [1] Remove self-signed cert+key from ${SSL_DIR}/"
+    echo "  [2] uhttpd: restore previous cert configuration"
+    echo "  [3] nodogsplash: remove port 443 allow rule"
+    echo ""
+    printf "Revert all? [y/N] "
+    read -r CONFIRM
+    case "$CONFIRM" in
+        [yY]|[yY][eE][sS]) ;;
+        *) echo "Aborted."; exit 0 ;;
+    esac
+
+    # ── Restore uhttpd ────────────────────────────────────────────────────
+
+    rm -f "${SSL_DIR}/server.crt" "${SSL_DIR}/server.key"
+
+    RESTORED_CERT=false
+    if [ -s "${BACKUP_DIR}/uhttpd.cert" ]; then
+        PREV_CERT=$(cat "${BACKUP_DIR}/uhttpd.cert")
+        if [ -f "$PREV_CERT" ]; then
+            uci set uhttpd.main.cert="$PREV_CERT"
+            RESTORED_CERT=true
+        fi
+    fi
+    if [ -s "${BACKUP_DIR}/uhttpd.key" ]; then
+        PREV_KEY=$(cat "${BACKUP_DIR}/uhttpd.key")
+        if [ -f "$PREV_KEY" ]; then
+            uci set uhttpd.main.key="$PREV_KEY"
+            RESTORED_CERT=true
+        fi
+    fi
+
+    if [ "$RESTORED_CERT" = false ]; then
+        # No previous cert/key — remove HTTPS listeners
+        uci -q delete uhttpd.main.listen_https
+        uci -q delete uhttpd.main.cert
+        uci -q delete uhttpd.main.key
+    fi
+
+    echo "[1] uhttpd cert reverted."
+
+    # ── Remove port 443 allow from nodogsplash ────────────────────────────
+
+    # Remove the 'allow tcp port 443' entry if 99-tollgate-setup didn't add it
+    # (self-signed mode added it; only remove if it wasn't there before)
+    nds_users=$(uci -q get nodogsplash.@nodogsplash[0].users_to_router 2>/dev/null || echo "")
+    if echo "$nds_users" | grep -q "port 443"; then
+        # Only remove if it's the only port 443 entry and wasn't pre-existing
+        uci -q del_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443' 2>/dev/null || true
+    fi
+    echo "[2] nodogsplash firewall updated."
+
+    # ── Commit and reload ─────────────────────────────────────────────────
+
+    uci commit uhttpd
+    uci commit nodogsplash
+
+    /etc/init.d/uhttpd reload
+    /etc/init.d/nodogsplash restart
+
+    # Clean up backup
+    rm -rf "$BACKUP_DIR"
+
+    echo ""
+    echo "Done. Self-signed HTTPS removed."
+    echo "  Portal URL: http://TollGate.lan/"
+    exit 0
+fi
+
+# ── Real cert revert ─────────────────────────────────────────────────────────
 
 echo "Reverting SSL configuration for: ${DOMAIN:-unknown}"
 echo ""
 echo "Changes to revert:"
 echo "  [1] Remove cert+key from ${SSL_DIR}/"
-echo "  [2] uhttpd: restore default self-signed cert"
+echo "  [2] uhttpd: restore previous cert configuration"
 echo "  [3] dnsmasq: remove DNS entry for ${DOMAIN}"
-echo "  [4] nodogsplash: revert to TollGate.lan port 80"
+echo "  [4] nodogsplash: revert gatewaydomainname and remove port 443 allow"
 echo ""
 printf "Revert all? [y/N] "
 read -r CONFIRM
@@ -39,25 +114,41 @@ case "$CONFIRM" in
     *) echo "Aborted."; exit 0 ;;
 esac
 
-# ── Restore uhttpd ─────────────────────────────────────────────────────────
+# ── Restore uhttpd ──────────────────────────────────────────────────────────
 
-# Remove custom cert and point uhttpd back to the default self-signed ones
 rm -f "${SSL_DIR}/server.crt" "${SSL_DIR}/server.key"
 
-if [ -f /etc/uhttpd.crt ] && [ -f /etc/uhttpd.key ]; then
-    uci set uhttpd.main.cert='/etc/uhttpd.crt'
-    uci set uhttpd.main.key='/etc/uhttpd.key'
-else
-    # Remove cert/key references; uhttpd will auto-generate on next start
-    uci -q delete uhttpd.main.cert
-    uci -q delete uhttpd.main.key
+RESTORED_CERT=false
+if [ -s "${BACKUP_DIR}/uhttpd.cert" ]; then
+    PREV_CERT=$(cat "${BACKUP_DIR}/uhttpd.cert")
+    if [ -f "$PREV_CERT" ]; then
+        uci set uhttpd.main.cert="$PREV_CERT"
+        RESTORED_CERT=true
+    fi
+fi
+if [ -s "${BACKUP_DIR}/uhttpd.key" ]; then
+    PREV_KEY=$(cat "${BACKUP_DIR}/uhttpd.key")
+    if [ -f "$PREV_KEY" ]; then
+        uci set uhttpd.main.key="$PREV_KEY"
+        RESTORED_CERT=true
+    fi
+fi
+
+if [ "$RESTORED_CERT" = false ]; then
+    if [ -f /etc/uhttpd.crt ] && [ -f /etc/uhttpd.key ]; then
+        uci set uhttpd.main.cert='/etc/uhttpd.crt'
+        uci set uhttpd.main.key='/etc/uhttpd.key'
+    else
+        uci -q delete uhttpd.main.cert
+        uci -q delete uhttpd.main.key
+        uci -q delete uhttpd.main.listen_https
+    fi
 fi
 echo "[1] uhttpd cert reverted."
 
-# ── Remove dnsmasq DNS entry ───────────────────────────────────────────────
+# ── Remove dnsmasq DNS entry ────────────────────────────────────────────────
 
 if [ -n "$DOMAIN" ]; then
-    # Remove the domain section we added
     for idx in $(uci show dhcp 2>/dev/null | grep "=domain" | cut -d. -f2 | cut -d= -f1); do
         name=$(uci -q get "dhcp.${idx}.name" 2>/dev/null || echo "")
         if [ "$name" = "$DOMAIN" ]; then
@@ -75,6 +166,10 @@ ORIGINAL_PORT=$(cat "${BACKUP_DIR}/nds.gatewayport" 2>/dev/null || echo "80")
 
 uci set nodogsplash.@nodogsplash[0].gatewaydomainname="$ORIGINAL_DOMAIN"
 uci set nodogsplash.@nodogsplash[0].gatewayport="$ORIGINAL_PORT"
+
+# Remove port 443 allow rule
+uci -q del_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443' 2>/dev/null || true
+
 echo "[3] nodogsplash reverted to ${ORIGINAL_DOMAIN}:${ORIGINAL_PORT}"
 
 # ── Commit and reload ──────────────────────────────────────────────────────

--- a/packaging/files/usr/bin/tollgate-remove-ssl
+++ b/packaging/files/usr/bin/tollgate-remove-ssl
@@ -5,11 +5,9 @@
 #
 # Undoes the changes made by tollgate-apply-ssl:
 #   1. Removes the installed cert+key
-#   2. Restores uhttpd cert/key to pre-SSL state
+#   2. Restarts tollgate-wrt (HTTPS disabled)
 #   3. Removes the dnsmasq DNS entry (real-cert mode only)
 #   4. Reverts nodogsplash gatewaydomainname (real-cert mode only)
-#   5. Removes port 443 allow from nodogsplash if present
-#   6. Reloads uhttpd, dnsmasq, nodogsplash
 
 set -euo pipefail
 
@@ -30,8 +28,7 @@ if [ "$MODE" = "self-signed" ]; then
     echo ""
     echo "Changes to revert:"
     echo "  [1] Remove self-signed cert+key from ${SSL_DIR}/"
-    echo "  [2] uhttpd: restore previous cert configuration"
-    echo "  [3] nodogsplash: remove port 443 allow rule"
+    echo "  [2] tollgate-wrt: restart (HTTPS disabled)"
     echo ""
     printf "Revert all? [y/N] "
     read -r CONFIRM
@@ -40,53 +37,14 @@ if [ "$MODE" = "self-signed" ]; then
         *) echo "Aborted."; exit 0 ;;
     esac
 
-    # ── Restore uhttpd ────────────────────────────────────────────────────
+    # ── Remove certificates ─────────────────────────────────────────────────
 
     rm -f "${SSL_DIR}/server.crt" "${SSL_DIR}/server.key"
+    echo "[1] Certificates removed."
 
-    RESTORED_CERT=false
-    if [ -s "${BACKUP_DIR}/uhttpd.cert" ]; then
-        PREV_CERT=$(cat "${BACKUP_DIR}/uhttpd.cert")
-        if [ -f "$PREV_CERT" ]; then
-            uci set uhttpd.main.cert="$PREV_CERT"
-            RESTORED_CERT=true
-        fi
-    fi
-    if [ -s "${BACKUP_DIR}/uhttpd.key" ]; then
-        PREV_KEY=$(cat "${BACKUP_DIR}/uhttpd.key")
-        if [ -f "$PREV_KEY" ]; then
-            uci set uhttpd.main.key="$PREV_KEY"
-            RESTORED_CERT=true
-        fi
-    fi
+    # ── Restart tollgate-wrt ────────────────────────────────────────────────
 
-    if [ "$RESTORED_CERT" = false ]; then
-        # No previous cert/key — remove HTTPS listeners
-        uci -q delete uhttpd.main.listen_https
-        uci -q delete uhttpd.main.cert
-        uci -q delete uhttpd.main.key
-    fi
-
-    echo "[1] uhttpd cert reverted."
-
-    # ── Remove port 443 allow from nodogsplash ────────────────────────────
-
-    # Remove the 'allow tcp port 443' entry if 99-tollgate-setup didn't add it
-    # (self-signed mode added it; only remove if it wasn't there before)
-    nds_users=$(uci -q get nodogsplash.@nodogsplash[0].users_to_router 2>/dev/null || echo "")
-    if echo "$nds_users" | grep -q "port 443"; then
-        # Only remove if it's the only port 443 entry and wasn't pre-existing
-        uci -q del_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443' 2>/dev/null || true
-    fi
-    echo "[2] nodogsplash firewall updated."
-
-    # ── Commit and reload ─────────────────────────────────────────────────
-
-    uci commit uhttpd
-    uci commit nodogsplash
-
-    /etc/init.d/uhttpd reload
-    /etc/init.d/nodogsplash restart
+    /etc/init.d/tollgate-wrt restart
 
     # Clean up backup
     rm -rf "$BACKUP_DIR"
@@ -103,9 +61,9 @@ echo "Reverting SSL configuration for: ${DOMAIN:-unknown}"
 echo ""
 echo "Changes to revert:"
 echo "  [1] Remove cert+key from ${SSL_DIR}/"
-echo "  [2] uhttpd: restore previous cert configuration"
+echo "  [2] tollgate-wrt: restart (HTTPS disabled)"
 echo "  [3] dnsmasq: remove DNS entry for ${DOMAIN}"
-echo "  [4] nodogsplash: revert gatewaydomainname and remove port 443 allow"
+echo "  [4] nodogsplash: revert gatewaydomainname"
 echo ""
 printf "Revert all? [y/N] "
 read -r CONFIRM
@@ -114,37 +72,10 @@ case "$CONFIRM" in
     *) echo "Aborted."; exit 0 ;;
 esac
 
-# ── Restore uhttpd ──────────────────────────────────────────────────────────
+# ── Remove certificates ──────────────────────────────────────────────────────
 
 rm -f "${SSL_DIR}/server.crt" "${SSL_DIR}/server.key"
-
-RESTORED_CERT=false
-if [ -s "${BACKUP_DIR}/uhttpd.cert" ]; then
-    PREV_CERT=$(cat "${BACKUP_DIR}/uhttpd.cert")
-    if [ -f "$PREV_CERT" ]; then
-        uci set uhttpd.main.cert="$PREV_CERT"
-        RESTORED_CERT=true
-    fi
-fi
-if [ -s "${BACKUP_DIR}/uhttpd.key" ]; then
-    PREV_KEY=$(cat "${BACKUP_DIR}/uhttpd.key")
-    if [ -f "$PREV_KEY" ]; then
-        uci set uhttpd.main.key="$PREV_KEY"
-        RESTORED_CERT=true
-    fi
-fi
-
-if [ "$RESTORED_CERT" = false ]; then
-    if [ -f /etc/uhttpd.crt ] && [ -f /etc/uhttpd.key ]; then
-        uci set uhttpd.main.cert='/etc/uhttpd.crt'
-        uci set uhttpd.main.key='/etc/uhttpd.key'
-    else
-        uci -q delete uhttpd.main.cert
-        uci -q delete uhttpd.main.key
-        uci -q delete uhttpd.main.listen_https
-    fi
-fi
-echo "[1] uhttpd cert reverted."
+echo "[1] Certificates removed."
 
 # ── Remove dnsmasq DNS entry ────────────────────────────────────────────────
 
@@ -167,18 +98,14 @@ ORIGINAL_PORT=$(cat "${BACKUP_DIR}/nds.gatewayport" 2>/dev/null || echo "80")
 uci set nodogsplash.@nodogsplash[0].gatewaydomainname="$ORIGINAL_DOMAIN"
 uci set nodogsplash.@nodogsplash[0].gatewayport="$ORIGINAL_PORT"
 
-# Remove port 443 allow rule
-uci -q del_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 443' 2>/dev/null || true
-
 echo "[3] nodogsplash reverted to ${ORIGINAL_DOMAIN}:${ORIGINAL_PORT}"
 
 # ── Commit and reload ──────────────────────────────────────────────────────
 
-uci commit uhttpd
 uci commit dhcp
 uci commit nodogsplash
 
-/etc/init.d/uhttpd reload
+/etc/init.d/tollgate-wrt restart
 /etc/init.d/dnsmasq reload
 /etc/init.d/nodogsplash restart
 

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -608,6 +610,54 @@ func handleLightningInvoiceGet(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func newLuCIProxy() *httputil.ReverseProxy {
+	target, _ := url.Parse("http://127.0.0.1:8080")
+	return &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			r.SetXForwarded()
+			mainLogger.WithFields(logrus.Fields{
+				"method": r.In.Method,
+				"path":   r.In.URL.Path,
+			}).Debug("Proxying request to LuCI")
+		},
+	}
+}
+
+func isTollgateRoute(path string) bool {
+	switch path {
+	case "/whoami", "/ln-invoice", "/balance", "/usage":
+		return true
+	default:
+		return false
+	}
+}
+
+func startHTTPSServer(certFile, keyFile string) {
+	luciProxy := newLuCIProxy()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isTollgateRoute(r.URL.Path) {
+			http.DefaultServeMux.ServeHTTP(w, r)
+			return
+		}
+		luciProxy.ServeHTTP(w, r)
+	})
+
+	server := &http.Server{
+		Addr:         ":443",
+		Handler:      handler,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	mainLogger.Info("Starting HTTPS server on :443 with LuCI proxy")
+	if err := server.ListenAndServeTLS(certFile, keyFile); err != nil {
+		mainLogger.WithError(err).Error("HTTPS server failed")
+	}
+}
+
 func main() {
 	var port = ":2121" // Change from "0.0.0.0:2121" to just ":2121"
 	fmt.Println("Starting Tollgate Core")
@@ -664,6 +714,17 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, usageStr)
 	})
+
+	// Conditionally start HTTPS server on 443 with LuCI reverse proxy
+	certFile := "/etc/tollgate/ssl/server.crt"
+	keyFile := "/etc/tollgate/ssl/server.key"
+	if _, err := os.Stat(certFile); err == nil {
+		if _, err := os.Stat(keyFile); err == nil {
+			go startHTTPSServer(certFile, keyFile)
+		} else {
+			mainLogger.Warn("HTTPS cert found but key missing, skipping HTTPS")
+		}
+	}
 
 	mainLogger.Info("Starting HTTP server on all interfaces...")
 	server := &http.Server{


### PR DESCRIPTION
## Summary
- Go binary (`tollgate-wrt`) terminates TLS on port 443 and reverse-proxies LuCI to uhttpd on `127.0.0.1:8080`
- HTTPS is **opt-in**: run `tollgate-apply-ssl` to generate a self-signed cert; no cert = current behavior (port 2121 only)
- uhttpd restricted to localhost only — no longer exposed to clients
- `tollgate-apply-ssl` / `tollgate-remove-ssl` updated to restart `tollgate-wrt` instead of configuring uhttpd

## Architecture
| Port | Service | Purpose |
|------|---------|---------|
| 80 | NoDogSplash | Captive portal (HTTP interception) |
| 443 | tollgate-wrt (HTTPS) | LuCI admin + tollgate API (`/whoami`, `/ln-invoice`, `/balance`, `/usage`) |
| 2121 | tollgate-wrt (HTTP) | Tollgate protocol (unchanged) |
| 8080 | uhttpd (localhost only) | LuCI backend for reverse proxy |

## Files Changed
- **`src/main.go`** — `newLuCIProxy()`, `isTollgateRoute()`, `startHTTPSServer()`, conditional HTTPS startup
- **`tollgate-apply-ssl`** — Restart `tollgate-wrt` instead of configuring uhttpd HTTPS
- **`tollgate-remove-ssl`** — Remove certs + restart `tollgate-wrt` (no uhttpd changes)
- **`99-tollgate-setup`** — uhttpd bound to `127.0.0.1:8080`, removed self-signed cert auto-generation (previous commit on this branch)

## Testing
- `cd src && go build ./...` passes
- Zero new dependencies (`net/http/httputil` and `net/url` are stdlib)
- No binary size increase (already imports `crypto/tls` transitively)