### PR TITLE
fix: add Shutdown() to MerchantInterface, use net.Error for mint fallback

### DIFF
--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -51,6 +51,8 @@ type MerchantInterface interface {
 	GetUsage(macAddress string) (string, error)
 	// Wallet funding methods
 	Fund(cashuToken string) (uint64, error)
+	// Lifecycle
+	Shutdown() error
 }
 
 // Merchant represents the financial decision maker for the tollgate

--- a/src/merchant/merchant_degraded.go
+++ b/src/merchant/merchant_degraded.go
@@ -94,3 +94,4 @@ func (m *MerchantDegraded) AddAllotment(string, string, uint64) (*CustomerSessio
 }
 func (m *MerchantDegraded) GetUsage(string) (string, error) { return "", errDegraded }
 func (m *MerchantDegraded) Fund(string) (uint64, error)     { return 0, errDegraded }
+func (m *MerchantDegraded) Shutdown() error                  { return nil }

--- a/src/merchant/merchant_provider_test.go
+++ b/src/merchant/merchant_provider_test.go
@@ -54,6 +54,7 @@ func (s *stubMerchant) GetUsage(string) (string, error) {
 func (s *stubMerchant) Fund(string) (uint64, error) {
 	return 0, fmt.Errorf("stub: %s", s.label)
 }
+func (s *stubMerchant) Shutdown() error { return nil }
 
 // TestMutexMerchantProviderSatisfiesInterface verifies the compile-time
 // interface assertion in merchant_provider.go is valid.

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -1,8 +1,10 @@
 package tollwallet
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"sync"
 
@@ -41,7 +43,8 @@ func New(walletPath string, acceptedMints []string, allowAndSwapUntrustedMints b
 
 		w, err := wallet.LoadWallet(config)
 		if err != nil {
-			if strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "no such host") {
+			var netErr net.Error
+			if errors.As(err, &netErr) || isNetworkError(err) {
 				log.Printf("TollWallet.New: Mint %s unreachable: %v", mintURL, err)
 				lastErr = err
 				continue
@@ -332,4 +335,10 @@ func (w *TollWallet) Shutdown() error {
 		err = w.wallet.Shutdown()
 	})
 	return err
+}
+
+func isNetworkError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such host")
 }


### PR DESCRIPTION
Addresses two Copilot review findings on PR #120. Targets fix/degraded-mode-minimal — merge into #120 first.

## Changes

### 1. Add Shutdown() to MerchantInterface
Shutdown() was only on *Merchant, not the interface. Now callers can invoke it polymorphically through MerchantProvider without type assertions.
- merchant.go:55 — Shutdown() error on MerchantInterface
- merchant_degraded.go:97 — no-op Shutdown() on MerchantDegraded
- merchant_provider_test.go:57 — Shutdown() on stubMerchant

### 2. Replace brittle error string matching
tollwallet.go used strings.Contains(err.Error(), "timeout") to classify network errors. Now uses errors.As(err, &netErr) to catch net.OpError, url.Error, and timeout errors via the net.Error interface. String fallback retained for connection refused and no such host.

## Testing
All 13 existing Go unit tests pass. go build ./src/. compiles clean.

## Files Changed
| File | Change |
|------|--------|
| src/merchant/merchant.go | +2 |
| src/merchant/merchant_degraded.go | +1 |
| src/merchant/merchant_provider_test.go | +1 |
| src/tollwallet/tollwallet.go | +11/-1 |