### PR TITLE
fix(transport): force TLS 1.2 and set HTTP timeouts for OpenWrt

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"context" // Added for context.Background()
+	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -81,6 +83,20 @@ func InitializeGlobalLogger(logLevel string) {
 }
 
 func init() {
+	http.DefaultTransport = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 10 * time.Second,
+		}).DialContext,
+		DisableKeepAlives:     true,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12, MaxVersion: tls.VersionTLS12},
+		TLSHandshakeTimeout:   20 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       30 * time.Second,
+		ForceAttemptHTTP2:     false,
+	}
+	http.DefaultClient.Timeout = 30 * time.Second
+
 	var err error
 
 	configPath, installPath, identitiesPath := getTollgatePaths()

--- a/src/transport_test.go
+++ b/src/transport_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultTransport_TLSMaxVersionIsTLS12(t *testing.T) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	assert.True(t, ok, "DefaultTransport should be *http.Transport")
+
+	assert.NotNil(t, transport.TLSClientConfig, "TLSClientConfig should be set")
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MaxVersion,
+		"TLS MaxVersion must be TLS 1.2 for OpenWrt compatibility")
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion,
+		"TLS MinVersion must be TLS 1.2")
+}
+
+func TestDefaultTransport_TimeoutsSet(t *testing.T) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	assert.True(t, ok)
+
+	assert.Equal(t, 30*time.Second, transport.ResponseHeaderTimeout)
+	assert.Equal(t, 20*time.Second, transport.TLSHandshakeTimeout)
+	assert.Equal(t, 30*time.Second, transport.IdleConnTimeout)
+}
+
+func TestDefaultTransport_HTTP2Disabled(t *testing.T) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	assert.True(t, ok)
+	assert.False(t, transport.ForceAttemptHTTP2)
+}
+
+func TestDefaultTransport_DisableKeepAlives(t *testing.T) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	assert.True(t, ok)
+	assert.True(t, transport.DisableKeepAlives)
+}
+
+func TestDefaultClient_TimeoutSet(t *testing.T) {
+	assert.Equal(t, 30*time.Second, http.DefaultClient.Timeout)
+}

--- a/src/transport_test.go
+++ b/src/transport_test.go
@@ -44,3 +44,18 @@ func TestDefaultTransport_DisableKeepAlives(t *testing.T) {
 func TestDefaultClient_TimeoutSet(t *testing.T) {
 	assert.Equal(t, 30*time.Second, http.DefaultClient.Timeout)
 }
+
+func TestDefaultTransport_MaxIdleConns(t *testing.T) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	assert.True(t, ok)
+	assert.Equal(t, 10, transport.MaxIdleConns)
+}
+
+func TestDefaultTransport_DefaultClientUsesDefaultTransport(t *testing.T) {
+	assert.Nil(t, http.DefaultClient.Transport,
+		"DefaultClient should use DefaultTransport (no override)")
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	assert.True(t, ok)
+	assert.NotNil(t, transport.TLSClientConfig)
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MaxVersion)
+}


### PR DESCRIPTION
## PR A — TLS 1.2 + HTTP Transport Hardening

**Part of PR #118 decomposition.** Foundation PR — no dependencies.

### Problem
Go's pure TLS 1.3 `ClientHello` times out on the router's network path to Cashu mints. Without this fix, all mint API calls hang indefinitely.

### Changes
- Override `http.DefaultTransport` in `init()` with TLS 1.2 `MaxVersion`
- Set `ResponseHeaderTimeout: 30s`, `TLSHandshakeTimeout: 20s`, `DialContext.Timeout: 10s`
- Disable HTTP/2 (`ForceAttemptHTTP2: false`) and keep-alives (`DisableKeepAlives: true`)
- Add `transport_test.go` verifying TLS config at init time (5 tests)

### Test Coverage
| Type | File | Tests |
|---|---|---|
| Go unit | `src/transport_test.go` | 5 (TLS 1.2, timeouts, HTTP/2 disabled) |
| pytest | `tests/api/test_tls_transport.py` (test automation repo) | 3 (latency, no TLS errors, mint reachable) |
| Hardware | `r-check-merchant` | Mint API responds in <1s |

### Merge Gate
- [x] `go build ./...` passes
- [ ] `test_health.py` smoke tests pass on hardware
- [ ] `r-check-merchant` confirms mint API responded

See [PR118-DECOMPOSITION-PLAN.md](https://github.com/OpenTollGate/tollgate-module-basic-go/blob/main/PR118-DECOMPOSITION-PLAN.md) for full context.