### PR TITLE
feat: config schema, CLI --json, and test infrastructure (reopened for review)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,13 @@ jobs:
           node-version: '22'
       - name: Schema lint
         run: node tests/contract/js-schema-lint.mjs
+
+  build-purity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+      - name: Build purity check
+        run: bash tests/contract/build-purity.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,17 @@ jobs:
         working-directory: ${{ matrix.module }}
         run: go test ./... -v -count=1 -race
 
+  main-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+      - name: Run main package tests
+        working-directory: src
+        run: go test -v -count=1 -race -tags testenv .
+
   contract-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    branches: [main, master, develop]
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - src/config_manager
+          - src/utils
+          - src/cmd/tollgate-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+      - name: Run tests
+        working-directory: ${{ matrix.module }}
+        run: go test ./... -v -count=1 -race
+
+  contract-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Schema lint
+        run: node tests/contract/js-schema-lint.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ vendor/
 tollgate
 tollgate-wrt
 tollgate-module-basic-go
+tollgate-cli
+*.exe
 
 # Test artifacts
 **/tollwallet_db/*

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ memory-global
 memory-project/
 reference/
 .opencode/
+
+# Planning docs — internal, not for release
+docs/configuration-ui-merge-plan.md
+docs/configurationwizzard-integration.md
+PR.md

--- a/src/000_test_env_testenv.go
+++ b/src/000_test_env_testenv.go
@@ -1,3 +1,5 @@
+//go:build testenv
+
 package main
 
 import (

--- a/src/cli/config.go
+++ b/src/cli/config.go
@@ -1,0 +1,237 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager"
+)
+
+func (s *CLIServer) handleConfigCommand(args []string, flags map[string]string) CLIResponse {
+	if len(args) == 0 {
+		return CLIResponse{
+			Success:   false,
+			Error:     "Config command requires a subcommand (get, set, schema, save, save-identities)",
+			Timestamp: time.Now(),
+		}
+	}
+
+	subcommand := args[0]
+	switch subcommand {
+	case "get":
+		return s.handleConfigGet()
+	case "set":
+		if len(args) < 3 {
+			return CLIResponse{
+				Success:   false,
+				Error:     "config set requires <key> <value>",
+				Timestamp: time.Now(),
+			}
+		}
+		return s.handleConfigSet(args[1], args[2])
+	case "schema":
+		return s.handleConfigSchema()
+	case "save":
+		if len(args) < 2 {
+			return CLIResponse{
+				Success:   false,
+				Error:     "config save requires <json-string>",
+				Timestamp: time.Now(),
+			}
+		}
+		return s.handleConfigSave(args[1])
+	case "save-identities":
+		if len(args) < 2 {
+			return CLIResponse{
+				Success:   false,
+				Error:     "config save-identities requires <json-string>",
+				Timestamp: time.Now(),
+			}
+		}
+		return s.handleIdentitiesSave(args[1])
+	default:
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Unknown config subcommand: %s (supported: get, set, schema, save, save-identities)", subcommand),
+			Timestamp: time.Now(),
+		}
+	}
+}
+
+func (s *CLIServer) handleConfigGet() CLIResponse {
+	if s.configManager == nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     "Config manager not available",
+			Timestamp: time.Now(),
+		}
+	}
+
+	cfg := s.configManager.GetConfig()
+	identities := s.configManager.GetIdentities()
+
+	return CLIResponse{
+		Success: true,
+		Message: "Configuration retrieved",
+		Data: map[string]interface{}{
+			"config":     cfg,
+			"identities": identities,
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+func (s *CLIServer) handleConfigSet(key, value string) CLIResponse {
+	if s.configManager == nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     "Config manager not available",
+			Timestamp: time.Now(),
+		}
+	}
+
+	err := config_manager.SetDotPath(s.configManager, key, value)
+	if err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Failed to set %s: %v", key, err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	return CLIResponse{
+		Success: true,
+		Message: fmt.Sprintf("Set %s = %s (restart tollgate-wrt to apply)", key, value),
+		Data: map[string]interface{}{
+			"key":   key,
+			"value": value,
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+func (s *CLIServer) handleConfigSchema() CLIResponse {
+	return CLIResponse{
+		Success: true,
+		Message: "Configuration schema",
+		Data: map[string]interface{}{
+			"config":     config_manager.GetConfigSchema(),
+			"identities": config_manager.GetIdentitiesSchema(),
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+func (s *CLIServer) handleConfigSave(jsonStr string) CLIResponse {
+	if s.configManager == nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     "Config manager not available",
+			Timestamp: time.Now(),
+		}
+	}
+
+	var cfg config_manager.Config
+	if err := json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Invalid JSON: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	requiredFields := []string{"config_version", "metric", "step_size", "accepted_mints", "profit_share"}
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("JSON parse error: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+	var missing []string
+	for _, f := range requiredFields {
+		if _, ok := raw[f]; !ok {
+			missing = append(missing, f)
+		}
+	}
+	if len(missing) > 0 {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Missing required fields: %v", missing),
+			Timestamp: time.Now(),
+		}
+	}
+
+	if err := cfg.ValidateProfitShare(); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Invalid profit_share: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	if err := config_manager.SaveConfig(s.configManager.ConfigFilePath, &cfg); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Failed to save config: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	if err := s.configManager.ReloadConfig(); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Config saved but reload failed: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	return CLIResponse{
+		Success:   true,
+		Message:   "Configuration saved (restart tollgate-wrt to apply)",
+		Timestamp: time.Now(),
+	}
+}
+
+func (s *CLIServer) handleIdentitiesSave(jsonStr string) CLIResponse {
+	if s.configManager == nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     "Config manager not available",
+			Timestamp: time.Now(),
+		}
+	}
+
+	var identities config_manager.IdentitiesConfig
+	if err := json.Unmarshal([]byte(jsonStr), &identities); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Invalid JSON: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	if err := config_manager.SaveIdentities(s.configManager.IdentitiesFilePath, &identities); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Failed to save identities: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	if err := s.configManager.ReloadIdentities(); err != nil {
+		return CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Identities saved but reload failed: %v", err),
+			Timestamp: time.Now(),
+		}
+	}
+
+	return CLIResponse{
+		Success:   true,
+		Message:   "Identities saved (restart tollgate-wrt to apply)",
+		Timestamp: time.Now(),
+	}
+}

--- a/src/cli/server.go
+++ b/src/cli/server.go
@@ -513,7 +513,7 @@ func (s *CLIServer) handleHealthCommand() CLIResponse {
 		"status":     "ok",
 		"version":    GetVersionInfo(),
 		"config_ok":  s.configManager != nil,
-		"wallet_ok":  s.merchant != nil,
+		"wallet_ok":  s.merchantProvider != nil && s.merchantProvider.GetMerchant() != nil,
 		"uptime":     time.Since(s.startTime).String(),
 	}
 	return CLIResponse{

--- a/src/cli/server.go
+++ b/src/cli/server.go
@@ -172,6 +172,10 @@ func (s *CLIServer) processCommand(msg CLIMessage) CLIResponse {
 		return s.handleStatusCommand(msg.Args, msg.Flags)
 	case "version":
 		return s.handleVersionCommand()
+	case "config":
+		return s.handleConfigCommand(msg.Args, msg.Flags)
+	case "health":
+		return s.handleHealthCommand()
 	default:
 		return CLIResponse{
 			Success:   false,
@@ -499,6 +503,23 @@ func (s *CLIServer) handleVersionCommand() CLIResponse {
 	return CLIResponse{
 		Success:   true,
 		Message:   GetFormattedVersionInfo(),
+		Data:      GetFullVersionInfo(),
+		Timestamp: time.Now(),
+	}
+}
+
+func (s *CLIServer) handleHealthCommand() CLIResponse {
+	health := map[string]interface{}{
+		"status":     "ok",
+		"version":    GetVersionInfo(),
+		"config_ok":  s.configManager != nil,
+		"wallet_ok":  s.merchant != nil,
+		"uptime":     time.Since(s.startTime).String(),
+	}
+	return CLIResponse{
+		Success:   true,
+		Message:   "healthy",
+		Data:      health,
 		Timestamp: time.Now(),
 	}
 }

--- a/src/cmd/tollgate-cli/contract_test.go
+++ b/src/cmd/tollgate-cli/contract_test.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestCLIResponseJSONShape(t *testing.T) {
+	resp := CLIResponse{
+		Success: true,
+		Message: "test message",
+		Data: map[string]interface{}{
+			"balance_sats": uint64(12345),
+		},
+		Timestamp: time.Now(),
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Failed to marshal CLIResponse: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal CLIResponse: %v", err)
+	}
+
+	requiredFields := []string{"success", "message", "data", "timestamp"}
+	for _, f := range requiredFields {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("CLIResponse JSON missing field: %s", f)
+		}
+	}
+
+	if success, ok := parsed["success"].(bool); !ok || !success {
+		t.Errorf("CLIResponse.success should be true bool, got %v", parsed["success"])
+	}
+}
+
+func TestCLIResponseErrorShape(t *testing.T) {
+	resp := CLIResponse{
+		Success: false,
+		Error:   "something went wrong",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Failed to marshal error response: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if _, ok := parsed["error"]; !ok {
+		t.Error("Error response missing 'error' field")
+	}
+	if _, ok := parsed["success"]; !ok {
+		t.Error("Error response missing 'success' field")
+	}
+}
+
+func TestCLIMessageJSONShape(t *testing.T) {
+	msg := CLIMessage{
+		Command: "wallet",
+		Args:    []string{"balance"},
+		Flags:   map[string]string{"test": "value"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal CLIMessage: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal CLIMessage: %v", err)
+	}
+
+	if _, ok := parsed["command"]; !ok {
+		t.Error("CLIMessage missing 'command' field")
+	}
+	if _, ok := parsed["args"]; !ok {
+		t.Error("CLIMessage missing 'args' field")
+	}
+}
+
+func TestWalletBalanceDataShape(t *testing.T) {
+	data := map[string]interface{}{
+		"balance_sats": uint64(5000),
+		"address":      "",
+		"drain_target": "",
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	if _, ok := parsed["balance_sats"]; !ok {
+		t.Error("Wallet balance data missing 'balance_sats'")
+	}
+}
+
+func TestServiceStatusDataShape(t *testing.T) {
+	data := map[string]interface{}{
+		"running":    true,
+		"version":    "v0.0.4",
+		"uptime":     "1h23m45s",
+		"config_ok":  true,
+		"wallet_ok":  true,
+		"network_ok": true,
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	requiredFields := []string{"running", "version", "uptime", "config_ok", "wallet_ok", "network_ok"}
+	for _, f := range requiredFields {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("ServiceStatus data missing field: %s", f)
+		}
+	}
+}
+
+func TestVersionDataShape(t *testing.T) {
+	data := map[string]string{
+		"version":         "v0.0.4",
+		"commit":          "abc1234",
+		"build_time":      "2025-01-01",
+		"go_version":      "go1.24",
+		"openwrt_version": "24.10.1",
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	requiredFields := []string{"version", "commit", "build_time", "go_version", "openwrt_version"}
+	for _, f := range requiredFields {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("Version data missing field: %s", f)
+		}
+	}
+}
+
+func TestPrivateNetworkInfoShape(t *testing.T) {
+	data := map[string]interface{}{
+		"ssid":     "MyNetwork",
+		"password": "secret123",
+		"enabled":  true,
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	requiredFields := []string{"ssid", "password", "enabled"}
+	for _, f := range requiredFields {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("PrivateNetworkInfo data missing field: %s", f)
+		}
+	}
+}
+
+func TestConfigGetResponseShape(t *testing.T) {
+	data := map[string]interface{}{
+		"config": map[string]interface{}{
+			"config_version": "v0.0.7",
+			"metric":         "bytes",
+		},
+		"identities": map[string]interface{}{
+			"config_version": "v0.0.1",
+		},
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	if _, ok := parsed["config"]; !ok {
+		t.Error("Config get response missing 'config'")
+	}
+	if _, ok := parsed["identities"]; !ok {
+		t.Error("Config get response missing 'identities'")
+	}
+}
+
+func TestConfigSchemaResponseShape(t *testing.T) {
+	data := map[string]interface{}{
+		"config": []interface{}{
+			map[string]interface{}{
+				"name":     "Metric",
+				"type":     "string",
+				"json_key": "metric",
+				"editable": true,
+			},
+		},
+		"identities": []interface{}{
+			map[string]interface{}{
+				"name":     "ConfigVersion",
+				"type":     "string",
+				"json_key": "config_version",
+				"editable": false,
+			},
+		},
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	for _, key := range []string{"config", "identities"} {
+		arr, ok := parsed[key].([]interface{})
+		if !ok || len(arr) == 0 {
+			t.Errorf("Schema response %s is missing or empty", key)
+		}
+		first := arr[0].(map[string]interface{})
+		for _, f := range []string{"name", "type", "json_key", "editable"} {
+			if _, ok := first[f]; !ok {
+				t.Errorf("Schema field missing key: %s", f)
+			}
+		}
+	}
+}
+
+func TestHealthResponseShape(t *testing.T) {
+	data := map[string]interface{}{
+		"running":             true,
+		"socket_ok":           true,
+		"uptime":              "1h",
+		"version":             "v0.0.4",
+		"config_ok":           true,
+		"wallet_ok":           true,
+		"network_ok":          true,
+		"healthy":             true,
+		"wallet_balance_sats": uint64(500),
+		"mint_count":          2,
+		"metric":              "bytes",
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	requiredFields := []string{"running", "socket_ok", "healthy", "config_ok", "wallet_ok"}
+	for _, f := range requiredFields {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("Health response missing field: %s", f)
+		}
+	}
+}
+
+func TestConfigSetResponseShape(t *testing.T) {
+	data := map[string]interface{}{
+		"key":   "metric",
+		"value": "milliseconds",
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	for _, f := range []string{"key", "value"} {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("Config set response missing field: %s", f)
+		}
+	}
+}
+
+func TestWalletDrainDataShape(t *testing.T) {
+	data := map[string]interface{}{
+		"success":     true,
+		"tokens":      []interface{}{},
+		"total_sats":  uint64(1000),
+		"save_to_file": "drain.txt",
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	for _, f := range []string{"success", "tokens", "total_sats"} {
+		if _, ok := parsed[f]; !ok {
+			t.Errorf("Wallet drain response missing field: %s", f)
+		}
+	}
+}
+
+func TestWalletFundDataShape(t *testing.T) {
+	data := map[string]interface{}{
+		"amount_received": uint64(500),
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	var parsed map[string]interface{}
+	json.Unmarshal(jsonBytes, &parsed)
+
+	if _, ok := parsed["amount_received"]; !ok {
+		t.Error("Wallet fund response missing 'amount_received'")
+	}
+}

--- a/src/cmd/tollgate-cli/main.go
+++ b/src/cmd/tollgate-cli/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// askConfirmation prompts the user for yes/no confirmation
 func askConfirmation(message string) bool {
 	fmt.Printf("%s (y/N): ", message)
 	scanner := bufio.NewScanner(os.Stdin)
@@ -28,7 +27,6 @@ const (
 	SocketPath = "/var/run/tollgate.sock"
 )
 
-// Simple message types to avoid module dependencies
 type CLIMessage struct {
 	Command   string            `json:"command"`
 	Args      []string          `json:"args,omitempty"`
@@ -44,6 +42,8 @@ type CLIResponse struct {
 	Progress  string      `json:"progress,omitempty"`
 	Timestamp time.Time   `json:"timestamp"`
 }
+
+var jsonOutput bool
 
 var rootCmd = &cobra.Command{
 	Use:   "tollgate",
@@ -81,7 +81,10 @@ var drainCashuCmd = &cobra.Command{
 	Short: "Drain wallet to Cashu tokens",
 	Long:  "Create Cashu tokens for each mint containing all available balance",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Show warning and get confirmation
+		if jsonOutput {
+			return sendCommandRaw("wallet", []string{"drain", "cashu"}, nil)
+		}
+
 		fmt.Println("\n⚠️  WARNING: Draining the wallet will remove ALL funds from the wallet!")
 		fmt.Println("The funds will be converted to Cashu tokens that will be saved to a file.")
 		fmt.Println("Once drained, the tokens are OUT of the wallet and must be stored securely.")
@@ -91,7 +94,6 @@ var drainCashuCmd = &cobra.Command{
 			return nil
 		}
 
-		// Generate filename with timestamp
 		filename := fmt.Sprintf("wallet_drain_%s.txt", time.Now().Format("2006-01-02_15-04-05"))
 
 		flags := map[string]string{
@@ -122,18 +124,24 @@ var infoCmd = &cobra.Command{
 }
 
 var fundCmd = &cobra.Command{
-	Use:   "fund",
+	Use:   "fund [cashu-token]",
 	Short: "Fund wallet with a Cashu token",
-	Long:  "Add funds to the wallet by pasting a Cashu token when prompted.",
-	Args:  cobra.NoArgs,
+	Long:  "Add funds to the wallet by providing a Cashu token.",
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Interactive mode only - prompt for token
-		fmt.Print("Paste your Cashu token: ")
-		scanner := bufio.NewScanner(os.Stdin)
-		if !scanner.Scan() {
-			return fmt.Errorf("failed to read token input")
+		var cashuToken string
+		if len(args) == 1 {
+			cashuToken = strings.TrimSpace(args[0])
+		} else if !jsonOutput {
+			fmt.Print("Paste your Cashu token: ")
+			scanner := bufio.NewScanner(os.Stdin)
+			if !scanner.Scan() {
+				return fmt.Errorf("failed to read token input")
+			}
+			cashuToken = strings.TrimSpace(scanner.Text())
+		} else {
+			return fmt.Errorf("fund command requires a cashu token argument when using --json")
 		}
-		cashuToken := strings.TrimSpace(scanner.Text())
 
 		if cashuToken == "" {
 			return fmt.Errorf("no token provided")
@@ -175,7 +183,10 @@ var privateDisableCmd = &cobra.Command{
 	Short: "Disable private network",
 	Long:  "Disable the private WiFi network on both 2.4GHz and 5GHz radios",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Warn user about potential lockout
+		if jsonOutput {
+			return sendCommandRaw("network", []string{"private", "disable"}, nil)
+		}
+
 		fmt.Println("\n⚠️  WARNING: Disabling the private network may lock you out of the router!")
 		fmt.Println("Make sure you have another way to access the router (e.g., via the public network or physical access).")
 
@@ -205,10 +216,8 @@ var privateSetPasswordCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			// Generate random password
 			return sendCommandAndDisplay("network", []string{"private", "set-password"}, nil)
 		}
-		// Set specific password
 		return sendCommandAndDisplay("network", []string{"private", "set-password", args[0]}, nil)
 	},
 }
@@ -308,18 +317,108 @@ var logsCmd = &cobra.Command{
 	},
 }
 
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Configuration management",
+	Long:  "View and manage TollGate configuration. All subcommands route through the running service.",
+}
+
+var configGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get current configuration",
+	Long:  "Display the current configuration. With --json, outputs structured JSON.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sendCommandAndDisplay("config", []string{"get"}, nil)
+	},
+}
+
+var configSetCmd = &cobra.Command{
+	Use:   "set [key] [value]",
+	Short: "Set a configuration value",
+	Long: `Set a configuration value by dot-path key. Changes are persisted immediately.
+Examples:
+  tollgate config set metric milliseconds
+  tollgate config set step_size 44040192
+  tollgate config set accepted_mints.0.price_per_step 2
+  tollgate config set show_setup false`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sendCommandAndDisplay("config", []string{"set", args[0], args[1]}, nil)
+	},
+}
+
+var configSchemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Get configuration schema",
+	Long:  "Output the configuration schema describing all fields, types, defaults, and validation rules.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sendCommandAndDisplay("config", []string{"schema"}, nil)
+	},
+}
+
+var configSaveCmd = &cobra.Command{
+	Use:   "save [json]",
+	Short: "Save full configuration from JSON string",
+	Long:  "Replace the entire config.json with the provided JSON string. Use with caution.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sendCommandAndDisplay("config", []string{"save", args[0]}, nil)
+	},
+}
+
+var configSaveIdentitiesCmd = &cobra.Command{
+	Use:   "save-identities [json]",
+	Short: "Save full identities from JSON string",
+	Long:  "Replace the entire identities.json with the provided JSON string. Use with caution.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sendCommandAndDisplay("config", []string{"save-identities", args[0]}, nil)
+	},
+}
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Check service health",
+	Long:  "Check the health of TollGate service components.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		response, err := sendCommand(CLIMessage{
+			Command:   "health",
+			Args:      []string{},
+			Timestamp: time.Now(),
+		})
+		if err != nil {
+			if jsonOutput {
+				return printJSON(map[string]interface{}{
+					"success":   false,
+					"running":   false,
+					"socket_ok": false,
+					"error":     fmt.Sprintf("Service not reachable: %v", err),
+					"timestamp": time.Now().Format(time.RFC3339),
+				})
+			}
+			return fmt.Errorf("Service not reachable: %v", err)
+		}
+		if jsonOutput {
+			return printJSON(response)
+		}
+		displayResponse(response)
+		return nil
+	},
+}
+
 func init() {
-	// Add flags to logs command
+	rootCmd.PersistentFlags().BoolVarP(&jsonOutput, "json", "j", false, "Output results as JSON")
+
 	logsCmd.Flags().IntP("tail", "n", 0, "Number of lines to show from the end (0 = all)")
 	logsCmd.Flags().BoolP("follow", "f", false, "Follow log output (like tail -f)")
 
-	// Build command tree
 	drainCmd.AddCommand(drainCashuCmd)
 	walletCmd.AddCommand(drainCmd, balanceCmd, infoCmd, fundCmd)
 	privateCmd.AddCommand(privateStatusCmd, privateEnableCmd, privateDisableCmd, privateRenameCmd, privateSetPasswordCmd)
 	networkCmd.AddCommand(privateCmd)
 	upstreamCmd.AddCommand(upstreamScanCmd, upstreamConnectCmd, upstreamListCmd, upstreamRemoveCmd)
-	rootCmd.AddCommand(walletCmd, networkCmd, upstreamCmd, statusCmd, versionCmd, startCmd, stopCmd, restartCmd, logsCmd)
+	configCmd.AddCommand(configGetCmd, configSetCmd, configSchemaCmd, configSaveCmd, configSaveIdentitiesCmd)
+	rootCmd.AddCommand(walletCmd, networkCmd, upstreamCmd, statusCmd, versionCmd, startCmd, stopCmd, restartCmd, logsCmd, configCmd, healthCmd)
 }
 
 func main() {
@@ -330,7 +429,6 @@ func main() {
 }
 
 func sendCommandAndDisplay(command string, args []string, flags map[string]string) error {
-	// Create CLI message
 	msg := CLIMessage{
 		Command:   command,
 		Args:      args,
@@ -338,13 +436,22 @@ func sendCommandAndDisplay(command string, args []string, flags map[string]strin
 		Timestamp: time.Now(),
 	}
 
-	// Send command to service
 	response, err := sendCommand(msg)
 	if err != nil {
+		if jsonOutput {
+			return printJSON(&CLIResponse{
+				Success:   false,
+				Error:     fmt.Sprintf("Failed to communicate with TollGate service: %v", err),
+				Timestamp: time.Now(),
+			})
+		}
 		return fmt.Errorf("failed to communicate with TollGate service: %v\nMake sure the TollGate service is running", err)
 	}
 
-	// Display response
+	if jsonOutput {
+		return printJSON(response)
+	}
+
 	displayResponse(response)
 
 	if !response.Success {
@@ -354,15 +461,42 @@ func sendCommandAndDisplay(command string, args []string, flags map[string]strin
 	return nil
 }
 
+func sendCommandRaw(command string, args []string, flags map[string]string) error {
+	msg := CLIMessage{
+		Command:   command,
+		Args:      args,
+		Flags:     flags,
+		Timestamp: time.Now(),
+	}
+
+	response, err := sendCommand(msg)
+	if err != nil {
+		return printJSON(&CLIResponse{
+			Success:   false,
+			Error:     fmt.Sprintf("Failed to communicate with TollGate service: %v", err),
+			Timestamp: time.Now(),
+		})
+	}
+
+	return printJSON(response)
+}
+
+func printJSON(v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
 func sendCommand(msg CLIMessage) (*CLIResponse, error) {
-	// Connect to Unix socket
 	conn, err := net.Dial("unix", SocketPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to TollGate service: %v", err)
 	}
 	defer conn.Close()
 
-	// Send message
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode message: %v", err)
@@ -378,7 +512,6 @@ func sendCommand(msg CLIMessage) (*CLIResponse, error) {
 		return nil, fmt.Errorf("failed to send newline: %v", err)
 	}
 
-	// Read response
 	scanner := bufio.NewScanner(conn)
 	if !scanner.Scan() {
 		return nil, fmt.Errorf("no response from service")
@@ -443,8 +576,11 @@ func sendCommandStreaming(command string, args []string, flags map[string]string
 	return fmt.Errorf("no response from service")
 }
 
-// executeServiceCommand executes service control commands directly via init scripts
 func executeServiceCommand(action string) error {
+	if jsonOutput {
+		return executeServiceCommandJSON(action)
+	}
+
 	var cmds []struct {
 		name string
 		cmd  *exec.Cmd
@@ -479,7 +615,6 @@ func executeServiceCommand(action string) error {
 		return fmt.Errorf("unknown service action: %s", action)
 	}
 
-	// Execute commands in sequence
 	for _, c := range cmds {
 		fmt.Printf("Executing: %s %s...\n", c.name, action)
 		output, err := c.cmd.CombinedOutput()
@@ -499,30 +634,80 @@ func executeServiceCommand(action string) error {
 	return nil
 }
 
-// executeLogsCommand executes logread directly to show TollGate logs
+func executeServiceCommandJSON(action string) error {
+	var cmds []struct {
+		name string
+		cmd  *exec.Cmd
+	}
+
+	switch action {
+	case "start":
+		cmds = []struct {
+			name string
+			cmd  *exec.Cmd
+		}{
+			{"NoDogSplash", exec.Command("/etc/init.d/nodogsplash", "start")},
+			{"TollGate", exec.Command("/etc/init.d/tollgate-wrt", "start")},
+		}
+	case "stop":
+		cmds = []struct {
+			name string
+			cmd  *exec.Cmd
+		}{
+			{"TollGate", exec.Command("/etc/init.d/tollgate-wrt", "stop")},
+			{"NoDogSplash", exec.Command("/etc/init.d/nodogsplash", "stop")},
+		}
+	case "restart":
+		cmds = []struct {
+			name string
+			cmd  *exec.Cmd
+		}{
+			{"NoDogSplash", exec.Command("/etc/init.d/nodogsplash", "restart")},
+			{"TollGate", exec.Command("/etc/init.d/tollgate-wrt", "restart")},
+		}
+	default:
+		return printJSON(map[string]interface{}{
+			"success": false,
+			"error":   fmt.Sprintf("unknown service action: %s", action),
+		})
+	}
+
+	for _, c := range cmds {
+		output, err := c.cmd.CombinedOutput()
+		if err != nil {
+			return printJSON(map[string]interface{}{
+				"success": false,
+				"error":   fmt.Sprintf("failed to %s %s: %v", action, c.name, err),
+				"output":  string(output),
+			})
+		}
+	}
+
+	return printJSON(map[string]interface{}{
+		"success": true,
+		"message": fmt.Sprintf("Successfully %sed services", action),
+	})
+}
+
 func executeLogsCommand(tail int, follow bool) error {
 	args := []string{"-e", "tollgate"}
 
-	// Add follow flag if specified
 	if follow {
 		args = append(args, "-f")
 	}
 
-	// Add tail flag if specified
 	if tail > 0 {
 		args = append(args, "-l", fmt.Sprintf("%d", tail))
 	}
 
 	cmd := exec.Command("logread", args...)
 
-	// If following, connect stdout/stderr directly for real-time output
 	if follow {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
 	}
 
-	// Otherwise, capture and print output
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to read logs: %v", err)
@@ -615,7 +800,6 @@ func displayWalletDrainResult(data map[string]interface{}) {
 		fmt.Printf("Total drained: %.0f sats\n\n", total)
 	}
 
-	// Check if we need to save to file
 	var filename string
 	if saveToFile, ok := data["save_to_file"].(string); ok && saveToFile != "" {
 		filename = saveToFile
@@ -627,7 +811,6 @@ func displayWalletDrainResult(data map[string]interface{}) {
 			return
 		}
 
-		// If filename is specified, save to file
 		if filename != "" {
 			err := saveTokensToFile(filename, tokensData, data)
 			if err != nil {
@@ -637,7 +820,6 @@ func displayWalletDrainResult(data map[string]interface{}) {
 			}
 		}
 
-		// Display tokens
 		for i, tokenData := range tokensData {
 			if tokenMap, ok := tokenData.(map[string]interface{}); ok {
 				fmt.Printf("Token %d:\n", i+1)
@@ -648,7 +830,6 @@ func displayWalletDrainResult(data map[string]interface{}) {
 					fmt.Printf("  Balance: %.0f sats\n", balance)
 				}
 				if token, ok := tokenMap["token"].(string); ok {
-					// Print full token - user needs complete token to spend
 					fmt.Printf("  Token: %s\n", token)
 				}
 				fmt.Println()
@@ -657,7 +838,6 @@ func displayWalletDrainResult(data map[string]interface{}) {
 	}
 }
 
-// saveTokensToFile saves the drained tokens to a file in the current directory
 func saveTokensToFile(filename string, tokensData []interface{}, data map[string]interface{}) error {
 	file, err := os.Create(filename)
 	if err != nil {
@@ -665,7 +845,6 @@ func saveTokensToFile(filename string, tokensData []interface{}, data map[string
 	}
 	defer file.Close()
 
-	// Write header
 	_, err = file.WriteString("# TollGate Wallet Drain\n")
 	if err != nil {
 		return fmt.Errorf("failed to write header: %w", err)
@@ -682,7 +861,6 @@ func saveTokensToFile(filename string, tokensData []interface{}, data map[string
 		}
 	}
 
-	// Write each token
 	for i, tokenData := range tokensData {
 		if tokenMap, ok := tokenData.(map[string]interface{}); ok {
 			_, err = file.WriteString(fmt.Sprintf("## Token %d\n", i+1))

--- a/src/config_manager/config_dotpath.go
+++ b/src/config_manager/config_dotpath.go
@@ -9,8 +9,15 @@ import (
 )
 
 func SetDotPath(cm *ConfigManager, key, value string) error {
-	cfg := cm.GetConfig()
-	identities := cm.GetIdentities()
+	if err := validateAgainstSchema(key, value); err != nil {
+		return fmt.Errorf("validation failed for %q: %w", key, err)
+	}
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cfg := cm.config
+	identities := cm.identitiesConfig
 
 	parts := strings.Split(key, ".")
 	if len(parts) == 0 {
@@ -36,6 +43,139 @@ func SetDotPath(cm *ConfigManager, key, value string) error {
 			return err
 		}
 		return SaveConfig(cm.ConfigFilePath, cfg)
+	}
+}
+
+func validateAgainstSchema(key, value string) error {
+	parts := strings.Split(key, ".")
+	if len(parts) == 0 {
+		return fmt.Errorf("empty key")
+	}
+
+	root := parts[0]
+	rest := parts[1:]
+
+	var schema []FieldSchema
+	if root == "identities" {
+		schema = GetIdentitiesSchema()
+		rest = parts[1:]
+	} else {
+		schema = GetConfigSchema()
+		rest = parts
+	}
+
+	var field *FieldSchema
+	currentSchema := schema
+	for i, part := range rest {
+		if _, err := strconv.Atoi(part); err == nil {
+			if field != nil && (field.Type == "array") && len(field.Children) > 0 {
+				currentSchema = field.Children
+			}
+			continue
+		}
+		found := false
+		for idx := range currentSchema {
+			if currentSchema[idx].JSONKey == part {
+				field = &currentSchema[idx]
+				found = true
+				if i < len(rest)-1 && len(field.Children) > 0 {
+					currentSchema = field.Children
+				}
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+
+	if field == nil {
+		return nil
+	}
+
+	if len(field.Enum) > 0 {
+		for _, e := range field.Enum {
+			if e == value {
+				return nil
+			}
+		}
+		return fmt.Errorf("value %q not in allowed values: %v", value, field.Enum)
+	}
+
+	switch field.Type {
+	case "uint64":
+		n, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid uint64 value %q", value)
+		}
+		if field.Min != nil {
+			if min, ok := field.Min.(uint64); ok && n < min {
+				return fmt.Errorf("value %d is below minimum %d", n, min)
+			}
+		}
+		if field.Max != nil {
+			if max, ok := field.Max.(uint64); ok && n > max {
+				return fmt.Errorf("value %d exceeds maximum %d", n, max)
+			}
+		}
+	case "int":
+		n, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid int value %q", value)
+		}
+		if field.Min != nil {
+			if min, ok := toInt64(field.Min); ok && n < min {
+				return fmt.Errorf("value %d is below minimum %d", n, min)
+			}
+		}
+		if field.Max != nil {
+			if max, ok := toInt64(field.Max); ok && n > max {
+				return fmt.Errorf("value %d exceeds maximum %d", n, max)
+			}
+		}
+	case "float64":
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("invalid float64 value %q", value)
+		}
+		if field.Min != nil {
+			if min, ok := toFloat64(field.Min); ok && f < min {
+				return fmt.Errorf("value %f is below minimum %f", f, min)
+			}
+		}
+		if field.Max != nil {
+			if max, ok := toFloat64(field.Max); ok && f > max {
+				return fmt.Errorf("value %f exceeds maximum %f", f, max)
+			}
+		}
+	}
+
+	return nil
+}
+
+func toInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	default:
+		return 0, false
+	}
+}
+
+func toFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	default:
+		return 0, false
 	}
 }
 

--- a/src/config_manager/config_dotpath.go
+++ b/src/config_manager/config_dotpath.go
@@ -85,12 +85,12 @@ func validateAgainstSchema(key, value string) error {
 			}
 		}
 		if !found {
-			return nil
+			return fmt.Errorf("unknown config key %q", strings.Join(parts[:i+1], "."))
 		}
 	}
 
 	if field == nil {
-		return nil
+		return fmt.Errorf("unknown config key %q", key)
 	}
 
 	if len(field.Enum) > 0 {

--- a/src/config_manager/config_dotpath.go
+++ b/src/config_manager/config_dotpath.go
@@ -1,0 +1,151 @@
+package config_manager
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func SetDotPath(cm *ConfigManager, key, value string) error {
+	cfg := cm.GetConfig()
+	identities := cm.GetIdentities()
+
+	parts := strings.Split(key, ".")
+	if len(parts) == 0 {
+		return fmt.Errorf("empty key")
+	}
+
+	root := parts[0]
+	rest := parts[1:]
+
+	switch root {
+	case "identities":
+		if len(rest) == 0 {
+			return fmt.Errorf("cannot replace entire identities object; use specific fields")
+		}
+		err := setFieldReflect(reflect.ValueOf(identities).Elem(), rest, value)
+		if err != nil {
+			return err
+		}
+		return SaveIdentities(cm.IdentitiesFilePath, identities)
+	default:
+		err := setFieldReflect(reflect.ValueOf(cfg).Elem(), parts, value)
+		if err != nil {
+			return err
+		}
+		return SaveConfig(cm.ConfigFilePath, cfg)
+	}
+}
+
+func setFieldReflect(v reflect.Value, parts []string, value string) error {
+	for i, part := range parts {
+		if !v.IsValid() {
+			return fmt.Errorf("invalid path at %s", strings.Join(parts[:i], "."))
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				return fmt.Errorf("nil pointer at %s", strings.Join(parts[:i], "."))
+			}
+			v = v.Elem()
+		}
+
+		isLast := i == len(parts)-1
+
+		if idx, err := strconv.Atoi(part); err == nil && v.Kind() == reflect.Slice {
+			if idx < 0 || idx >= v.Len() {
+				return fmt.Errorf("index %d out of range (len=%d) at %s", idx, v.Len(), strings.Join(parts[:i], "."))
+			}
+			v = v.Index(idx)
+			if isLast {
+				return setFieldValue(v, value)
+			}
+			continue
+		}
+
+		if v.Kind() == reflect.Struct {
+			field, found := findFieldByJSONTag(v, part)
+			if !found {
+				return fmt.Errorf("unknown field %s at %s", part, strings.Join(parts[:i+1], "."))
+			}
+			v = field
+			if isLast {
+				return setFieldValue(v, value)
+			}
+			continue
+		}
+
+		return fmt.Errorf("cannot navigate into %s at %s", v.Kind(), strings.Join(parts[:i], "."))
+	}
+
+	return fmt.Errorf("empty path")
+}
+
+func setFieldValue(v reflect.Value, value string) error {
+	if !v.CanSet() {
+		return fmt.Errorf("field is not settable")
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString(value)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid bool value %q: %w", value, err)
+		}
+		v.SetBool(b)
+	case reflect.Int, reflect.Int64:
+		if v.Type() == reflect.TypeOf(time.Duration(0)) {
+			d, err := time.ParseDuration(value)
+			if err != nil {
+				return fmt.Errorf("invalid duration %q (use e.g. 10s, 2m, 300ms): %w", value, err)
+			}
+			v.SetInt(int64(d))
+			return nil
+		}
+		n, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid integer value %q: %w", value, err)
+		}
+		v.SetInt(n)
+	case reflect.Uint, reflect.Uint64:
+		n, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid unsigned integer value %q: %w", value, err)
+		}
+		v.SetUint(n)
+	case reflect.Float64:
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("invalid float value %q: %w", value, err)
+		}
+		v.SetFloat(f)
+	default:
+		return fmt.Errorf("unsupported type %s for set", v.Kind())
+	}
+
+	return nil
+}
+
+func findFieldByJSONTag(v reflect.Value, tag string) (reflect.Value, bool) {
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" {
+			continue
+		}
+		parts := strings.Split(jsonTag, ",")
+		name := parts[0]
+		if name == "" {
+			name = field.Name
+		}
+		if name == tag {
+			return v.Field(i), true
+		}
+	}
+	return reflect.Value{}, false
+}

--- a/src/config_manager/config_drift_test.go
+++ b/src/config_manager/config_drift_test.go
@@ -1,0 +1,221 @@
+package config_manager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestConfigJSONFields verifies that the Config struct produces all JSON fields
+// expected by the LuCI UI (settings.js). If this test fails, either:
+//   - A new field was added to Config but the UI doesn't render it (update settings.js)
+//   - A field was removed from Config but the UI still references it (update settings.js)
+//   - A JSON tag was renamed (update settings.js accordingly)
+func TestConfigJSONFields(t *testing.T) {
+	cfg := NewDefaultConfig()
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Failed to marshal default config: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	topLevelFields := []string{
+		"config_version",
+		"log_level",
+		"accepted_mints",
+		"profit_share",
+		"step_size",
+		"margin",
+		"metric",
+		"show_setup",
+		"reseller_mode",
+		"upstream_detector",
+		"upstream_session_manager",
+	}
+	for _, field := range topLevelFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("Config JSON missing top-level field: %s (UI may be broken)", field)
+		}
+	}
+
+	mintsRaw, ok := raw["accepted_mints"].([]interface{})
+	if !ok || len(mintsRaw) == 0 {
+		t.Fatal("accepted_mints is missing or empty")
+	}
+	mintFields := []string{
+		"url",
+		"min_balance",
+		"balance_tolerance_percent",
+		"payout_interval_seconds",
+		"min_payout_amount",
+		"price_per_step",
+		"price_unit",
+		"purchase_min_steps",
+	}
+	mintObj, ok := mintsRaw[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("first accepted_mints entry is not an object")
+	}
+	for _, field := range mintFields {
+		if _, ok := mintObj[field]; !ok {
+			t.Errorf("accepted_mints entry missing field: %s (UI mint card may be broken)", field)
+		}
+	}
+
+	sharesRaw, ok := raw["profit_share"].([]interface{})
+	if !ok || len(sharesRaw) == 0 {
+		t.Fatal("profit_share is missing or empty")
+	}
+	shareFields := []string{"factor", "identity"}
+	shareObj, ok := sharesRaw[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("first profit_share entry is not an object")
+	}
+	for _, field := range shareFields {
+		if _, ok := shareObj[field]; !ok {
+			t.Errorf("profit_share entry missing field: %s (UI share card may be broken)", field)
+		}
+	}
+
+	crowsnest, ok := raw["upstream_detector"].(map[string]interface{})
+	if !ok {
+		t.Fatal("upstream_detector is missing or not an object")
+	}
+	crowsnestFields := []string{
+		"probe_timeout",
+		"probe_retry_count",
+		"probe_retry_delay",
+		"require_valid_signature",
+		"ignore_interfaces",
+		"discovery_timeout",
+	}
+	for _, field := range crowsnestFields {
+		if _, ok := crowsnest[field]; !ok {
+			t.Errorf("upstream_detector missing field: %s (UI crowsnest section may be broken)", field)
+		}
+	}
+}
+
+// TestIdentitiesJSONFields verifies that the IdentitiesConfig struct produces
+// all JSON fields expected by the LuCI UI identities tab.
+func TestIdentitiesJSONFields(t *testing.T) {
+	cfg := NewDefaultIdentitiesConfig()
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Failed to marshal default identities: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Failed to unmarshal identities: %v", err)
+	}
+
+	topLevelFields := []string{
+		"config_version",
+		"owned_identities",
+		"public_identities",
+	}
+	for _, field := range topLevelFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("Identities JSON missing top-level field: %s", field)
+		}
+	}
+
+	pubIdentFields := []string{"name", "pubkey", "lightning_address"}
+	fullIdent := PublicIdentity{Name: "test", PubKey: "abc123", LightningAddress: "x@y.z"}
+	fullIdentData, _ := json.Marshal(fullIdent)
+	var fullIdentObj map[string]interface{}
+	json.Unmarshal(fullIdentData, &fullIdentObj)
+	for _, field := range pubIdentFields {
+		if _, ok := fullIdentObj[field]; !ok {
+			t.Errorf("public_identity JSON tag missing for field: %s (UI identity card may be broken)", field)
+		}
+	}
+
+	ownedIdents, ok := raw["owned_identities"].([]interface{})
+	if !ok || len(ownedIdents) == 0 {
+		t.Fatal("owned_identities is missing or empty")
+	}
+	ownedIdentObj, ok := ownedIdents[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("first owned_identity entry is not an object")
+	}
+	if _, ok := ownedIdentObj["name"]; !ok {
+		t.Error("owned_identity entry missing field: name (UI owned table may be broken)")
+	}
+}
+
+// TestConfigRoundTrip verifies that saving and loading config preserves all fields.
+func TestConfigRoundTrip(t *testing.T) {
+	original := NewDefaultConfig()
+
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var loaded Config
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if loaded.ConfigVersion != original.ConfigVersion {
+		t.Errorf("config_version mismatch: got %s, want %s", loaded.ConfigVersion, original.ConfigVersion)
+	}
+	if loaded.LogLevel != original.LogLevel {
+		t.Errorf("log_level mismatch: got %s, want %s", loaded.LogLevel, original.LogLevel)
+	}
+	if loaded.Metric != original.Metric {
+		t.Errorf("metric mismatch: got %s, want %s", loaded.Metric, original.Metric)
+	}
+	if loaded.StepSize != original.StepSize {
+		t.Errorf("step_size mismatch: got %d, want %d", loaded.StepSize, original.StepSize)
+	}
+	if len(loaded.AcceptedMints) != len(original.AcceptedMints) {
+		t.Errorf("accepted_mints length mismatch: got %d, want %d", len(loaded.AcceptedMints), len(original.AcceptedMints))
+	}
+	if len(loaded.ProfitShare) != len(original.ProfitShare) {
+		t.Errorf("profit_share length mismatch: got %d, want %d", len(loaded.ProfitShare), len(original.ProfitShare))
+	}
+	for i, ps := range loaded.ProfitShare {
+		if ps.Identity != original.ProfitShare[i].Identity {
+			t.Errorf("profit_share[%d].identity mismatch: got %s, want %s", i, ps.Identity, original.ProfitShare[i].Identity)
+		}
+		if ps.Factor != original.ProfitShare[i].Factor {
+			t.Errorf("profit_share[%d].factor mismatch: got %f, want %f", i, ps.Factor, original.ProfitShare[i].Factor)
+		}
+	}
+}
+
+// TestIdentitiesRoundTrip verifies that saving and loading identities preserves all fields.
+func TestIdentitiesRoundTrip(t *testing.T) {
+	original := NewDefaultIdentitiesConfig()
+
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var loaded IdentitiesConfig
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if loaded.ConfigVersion != original.ConfigVersion {
+		t.Errorf("config_version mismatch: got %s, want %s", loaded.ConfigVersion, original.ConfigVersion)
+	}
+	if len(loaded.OwnedIdentities) != len(original.OwnedIdentities) {
+		t.Errorf("owned_identities length mismatch: got %d, want %d", len(loaded.OwnedIdentities), len(original.OwnedIdentities))
+	}
+	if len(loaded.PublicIdentities) != len(original.PublicIdentities) {
+		t.Errorf("public_identities length mismatch: got %d, want %d", len(loaded.PublicIdentities), len(original.PublicIdentities))
+	}
+	for i, pi := range loaded.PublicIdentities {
+		if pi.Name != original.PublicIdentities[i].Name {
+			t.Errorf("public_identities[%d].name mismatch: got %s, want %s", i, pi.Name, original.PublicIdentities[i].Name)
+		}
+	}
+}

--- a/src/config_manager/config_manager.go
+++ b/src/config_manager/config_manager.go
@@ -65,7 +65,12 @@ func NewConfigManager(configPath, installPath, identitiesPath string) (*ConfigMa
 func (cm *ConfigManager) GetConfig() *Config {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
-	return cm.config
+	cp := *cm.config
+	cp.AcceptedMints = make([]MintConfig, len(cm.config.AcceptedMints))
+	copy(cp.AcceptedMints, cm.config.AcceptedMints)
+	cp.ProfitShare = make([]ProfitShareConfig, len(cm.config.ProfitShare))
+	copy(cp.ProfitShare, cm.config.ProfitShare)
+	return &cp
 }
 
 func (cm *ConfigManager) ReloadConfig() error {
@@ -100,13 +105,19 @@ func (cm *ConfigManager) ReloadIdentities() error {
 func (cm *ConfigManager) GetInstallConfig() *InstallConfig {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
-	return cm.installConfig
+	cp := *cm.installConfig
+	return &cp
 }
 
 func (cm *ConfigManager) GetIdentities() *IdentitiesConfig {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
-	return cm.identitiesConfig
+	cp := *cm.identitiesConfig
+	cp.PublicIdentities = make([]PublicIdentity, len(cm.identitiesConfig.PublicIdentities))
+	copy(cp.PublicIdentities, cm.identitiesConfig.PublicIdentities)
+	cp.OwnedIdentities = make([]OwnedIdentity, len(cm.identitiesConfig.OwnedIdentities))
+	copy(cp.OwnedIdentities, cm.identitiesConfig.OwnedIdentities)
+	return &cp
 }
 
 // GetIdentity retrieves a public identity by name.
@@ -123,25 +134,26 @@ func (cm *ConfigManager) GetIdentity(name string) (*PublicIdentity, error) {
 
 // UpdatePricing updates the pricing information in the config file if it has changed.
 func (cm *ConfigManager) UpdatePricing(pricePerStep, stepSize int) error {
-	config := cm.GetConfig()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
 	needsUpdate := false
 
-	// Assuming the first mint is the one to update. This may need to be revisited.
-	if len(config.AcceptedMints) > 0 {
-		if config.AcceptedMints[0].PricePerStep != uint64(pricePerStep) {
-			config.AcceptedMints[0].PricePerStep = uint64(pricePerStep)
+	if len(cm.config.AcceptedMints) > 0 {
+		if cm.config.AcceptedMints[0].PricePerStep != uint64(pricePerStep) {
+			cm.config.AcceptedMints[0].PricePerStep = uint64(pricePerStep)
 			needsUpdate = true
 		}
 	}
 
-	if config.StepSize != uint64(stepSize) {
-		config.StepSize = uint64(stepSize)
+	if cm.config.StepSize != uint64(stepSize) {
+		cm.config.StepSize = uint64(stepSize)
 		needsUpdate = true
 	}
 
 	if needsUpdate {
 		log.Printf("Price changed. Udpating config file with price_per_step=%d, step_size=%d", pricePerStep, stepSize)
-		return SaveConfig(cm.ConfigFilePath, config)
+		return SaveConfig(cm.ConfigFilePath, cm.config)
 	}
 
 	return nil

--- a/src/config_manager/config_manager.go
+++ b/src/config_manager/config_manager.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -13,6 +14,7 @@ type ConfigManager struct {
 	ConfigFilePath     string
 	InstallFilePath    string
 	IdentitiesFilePath string
+	mu                 sync.RWMutex
 	config             *Config
 	installConfig      *InstallConfig
 	identitiesConfig   *IdentitiesConfig
@@ -61,21 +63,56 @@ func NewConfigManager(configPath, installPath, identitiesPath string) (*ConfigMa
 
 // GetConfig returns the loaded main configuration.
 func (cm *ConfigManager) GetConfig() *Config {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	return cm.config
+}
+
+func (cm *ConfigManager) ReloadConfig() error {
+	loaded, err := LoadConfig(cm.ConfigFilePath)
+	if err != nil {
+		return err
+	}
+	if loaded == nil {
+		return fmt.Errorf("config file %s is empty or missing", cm.ConfigFilePath)
+	}
+	cm.mu.Lock()
+	cm.config = loaded
+	cm.mu.Unlock()
+	return nil
+}
+
+func (cm *ConfigManager) ReloadIdentities() error {
+	loaded, err := LoadIdentities(cm.IdentitiesFilePath)
+	if err != nil {
+		return err
+	}
+	if loaded == nil {
+		return fmt.Errorf("identities file %s is empty or missing", cm.IdentitiesFilePath)
+	}
+	cm.mu.Lock()
+	cm.identitiesConfig = loaded
+	cm.mu.Unlock()
+	return nil
 }
 
 // GetInstallConfig returns the loaded install configuration.
 func (cm *ConfigManager) GetInstallConfig() *InstallConfig {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	return cm.installConfig
 }
 
-// GetIdentities returns the loaded identities configuration.
 func (cm *ConfigManager) GetIdentities() *IdentitiesConfig {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	return cm.identitiesConfig
 }
 
 // GetIdentity retrieves a public identity by name.
 func (cm *ConfigManager) GetIdentity(name string) (*PublicIdentity, error) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	for _, identity := range cm.identitiesConfig.PublicIdentities {
 		if identity.Name == name {
 			return &identity, nil
@@ -112,6 +149,8 @@ func (cm *ConfigManager) UpdatePricing(pricePerStep, stepSize int) error {
 
 // GetOwnedIdentity retrieves an owned identity by name.
 func (cm *ConfigManager) GetOwnedIdentity(name string) (*OwnedIdentity, error) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	for _, identity := range cm.identitiesConfig.OwnedIdentities {
 		if identity.Name == name {
 			return &identity, nil

--- a/src/config_manager/config_manager_config.go
+++ b/src/config_manager/config_manager_config.go
@@ -2,10 +2,14 @@ package config_manager
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"math"
 	"os"
 	"time"
 )
+
+const profitShareSumTolerance = 1e-6
 
 // Config represents the main configuration for the Tollgate service.
 type Config struct {
@@ -108,7 +112,27 @@ type SessionConfig struct {
 
 // UsageTrackingConfig holds usage tracking configuration
 type UsageTrackingConfig struct {
-	DataMonitoringInterval time.Duration `json:"data_monitoring_interval"` // How often to check data usage
+	DataMonitoringInterval time.Duration `json:"data_monitoring_interval"`
+}
+
+func (c *Config) ValidateProfitShare() error {
+	if len(c.ProfitShare) == 0 {
+		return fmt.Errorf("profit_share is empty: at least one entry required")
+	}
+	var sum float64
+	for i, ps := range c.ProfitShare {
+		if ps.Factor < 0 {
+			return fmt.Errorf("profit_share[%d] (%q) has negative factor %v", i, ps.Identity, ps.Factor)
+		}
+		if ps.Factor > 1.0 {
+			return fmt.Errorf("profit_share[%d] (%q) has factor %v > 1.0 (use decimal ratio, not percentage)", i, ps.Identity, ps.Factor)
+		}
+		sum += ps.Factor
+	}
+	if math.Abs(sum-1.0) > profitShareSumTolerance {
+		return fmt.Errorf("profit_share factors must sum to 1.0, got %v (%.1f%% will remain in wallet each payout cycle)", sum, (1.0-sum)*100)
+	}
+	return nil
 }
 
 // LoadConfig loads and parses config.json.
@@ -241,14 +265,30 @@ func EnsureDefaultConfig(filePath string) (*Config, error) {
 
 	// File exists, attempt to unmarshal
 	var config Config
-	if err := json.Unmarshal(data, &config); err != nil || config.ConfigVersion != defaultConfig.ConfigVersion {
-		// Unmarshal failed or version mismatch, trigger backup and recreate
+	unmarshalErr := json.Unmarshal(data, &config)
+	profitShareErr := error(nil)
+	if unmarshalErr == nil {
+		profitShareErr = config.ValidateProfitShare()
+	}
+	if unmarshalErr != nil {
+		log.Printf("WARNING: Invalid config JSON, backing up and recreating: %v", unmarshalErr)
 		if backupErr := backupAndLog(filePath, "/etc/tollgate/config_backups", "config", defaultConfig.ConfigVersion); backupErr != nil {
-			log.Printf("CRITICAL: Failed to backup and remove invalid config: %v", backupErr)
-			// Depending on desired behavior, we might return an error or proceed with default
+			log.Printf("CRITICAL: Failed to backup invalid config: %v", backupErr)
 			return nil, backupErr
 		}
-		// Save new default config
+		return defaultConfig, SaveConfig(filePath, defaultConfig)
+	}
+	if profitShareErr != nil {
+		log.Printf("WARNING: Invalid profit_share, resetting to defaults: %v", profitShareErr)
+		config.ProfitShare = defaultConfig.ProfitShare
+		return &config, SaveConfig(filePath, &config)
+	}
+	if config.ConfigVersion != defaultConfig.ConfigVersion {
+		log.Printf("WARNING: Config version mismatch, backing up and recreating")
+		if backupErr := backupAndLog(filePath, "/etc/tollgate/config_backups", "config", defaultConfig.ConfigVersion); backupErr != nil {
+			log.Printf("CRITICAL: Failed to backup config: %v", backupErr)
+			return nil, backupErr
+		}
 		return defaultConfig, SaveConfig(filePath, defaultConfig)
 	}
 

--- a/src/config_manager/config_manager_identities.go
+++ b/src/config_manager/config_manager_identities.go
@@ -44,15 +44,12 @@ func NewDefaultIdentitiesConfig() *IdentitiesConfig {
 		PublicIdentities: []PublicIdentity{
 			{
 				Name:             "developer",
+				PubKey:           "not currently used",
 				LightningAddress: "tollgate@minibits.cash",
 			},
 			{
-				Name:   "trusted_maintainer_1",
-				PubKey: "5075e61f0b048148b60105c1dd72bbeae1957336ae5824087e52efa374f8416a",
-			},
-			{
 				Name:             "owner",
-				PubKey:           "[on_setup]",
+				PubKey:           "not currently used",
 				LightningAddress: "tollgate@minibits.cash",
 			},
 		},
@@ -85,7 +82,7 @@ func SaveIdentities(filePath string, identitiesConfig *IdentitiesConfig) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filePath, data, 0644)
+	return os.WriteFile(filePath, data, 0600)
 }
 
 // EnsureDefaultIdentities ensures a default identities.json exists, loading from file if present.

--- a/src/config_manager/config_manager_install.go
+++ b/src/config_manager/config_manager_install.go
@@ -85,7 +85,6 @@ func EnsureDefaultInstall(filePath string) (*InstallConfig, error) {
 	return &installConfig, nil
 }
 
-// Save saves the InstallConfig to a specified file path.
 func (ic *InstallConfig) Save(filePath string) error {
 	return SaveInstallConfig(filePath, ic)
 }

--- a/src/config_manager/config_manager_test.go
+++ b/src/config_manager/config_manager_test.go
@@ -247,5 +247,6 @@ func TestValidateProfitShare(t *testing.T) {
 					t.Errorf("ValidateProfitShare() error = %q, want containing %q", err.Error(), tt.errMsg)
 				}
 			}
+		})
 	}
 }

--- a/src/config_manager/config_manager_test.go
+++ b/src/config_manager/config_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -177,5 +178,74 @@ func TestUpstreamWifiConfig_RoundTrip(t *testing.T) {
 	}
 	if loaded.UpstreamWifi.SignalFloor != -70 {
 		t.Errorf("expected SignalFloor=-70, got %d", loaded.UpstreamWifi.SignalFloor)
+	}
+}
+
+func TestValidateProfitShare(t *testing.T) {
+	tests := []struct {
+		name    string
+		shares  []ProfitShareConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "default config is valid",
+			shares:  NewDefaultConfig().ProfitShare,
+			wantErr: false,
+		},
+		{
+			name:    "single factor 1.0",
+			shares:  []ProfitShareConfig{{Factor: 1.0, Identity: "owner"}},
+			wantErr: false,
+		},
+		{
+			name:    "sum < 1.0",
+			shares:  []ProfitShareConfig{{Factor: 0.5, Identity: "a"}, {Factor: 0.3, Identity: "b"}},
+			wantErr: true,
+			errMsg:  "must sum to 1.0",
+		},
+		{
+			name:    "sum > 1.0",
+			shares:  []ProfitShareConfig{{Factor: 0.8, Identity: "a"}, {Factor: 0.3, Identity: "b"}},
+			wantErr: true,
+			errMsg:  "must sum to 1.0",
+		},
+		{
+			name:    "negative factor",
+			shares:  []ProfitShareConfig{{Factor: -0.1, Identity: "a"}, {Factor: 1.1, Identity: "b"}},
+			wantErr: true,
+			errMsg:  "negative factor",
+		},
+		{
+			name:    "factor > 1.0",
+			shares:  []ProfitShareConfig{{Factor: 79.0, Identity: "owner"}},
+			wantErr: true,
+			errMsg:  "> 1.0",
+		},
+		{
+			name:    "empty list",
+			shares:  []ProfitShareConfig{},
+			wantErr: true,
+			errMsg:  "empty",
+		},
+		{
+			name:    "thirds within tolerance",
+			shares:  []ProfitShareConfig{{Factor: 1.0 / 3, Identity: "a"}, {Factor: 1.0 / 3, Identity: "b"}, {Factor: 1.0 / 3, Identity: "c"}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{ProfitShare: tt.shares}
+			err := cfg.ValidateProfitShare()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProfitShare() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("ValidateProfitShare() error = %q, want containing %q", err.Error(), tt.errMsg)
+				}
+			}
 	}
 }

--- a/src/config_manager/config_schema.go
+++ b/src/config_manager/config_schema.go
@@ -1,0 +1,143 @@
+package config_manager
+
+type FieldSchema struct {
+	Name        string            `json:"name"`
+	Type        string            `json:"type"`
+	Description string            `json:"description,omitempty"`
+	Default     interface{}       `json:"default,omitempty"`
+	Required    bool              `json:"required"`
+	Enum        []string          `json:"enum,omitempty"`
+	Min         interface{}       `json:"min,omitempty"`
+	Max         interface{}       `json:"max,omitempty"`
+	Children    []FieldSchema     `json:"children,omitempty"`
+	JSONKey     string            `json:"json_key"`
+	Editable    bool              `json:"editable"`
+}
+
+func GetConfigSchema() []FieldSchema {
+	return []FieldSchema{
+		{
+			Name: "ConfigVersion", JSONKey: "config_version", Type: "string",
+			Description: "Configuration file version", Default: "v0.0.7", Required: true, Editable: false,
+		},
+		{
+			Name: "LogLevel", JSONKey: "log_level", Type: "string",
+			Description: "Logging verbosity", Default: "info", Required: true, Editable: true,
+			Enum: []string{"debug", "info", "warn", "error"},
+		},
+		{
+			Name: "Metric", JSONKey: "metric", Type: "string",
+			Description: "Metering metric type", Default: "bytes", Required: true, Editable: true,
+			Enum: []string{"bytes", "milliseconds"},
+		},
+		{
+			Name: "StepSize", JSONKey: "step_size", Type: "uint64",
+			Description: "Step size in bytes (if metric=bytes) or milliseconds (if metric=milliseconds)", Default: uint64(22020096), Required: true, Editable: true,
+		},
+		{
+			Name: "Margin", JSONKey: "margin", Type: "float64",
+			Description: "Margin factor (0.0-1.0)", Default: 0.1, Required: false, Editable: true,
+			Min: 0.0, Max: 1.0,
+		},
+		{
+			Name: "ShowSetup", JSONKey: "show_setup", Type: "bool",
+			Description: "Show setup wizard on first access", Default: true, Required: true, Editable: true,
+		},
+		{
+			Name: "ResellerMode", JSONKey: "reseller_mode", Type: "bool",
+			Description: "Enable reseller mode for upstream gateway discovery", Default: false, Required: true, Editable: true,
+		},
+		{
+			Name: "AcceptedMints", JSONKey: "accepted_mints", Type: "array",
+			Description: "List of accepted Cashu mints", Required: true, Editable: true,
+			Children: []FieldSchema{
+				{Name: "URL", JSONKey: "url", Type: "string", Description: "Mint URL", Required: true, Editable: true},
+				{Name: "MinBalance", JSONKey: "min_balance", Type: "uint64", Description: "Minimum balance before auto-replenish (sats)", Default: uint64(64), Required: true, Editable: true},
+				{Name: "BalanceTolerancePercent", JSONKey: "balance_tolerance_percent", Type: "uint64", Description: "Tolerance percentage for balance checks", Default: uint64(10), Required: true, Editable: true},
+				{Name: "PayoutIntervalSeconds", JSONKey: "payout_interval_seconds", Type: "uint64", Description: "Seconds between payout rounds", Default: uint64(60), Required: true, Editable: true},
+				{Name: "MinPayoutAmount", JSONKey: "min_payout_amount", Type: "uint64", Description: "Minimum payout amount in sats", Default: uint64(128), Required: true, Editable: true},
+				{Name: "PricePerStep", JSONKey: "price_per_step", Type: "uint64", Description: "Price per step in sats", Default: uint64(1), Required: true, Editable: true},
+				{Name: "PriceUnit", JSONKey: "price_unit", Type: "string", Description: "Price unit", Default: "sats", Required: true, Editable: true},
+				{Name: "MinPurchaseSteps", JSONKey: "purchase_min_steps", Type: "uint64", Description: "Minimum number of steps per purchase", Default: uint64(0), Required: true, Editable: true},
+			},
+		},
+		{
+			Name: "ProfitShare", JSONKey: "profit_share", Type: "array",
+			Description: "Profit sharing configuration", Required: true, Editable: true,
+			Children: []FieldSchema{
+			{Name: "Factor", JSONKey: "factor", Type: "float64", Description: "Share ratio (0.0\u20131.0). All factors MUST sum to 1.0. Use 0.79 not 79\u2014this is a ratio, not a percentage.", Required: true, Editable: true, Min: 0.0, Max: 1.0},
+				{Name: "Identity", JSONKey: "identity", Type: "string", Description: "Identity name from identities.json", Required: true, Editable: true},
+			},
+		},
+		{
+			Name: "UpstreamDetector", JSONKey: "upstream_detector", Type: "object",
+			Description: "Upstream gateway detector configuration", Required: true, Editable: true,
+			Children: []FieldSchema{
+				{Name: "ProbeTimeout", JSONKey: "probe_timeout", Type: "duration", Description: "Timeout for each probe", Default: "10s", Required: true, Editable: true},
+				{Name: "ProbeRetryCount", JSONKey: "probe_retry_count", Type: "int", Description: "Number of probe retries", Default: 3, Required: true, Editable: true},
+				{Name: "ProbeRetryDelay", JSONKey: "probe_retry_delay", Type: "duration", Description: "Delay between retries", Default: "2s", Required: true, Editable: true},
+				{Name: "RequireValidSignature", JSONKey: "require_valid_signature", Type: "bool", Description: "Require valid NIP-70 signature", Default: true, Required: true, Editable: true},
+				{Name: "IgnoreInterfaces", JSONKey: "ignore_interfaces", Type: "array", Description: "Interfaces to ignore", Default: []string{"lo", "docker0", "br-lan", "hostap0"}, Required: false, Editable: true, Children: []FieldSchema{{Type: "string"}}},
+				{Name: "OnlyInterfaces", JSONKey: "only_interfaces", Type: "array", Description: "Only probe these interfaces (empty = all)", Default: []string{}, Required: false, Editable: true, Children: []FieldSchema{{Type: "string"}}},
+				{Name: "DiscoveryTimeout", JSONKey: "discovery_timeout", Type: "duration", Description: "Deduplication window", Default: "5m0s", Required: true, Editable: true},
+			},
+		},
+		{
+			Name: "UpstreamSessionManager", JSONKey: "upstream_session_manager", Type: "object",
+			Description: "Upstream session manager configuration", Required: true, Editable: true,
+			Children: []FieldSchema{
+				{Name: "MaxPricePerMillisecond", JSONKey: "max_price_per_millisecond", Type: "float64", Description: "Max sats per millisecond", Default: 0.002777777778, Required: true, Editable: true},
+				{Name: "MaxPricePerByte", JSONKey: "max_price_per_byte", Type: "float64", Description: "Max sats per byte", Default: 0.00003725782414, Required: true, Editable: true},
+				{
+					Name: "Trust", JSONKey: "trust", Type: "object", Description: "Trust policy", Required: true, Editable: true,
+					Children: []FieldSchema{
+						{Name: "DefaultPolicy", JSONKey: "default_policy", Type: "string", Description: "Default trust policy", Default: "trust_all", Required: true, Editable: true, Enum: []string{"trust_all", "trust_none"}},
+						{Name: "Allowlist", JSONKey: "allowlist", Type: "array", Description: "Trusted pubkeys", Default: []string{}, Required: false, Editable: true, Children: []FieldSchema{{Type: "string"}}},
+						{Name: "Blocklist", JSONKey: "blocklist", Type: "array", Description: "Blocked pubkeys", Default: []string{}, Required: false, Editable: true, Children: []FieldSchema{{Type: "string"}}},
+					},
+				},
+				{
+					Name: "Sessions", JSONKey: "sessions", Type: "object", Description: "Session settings", Required: true, Editable: true,
+					Children: []FieldSchema{
+						{Name: "PreferredSessionIncrementsMilliseconds", JSONKey: "preferred_session_increments_milliseconds", Type: "uint64", Description: "Preferred time session increment (ms)", Default: uint64(60000), Required: true, Editable: true},
+						{Name: "PreferredSessionIncrementsBytes", JSONKey: "preferred_session_increments_bytes", Type: "uint64", Description: "Preferred data session increment (bytes)", Default: uint64(131100000), Required: true, Editable: true},
+						{Name: "MillisecondRenewalOffset", JSONKey: "millisecond_renewal_offset", Type: "uint64", Description: "Renew this many ms before expiry", Default: uint64(10000), Required: true, Editable: true},
+						{Name: "BytesRenewalOffset", JSONKey: "bytes_renewal_offset", Type: "uint64", Description: "Renew this many bytes before limit", Default: uint64(131100000), Required: true, Editable: true},
+					},
+				},
+				{
+					Name: "UsageTracking", JSONKey: "usage_tracking", Type: "object", Description: "Usage tracking settings", Required: true, Editable: true,
+					Children: []FieldSchema{
+						{Name: "DataMonitoringInterval", JSONKey: "data_monitoring_interval", Type: "duration", Description: "How often to check data usage", Default: "500ms", Required: true, Editable: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func GetIdentitiesSchema() []FieldSchema {
+	return []FieldSchema{
+		{
+			Name: "ConfigVersion", JSONKey: "config_version", Type: "string",
+			Description: "Identities file version", Default: "v0.0.1", Required: true, Editable: false,
+		},
+		{
+			Name: "OwnedIdentities", JSONKey: "owned_identities", Type: "array",
+			Description: "Identities with private keys (managed by the system)", Required: true, Editable: false,
+			Children: []FieldSchema{
+				{Name: "Name", JSONKey: "name", Type: "string", Description: "Identity name", Required: true, Editable: false},
+				{Name: "PrivateKey", JSONKey: "privatekey", Type: "string", Description: "Nostr private key (sensitive)", Required: true, Editable: false},
+			},
+		},
+		{
+			Name: "PublicIdentities", JSONKey: "public_identities", Type: "array",
+			Description: "Public identities for profit sharing and trust", Required: true, Editable: true,
+			Children: []FieldSchema{
+				{Name: "Name", JSONKey: "name", Type: "string", Description: "Identity name", Required: true, Editable: true},
+				{Name: "PubKey", JSONKey: "pubkey", Type: "string", Description: "Nostr public key — not currently used for payouts (lightning_address is used instead)", Required: false, Editable: true},
+				{Name: "LightningAddress", JSONKey: "lightning_address", Type: "string", Description: "Lightning address for payouts", Required: false, Editable: true},
+			},
+		},
+	}
+}

--- a/src/config_manager/config_schema.go
+++ b/src/config_manager/config_schema.go
@@ -113,6 +113,25 @@ func GetConfigSchema() []FieldSchema {
 				},
 			},
 		},
+		{
+			Name: "UpstreamWifi", JSONKey: "upstream_wifi", Type: "object",
+			Description: "Upstream WiFi scanning and selection configuration", Required: true, Editable: true,
+			Children: []FieldSchema{
+				{Name: "ScanIntervalSeconds", JSONKey: "scan_interval_seconds", Type: "int", Description: "Seconds between full WiFi scans", Default: 300, Required: true, Editable: true, Min: 10, Max: 3600},
+				{Name: "FastCheckSeconds", JSONKey: "fast_check_seconds", Type: "int", Description: "Seconds between fast signal checks", Default: 30, Required: true, Editable: true, Min: 5, Max: 300},
+				{Name: "LostThreshold", JSONKey: "lost_threshold", Type: "int", Description: "Consecutive fast-check failures before marking as lost", Default: 2, Required: true, Editable: true, Min: 1, Max: 10},
+				{Name: "HysteresisDB", JSONKey: "hysteresis_db", Type: "int", Description: "Signal hysteresis in dB to prevent flapping", Default: 12, Required: true, Editable: true, Min: 0, Max: 30},
+				{Name: "SignalFloor", JSONKey: "signal_floor", Type: "int", Description: "Minimum signal strength in dBm to consider a network usable", Default: -85, Required: true, Editable: true, Min: -100, Max: -30},
+				{Name: "BlacklistTTLMinutes", JSONKey: "blacklist_ttl_minutes", Type: "int", Description: "Minutes before a blacklisted network is retried", Default: 60, Required: true, Editable: true, Min: 1, Max: 1440},
+				{Name: "EmergencyPenalty", JSONKey: "emergency_penalty", Type: "int", Description: "Penalty score added on emergency disconnect", Default: 20, Required: true, Editable: true, Min: 0, Max: 100},
+				{Name: "MaxConsecutiveFailures", JSONKey: "max_consecutive_failures", Type: "int", Description: "Consecutive failures before emergency scan", Default: 3, Required: true, Editable: true, Min: 1, Max: 20},
+				{Name: "SwitchCooldownMinutes", JSONKey: "switch_cooldown_minutes", Type: "int", Description: "Minimum minutes between network switches", Default: 10, Required: true, Editable: true, Min: 1, Max: 120},
+				{Name: "StartupGraceSeconds", JSONKey: "startup_grace_seconds", Type: "int", Description: "Grace period on startup before scoring", Default: 90, Required: true, Editable: true, Min: 10, Max: 600},
+				{Name: "PostSwitchWaitSeconds", JSONKey: "post_switch_wait_seconds", Type: "int", Description: "Seconds to wait after a switch before scoring", Default: 5, Required: true, Editable: true, Min: 1, Max: 60},
+				{Name: "DHCPTimeoutSeconds", JSONKey: "dhcp_timeout_seconds", Type: "int", Description: "Timeout for DHCP after connecting to a network", Default: 180, Required: true, Editable: true, Min: 10, Max: 600},
+				{Name: "ManualPauseSeconds", JSONKey: "manual_pause_seconds", Type: "int", Description: "Seconds to pause scanning after manual intervention", Default: 120, Required: true, Editable: true, Min: 10, Max: 600},
+			},
+		},
 	}
 }
 

--- a/src/config_manager/config_schema_drift_test.go
+++ b/src/config_manager/config_schema_drift_test.go
@@ -1,0 +1,420 @@
+package config_manager
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func collectJSONTags(t reflect.Type, prefix string) map[string]string {
+	tags := make(map[string]string)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return tags
+	}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+		parts := strings.Split(jsonTag, ",")
+		name := parts[0]
+		if name == "" {
+			name = field.Name
+		}
+		omitempty := len(parts) > 1 && parts[1] == "omitempty"
+		fullPath := name
+		if prefix != "" {
+			fullPath = prefix + "." + name
+		}
+
+		ft := field.Type
+		if ft.Kind() == reflect.Slice {
+			elemType := ft.Elem()
+			if elemType.Kind() == reflect.Ptr {
+				elemType = elemType.Elem()
+			}
+			if elemType.Kind() == reflect.Struct {
+				for k, v := range collectJSONTags(elemType, fullPath+"[]") {
+					tags[k] = v
+				}
+			}
+			tags[fullPath] = omitemptyTag(omitempty)
+		} else if ft.Kind() == reflect.Struct {
+			tags[fullPath] = omitemptyTag(omitempty)
+			for k, v := range collectJSONTags(ft, fullPath) {
+				tags[k] = v
+			}
+		} else if ft.Kind() == reflect.Ptr && ft.Elem().Kind() == reflect.Struct {
+			tags[fullPath] = omitemptyTag(omitempty)
+			for k, v := range collectJSONTags(ft.Elem(), fullPath) {
+				tags[k] = v
+			}
+		} else {
+			tags[fullPath] = omitemptyTag(omitempty)
+		}
+	}
+	return tags
+}
+
+func omitemptyTag(oe bool) string {
+	if oe {
+		return "omitempty"
+	}
+	return "required"
+}
+
+func collectSchemaKeys(schema []FieldSchema, prefix string) map[string]string {
+	keys := make(map[string]string)
+	for _, field := range schema {
+		fullPath := field.JSONKey
+		if prefix != "" {
+			fullPath = prefix + "." + field.JSONKey
+		}
+		keys[fullPath] = field.Type
+		if len(field.Children) > 0 && (field.Type == "array" || field.Type == "object") {
+			hasNamedChildren := false
+			for _, child := range field.Children {
+				if child.JSONKey != "" {
+					hasNamedChildren = true
+					break
+				}
+			}
+			if !hasNamedChildren {
+				continue
+			}
+			childPrefix := fullPath
+			if field.Type == "array" {
+				childPrefix = fullPath + "[]"
+			}
+			for k, v := range collectSchemaKeys(field.Children, childPrefix) {
+				keys[k] = v
+			}
+		}
+	}
+	return keys
+}
+
+func TestSchemaCoversAllConfigStructFields(t *testing.T) {
+	configTags := collectJSONTags(reflect.TypeOf(Config{}), "")
+	schemaKeys := collectSchemaKeys(GetConfigSchema(), "")
+
+	for tagPath := range configTags {
+		if _, ok := schemaKeys[tagPath]; !ok {
+			t.Errorf("Config struct has json tag %q but schema has no matching entry — UI won't show this field", tagPath)
+		}
+	}
+}
+
+func TestSchemaHasNoOrphanEntries(t *testing.T) {
+	configTags := collectJSONTags(reflect.TypeOf(Config{}), "")
+	schemaKeys := collectSchemaKeys(GetConfigSchema(), "")
+
+	for schemaPath := range schemaKeys {
+		if _, ok := configTags[schemaPath]; !ok {
+			t.Errorf("Schema declares %q but Config struct has no matching json tag — orphan schema entry", schemaPath)
+		}
+	}
+}
+
+func TestIdentitiesSchemaCoversAllStructFields(t *testing.T) {
+	configTags := collectJSONTags(reflect.TypeOf(IdentitiesConfig{}), "")
+	schemaKeys := collectSchemaKeys(GetIdentitiesSchema(), "")
+
+	for tagPath := range configTags {
+		if _, ok := schemaKeys[tagPath]; !ok {
+			t.Errorf("IdentitiesConfig struct has json tag %q but schema has no matching entry", tagPath)
+		}
+	}
+}
+
+func TestIdentitiesSchemaHasNoOrphans(t *testing.T) {
+	configTags := collectJSONTags(reflect.TypeOf(IdentitiesConfig{}), "")
+	schemaKeys := collectSchemaKeys(GetIdentitiesSchema(), "")
+
+	for schemaPath := range schemaKeys {
+		if _, ok := configTags[schemaPath]; !ok {
+			t.Errorf("Identities schema declares %q but IdentitiesConfig struct has no matching json tag", schemaPath)
+		}
+	}
+}
+
+func TestSchemaDotPathRoundTrip(t *testing.T) {
+	schema := GetConfigSchema()
+	for _, field := range schema {
+		if !field.Editable || field.Type == "array" || field.Type == "object" {
+			continue
+		}
+		t.Run("dotpath."+field.JSONKey, func(t *testing.T) {
+			tmp := t.TempDir()
+			cm, err := NewConfigManager(
+				tmp+"/config.json",
+				tmp+"/install.json",
+				tmp+"/identities.json",
+			)
+			if err != nil {
+				t.Fatalf("Failed to create ConfigManager: %v", err)
+			}
+
+			testValue := getTestValueForType(field)
+			if testValue == "" {
+				return
+			}
+
+			err = SetDotPath(cm, field.JSONKey, testValue)
+			if err != nil {
+				t.Fatalf("SetDotPath(%s, %s) failed: %v", field.JSONKey, testValue, err)
+			}
+
+			loaded, loadErr := LoadConfig(tmp + "/config.json")
+			if loadErr != nil {
+				t.Fatalf("Failed to reload: %v", loadErr)
+			}
+
+			assertFieldValue(t, loaded, field.JSONKey, testValue, field.Type)
+		})
+	}
+}
+
+func TestSchemaDotPathMintChildren(t *testing.T) {
+	schema := GetConfigSchema()
+	var mintSchema *FieldSchema
+	for i := range schema {
+		if schema[i].JSONKey == "accepted_mints" {
+			mintSchema = &schema[i]
+			break
+		}
+	}
+	if mintSchema == nil {
+		t.Fatal("accepted_mints schema not found")
+	}
+
+	for _, child := range mintSchema.Children {
+		if !child.Editable {
+			continue
+		}
+		t.Run("mint.0."+child.JSONKey, func(t *testing.T) {
+			tmp := t.TempDir()
+			cm, err := NewConfigManager(
+				tmp+"/config.json",
+				tmp+"/install.json",
+				tmp+"/identities.json",
+			)
+			if err != nil {
+				t.Fatalf("Failed to create ConfigManager: %v", err)
+			}
+
+			testValue := getTestValueForType(child)
+			if testValue == "" {
+				return
+			}
+
+			dotPath := "accepted_mints.0." + child.JSONKey
+			err = SetDotPath(cm, dotPath, testValue)
+			if err != nil {
+				t.Fatalf("SetDotPath(%s, %s) failed: %v", dotPath, testValue, err)
+			}
+
+			loaded, _ := LoadConfig(tmp + "/config.json")
+			if len(loaded.AcceptedMints) == 0 {
+				t.Fatal("No mints loaded")
+			}
+			assertMintFieldValue(t, loaded.AcceptedMints[0], child.JSONKey, testValue, child.Type)
+		})
+	}
+}
+
+func TestSchemaDotPathProfitShareChildren(t *testing.T) {
+	schema := GetConfigSchema()
+	var psSchema *FieldSchema
+	for i := range schema {
+		if schema[i].JSONKey == "profit_share" {
+			psSchema = &schema[i]
+			break
+		}
+	}
+	if psSchema == nil {
+		t.Fatal("profit_share schema not found")
+	}
+
+	for _, child := range psSchema.Children {
+		if !child.Editable {
+			continue
+		}
+		t.Run("profit_share.0."+child.JSONKey, func(t *testing.T) {
+			tmp := t.TempDir()
+			cm, err := NewConfigManager(
+				tmp+"/config.json",
+				tmp+"/install.json",
+				tmp+"/identities.json",
+			)
+			if err != nil {
+				t.Fatalf("Failed to create ConfigManager: %v", err)
+			}
+
+			testValue := getTestValueForType(child)
+			if testValue == "" {
+				return
+			}
+
+			dotPath := "profit_share.0." + child.JSONKey
+			err = SetDotPath(cm, dotPath, testValue)
+			if err != nil {
+				t.Fatalf("SetDotPath(%s, %s) failed: %v", dotPath, testValue, err)
+			}
+
+			loaded, _ := LoadConfig(tmp + "/config.json")
+			if len(loaded.ProfitShare) == 0 {
+				t.Fatal("No profit shares loaded")
+			}
+			assertPSFieldValue(t, loaded.ProfitShare[0], child.JSONKey, testValue, child.Type)
+		})
+	}
+}
+
+func TestConfigGetSchemaConsistency(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfgJSON, _ := json.Marshal(cfg)
+	var cfgMap map[string]interface{}
+	json.Unmarshal(cfgJSON, &cfgMap)
+
+	schema := GetConfigSchema()
+	for _, field := range schema {
+		if field.Required && field.Type != "array" && field.Type != "object" {
+			if _, ok := cfgMap[field.JSONKey]; !ok {
+				t.Errorf("Required schema field %s not in default config JSON", field.JSONKey)
+			}
+		}
+	}
+
+	identCfg := NewDefaultIdentitiesConfig()
+	identJSON, _ := json.Marshal(identCfg)
+	var identMap map[string]interface{}
+	json.Unmarshal(identJSON, &identMap)
+
+	identSchema := GetIdentitiesSchema()
+	for _, field := range identSchema {
+		if field.Required && field.Type != "array" && field.Type != "object" {
+			if _, ok := identMap[field.JSONKey]; !ok {
+				t.Errorf("Required identities schema field %s not in default identities JSON", field.JSONKey)
+			}
+		}
+	}
+}
+
+func getTestValueForType(field FieldSchema) string {
+	if len(field.Enum) > 0 {
+		for _, e := range field.Enum {
+			defStr, _ := field.Default.(string)
+			if e != defStr {
+				return e
+			}
+		}
+		return field.Enum[0]
+	}
+	switch field.Type {
+	case "string":
+		return "test_value"
+	case "uint64":
+		return "99999"
+	case "int":
+		return "7"
+	case "float64":
+		return "0.5"
+	case "bool":
+		if def, ok := field.Default.(bool); ok && def {
+			return "false"
+		}
+		return "true"
+	case "duration":
+		return "15s"
+	default:
+		return ""
+	}
+}
+
+func assertFieldValue(t *testing.T, cfg *Config, jsonKey, value, typ string) {
+	t.Helper()
+	switch jsonKey {
+	case "log_level":
+		if cfg.LogLevel != value {
+			t.Errorf("log_level: got %s, want %s", cfg.LogLevel, value)
+		}
+	case "metric":
+		if cfg.Metric != value {
+			t.Errorf("metric: got %s, want %s", cfg.Metric, value)
+		}
+	case "step_size":
+		if typ == "uint64" && cfg.StepSize != 99999 {
+			t.Errorf("step_size: got %d, want 99999", cfg.StepSize)
+		}
+	case "show_setup":
+		if cfg.ShowSetup != false {
+			t.Error("show_setup: got true, want false")
+		}
+	case "reseller_mode":
+		if cfg.ResellerMode != true {
+			t.Error("reseller_mode: got false, want true")
+		}
+	case "margin":
+		if cfg.Margin != 0.5 {
+			t.Errorf("margin: got %f, want 0.5", cfg.Margin)
+		}
+	}
+}
+
+func assertMintFieldValue(t *testing.T, mint MintConfig, jsonKey, value, typ string) {
+	t.Helper()
+	switch jsonKey {
+	case "url":
+		if mint.URL != value {
+			t.Errorf("url: got %s, want %s", mint.URL, value)
+		}
+	case "min_balance":
+		if mint.MinBalance != 99999 {
+			t.Errorf("min_balance: got %d, want 99999", mint.MinBalance)
+		}
+	case "balance_tolerance_percent":
+		if mint.BalanceTolerancePercent != 99999 {
+			t.Errorf("balance_tolerance_percent: got %d", mint.BalanceTolerancePercent)
+		}
+	case "payout_interval_seconds":
+		if mint.PayoutIntervalSeconds != 99999 {
+			t.Errorf("payout_interval_seconds: got %d", mint.PayoutIntervalSeconds)
+		}
+	case "min_payout_amount":
+		if mint.MinPayoutAmount != 99999 {
+			t.Errorf("min_payout_amount: got %d", mint.MinPayoutAmount)
+		}
+	case "price_per_step":
+		if mint.PricePerStep != 99999 {
+			t.Errorf("price_per_step: got %d, want 99999", mint.PricePerStep)
+		}
+	case "price_unit":
+		if mint.PriceUnit != value {
+			t.Errorf("price_unit: got %s, want %s", mint.PriceUnit, value)
+		}
+	case "purchase_min_steps":
+		if mint.MinPurchaseSteps != 99999 {
+			t.Errorf("purchase_min_steps: got %d", mint.MinPurchaseSteps)
+		}
+	}
+}
+
+func assertPSFieldValue(t *testing.T, ps ProfitShareConfig, jsonKey, value, typ string) {
+	t.Helper()
+	switch jsonKey {
+	case "factor":
+		if ps.Factor != 0.5 {
+			t.Errorf("factor: got %f, want 0.5", ps.Factor)
+		}
+	case "identity":
+		if ps.Identity != value {
+			t.Errorf("identity: got %s, want %s", ps.Identity, value)
+		}
+	}
+}

--- a/src/config_manager/config_schema_test.go
+++ b/src/config_manager/config_schema_test.go
@@ -1,0 +1,270 @@
+package config_manager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSchemaConfigFields(t *testing.T) {
+	schema := GetConfigSchema()
+
+	schemaMap := make(map[string]*FieldSchema)
+	for i := range schema {
+		schemaMap[schema[i].JSONKey] = &schema[i]
+	}
+
+	requiredKeys := []string{
+		"config_version", "log_level", "metric", "step_size",
+		"accepted_mints", "profit_share", "show_setup", "reseller_mode",
+		"upstream_detector", "upstream_session_manager",
+	}
+	for _, key := range requiredKeys {
+		if _, ok := schemaMap[key]; !ok {
+			t.Errorf("Config schema missing field: %s", key)
+		}
+	}
+
+	mintSchema := schemaMap["accepted_mints"]
+	if mintSchema == nil {
+		t.Fatal("accepted_mints schema missing")
+	}
+	if len(mintSchema.Children) == 0 {
+		t.Fatal("accepted_mints schema has no children")
+	}
+	mintChildMap := make(map[string]bool)
+	for _, c := range mintSchema.Children {
+		mintChildMap[c.JSONKey] = true
+	}
+	for _, f := range []string{"url", "min_balance", "price_per_step", "price_unit", "purchase_min_steps"} {
+		if !mintChildMap[f] {
+			t.Errorf("accepted_mints child schema missing: %s", f)
+		}
+	}
+
+	psSchema := schemaMap["profit_share"]
+	if psSchema == nil {
+		t.Fatal("profit_share schema missing")
+	}
+	if len(psSchema.Children) == 0 {
+		t.Fatal("profit_share schema has no children")
+	}
+	psChildMap := make(map[string]bool)
+	for _, c := range psSchema.Children {
+		psChildMap[c.JSONKey] = true
+	}
+	for _, f := range []string{"factor", "identity"} {
+		if !psChildMap[f] {
+			t.Errorf("profit_share child schema missing: %s", f)
+		}
+	}
+}
+
+func TestSchemaIdentitiesFields(t *testing.T) {
+	schema := GetIdentitiesSchema()
+
+	schemaMap := make(map[string]*FieldSchema)
+	for i := range schema {
+		schemaMap[schema[i].JSONKey] = &schema[i]
+	}
+
+	requiredKeys := []string{"config_version", "owned_identities", "public_identities"}
+	for _, key := range requiredKeys {
+		if _, ok := schemaMap[key]; !ok {
+			t.Errorf("Identities schema missing field: %s", key)
+		}
+	}
+
+	piSchema := schemaMap["public_identities"]
+	if piSchema == nil {
+		t.Fatal("public_identities schema missing")
+	}
+	if len(piSchema.Children) == 0 {
+		t.Fatal("public_identities schema has no children")
+	}
+	piChildMap := make(map[string]bool)
+	for _, c := range piSchema.Children {
+		piChildMap[c.JSONKey] = true
+	}
+	for _, f := range []string{"name", "pubkey", "lightning_address"} {
+		if !piChildMap[f] {
+			t.Errorf("public_identities child schema missing: %s", f)
+		}
+	}
+}
+
+func TestSchemaMatchesConfigJSON(t *testing.T) {
+	schema := GetConfigSchema()
+	cfg := NewDefaultConfig()
+
+	cfgData, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+	var cfgMap map[string]interface{}
+	if err := json.Unmarshal(cfgData, &cfgMap); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	for _, field := range schema {
+		if field.Required && field.JSONKey != "margin" {
+			if _, ok := cfgMap[field.JSONKey]; !ok {
+				t.Errorf("Schema declares %s as required but Config JSON doesn't produce it", field.JSONKey)
+			}
+		}
+	}
+}
+
+func TestSchemaJSONSerialization(t *testing.T) {
+	schema := GetConfigSchema()
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("Failed to marshal config schema: %v", err)
+	}
+
+	var parsed []map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal config schema: %v", err)
+	}
+
+	for i, field := range parsed {
+		for _, required := range []string{"name", "type", "json_key", "required", "editable"} {
+			if _, ok := field[required]; !ok {
+				t.Errorf("Schema field %d missing key: %s", i, required)
+			}
+		}
+	}
+
+	identSchema := GetIdentitiesSchema()
+	identData, err := json.Marshal(identSchema)
+	if err != nil {
+		t.Fatalf("Failed to marshal identities schema: %v", err)
+	}
+	var identParsed []map[string]interface{}
+	if err := json.Unmarshal(identData, &identParsed); err != nil {
+		t.Fatalf("Failed to unmarshal identities schema: %v", err)
+	}
+	if len(identParsed) == 0 {
+		t.Error("Identities schema is empty")
+	}
+}
+
+func TestSchemaEditableFieldsHaveDescriptions(t *testing.T) {
+	schema := GetConfigSchema()
+	for _, field := range schema {
+		if field.Editable && field.Description == "" {
+			t.Errorf("Editable field %s (%s) has no description", field.Name, field.JSONKey)
+		}
+	}
+	identSchema := GetIdentitiesSchema()
+	for _, field := range identSchema {
+		if field.Editable && field.Description == "" {
+			t.Errorf("Editable identities field %s (%s) has no description", field.Name, field.JSONKey)
+		}
+	}
+}
+
+func TestSetDotPathSimpleFields(t *testing.T) {
+	tempDir := t.TempDir()
+	cm, err := NewConfigManager(
+		tempDir+"/config.json",
+		tempDir+"/install.json",
+		tempDir+"/identities.json",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	err = SetDotPath(cm, "metric", "milliseconds")
+	if err != nil {
+		t.Fatalf("Failed to set metric: %v", err)
+	}
+
+	loaded, err := LoadConfig(tempDir + "/config.json")
+	if err != nil {
+		t.Fatalf("Failed to reload config: %v", err)
+	}
+	if loaded.Metric != "milliseconds" {
+		t.Errorf("metric mismatch: got %s, want milliseconds", loaded.Metric)
+	}
+
+	err = SetDotPath(cm, "step_size", "44040192")
+	if err != nil {
+		t.Fatalf("Failed to set step_size: %v", err)
+	}
+
+	loaded, _ = LoadConfig(tempDir + "/config.json")
+	if loaded.StepSize != 44040192 {
+		t.Errorf("step_size mismatch: got %d, want 44040192", loaded.StepSize)
+	}
+
+	err = SetDotPath(cm, "show_setup", "false")
+	if err != nil {
+		t.Fatalf("Failed to set show_setup: %v", err)
+	}
+
+	loaded, _ = LoadConfig(tempDir + "/config.json")
+	if loaded.ShowSetup != false {
+		t.Errorf("show_setup mismatch: got %v, want false", loaded.ShowSetup)
+	}
+}
+
+func TestSetDotPathMintField(t *testing.T) {
+	tempDir := t.TempDir()
+	cm, err := NewConfigManager(
+		tempDir+"/config.json",
+		tempDir+"/install.json",
+		tempDir+"/identities.json",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	err = SetDotPath(cm, "accepted_mints.0.price_per_step", "5")
+	if err != nil {
+		t.Fatalf("Failed to set mint price: %v", err)
+	}
+
+	loaded, _ := LoadConfig(tempDir + "/config.json")
+	if loaded.AcceptedMints[0].PricePerStep != 5 {
+		t.Errorf("price_per_step mismatch: got %d, want 5", loaded.AcceptedMints[0].PricePerStep)
+	}
+}
+
+func TestSetDotPathInvalidKey(t *testing.T) {
+	tempDir := t.TempDir()
+	cm, err := NewConfigManager(
+		tempDir+"/config.json",
+		tempDir+"/install.json",
+		tempDir+"/identities.json",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	err = SetDotPath(cm, "nonexistent_field", "value")
+	if err == nil {
+		t.Error("Expected error for nonexistent field, got nil")
+	}
+}
+
+func TestSetDotPathInvalidValue(t *testing.T) {
+	tempDir := t.TempDir()
+	cm, err := NewConfigManager(
+		tempDir+"/config.json",
+		tempDir+"/install.json",
+		tempDir+"/identities.json",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	err = SetDotPath(cm, "step_size", "not-a-number")
+	if err == nil {
+		t.Error("Expected error for non-numeric step_size, got nil")
+	}
+
+	err = SetDotPath(cm, "show_setup", "not-a-bool")
+	if err == nil {
+		t.Error("Expected error for non-boolean show_setup, got nil")
+	}
+}

--- a/src/config_manager/config_schema_test.go
+++ b/src/config_manager/config_schema_test.go
@@ -268,3 +268,109 @@ func TestSetDotPathInvalidValue(t *testing.T) {
 		t.Error("Expected error for non-boolean show_setup, got nil")
 	}
 }
+
+func TestSetDotPathSchemaEnumValidation(t *testing.T) {
+	tempDir := t.TempDir()
+	cm, err := NewConfigManager(
+		tempDir+"/config.json",
+		tempDir+"/install.json",
+		tempDir+"/identities.json",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	err = SetDotPath(cm, "log_level", "INVALID")
+	if err == nil {
+		t.Error("Expected error for invalid log_level enum value, got nil")
+	}
+
+	err = SetDotPath(cm, "metric", "INVALID")
+	if err == nil {
+		t.Error("Expected error for invalid metric enum value, got nil")
+	}
+
+	err = SetDotPath(cm, "log_level", "debug")
+	if err != nil {
+		t.Errorf("Valid enum value 'debug' should be accepted, got: %v", err)
+	}
+
+	err = SetDotPath(cm, "metric", "milliseconds")
+	if err != nil {
+		t.Errorf("Valid enum value 'milliseconds' should be accepted, got: %v", err)
+	}
+}
+
+func TestSetDotPathSchemaMinMaxValidation(t *testing.T) {
+	tempDir := t.TempDir()
+	cm, err := NewConfigManager(
+		tempDir+"/config.json",
+		tempDir+"/install.json",
+		tempDir+"/identities.json",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	err = SetDotPath(cm, "margin", "5.0")
+	if err == nil {
+		t.Error("Expected error for margin > 1.0 (max), got nil")
+	}
+
+	err = SetDotPath(cm, "margin", "-0.5")
+	if err == nil {
+		t.Error("Expected error for margin < 0.0 (min), got nil")
+	}
+
+	err = SetDotPath(cm, "margin", "0.5")
+	if err != nil {
+		t.Errorf("Valid margin 0.5 should be accepted, got: %v", err)
+	}
+
+	err = SetDotPath(cm, "profit_share.0.factor", "5.0")
+	if err == nil {
+		t.Error("Expected error for profit_share factor > 1.0 (max), got nil")
+	}
+
+	err = SetDotPath(cm, "profit_share.0.factor", "-0.1")
+	if err == nil {
+		t.Error("Expected error for profit_share factor < 0.0 (min), got nil")
+	}
+}
+
+func TestSetDotPathSchemaUpstreamWifiValidation(t *testing.T) {
+	tempDir := t.TempDir()
+	cm, err := NewConfigManager(
+		tempDir+"/config.json",
+		tempDir+"/install.json",
+		tempDir+"/identities.json",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create ConfigManager: %v", err)
+	}
+
+	err = SetDotPath(cm, "upstream_wifi.scan_interval_seconds", "5")
+	if err == nil {
+		t.Error("Expected error for scan_interval_seconds < 10 (min), got nil")
+	}
+
+	err = SetDotPath(cm, "upstream_wifi.scan_interval_seconds", "5000")
+	if err == nil {
+		t.Error("Expected error for scan_interval_seconds > 3600 (max), got nil")
+	}
+
+	err = SetDotPath(cm, "upstream_wifi.scan_interval_seconds", "600")
+	if err != nil {
+		t.Errorf("Valid scan_interval_seconds 600 should be accepted, got: %v", err)
+	}
+
+	err = SetDotPath(cm, "upstream_wifi.signal_floor", "-20")
+	if err == nil {
+		t.Error("Expected error for signal_floor > -30 (max), got nil")
+	}
+
+	err = SetDotPath(cm, "upstream_wifi.signal_floor", "-70")
+	if err != nil {
+		t.Errorf("Valid signal_floor -70 should be accepted, got: %v", err)
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -263,16 +263,18 @@ func initCLIServer() {
 }
 
 func getMacAddress(ipAddress string) (string, error) {
-	cmdIn := `cat /tmp/dhcp.leases | cut -f 2,3,4 -s -d" " | grep -i ` + ipAddress + ` | cut -f 1 -s -d" "`
-	commandOutput, err := exec.Command("sh", "-c", cmdIn).Output()
-
-	var commandOutputString = string(commandOutput)
+	data, err := os.ReadFile("/tmp/dhcp.leases")
 	if err != nil {
-		fmt.Println(err, "Error when getting client's mac address. Command output: "+commandOutputString)
-		return "nil", err
+		return "", fmt.Errorf("reading dhcp leases: %w", err)
 	}
-
-	return strings.Trim(commandOutputString, "\n"), nil
+	ipLower := strings.ToLower(strings.TrimSpace(ipAddress))
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && strings.ToLower(fields[2]) == ipLower {
+			return strings.TrimSpace(fields[1]), nil
+		}
+	}
+	return "", fmt.Errorf("MAC not found for IP %s", ipAddress)
 }
 
 // CORS middleware to handle Cross-Origin Resource Sharing
@@ -284,9 +286,14 @@ func CorsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		}).Debug("CORS middleware processing request")
 
 		// Set CORS headers
-		w.Header().Set("Access-Control-Allow-Origin", "*") // Allow any origin, or specify domains like "https://yourdomain.com"
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		origin := r.Header.Get("Origin")
+		if origin == "" || isLocalOrigin(origin) {
+			if origin != "" {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			}
+		}
 
 		// Handle preflight OPTIONS requests
 		if r.Method == "OPTIONS" {
@@ -309,7 +316,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("mac", mac)
+	mainLogger.WithField("mac", mac).Debug("MAC address resolved")
 	fmt.Fprint(w, "mac=", mac)
 }
 
@@ -760,4 +767,21 @@ func getIP(r *http.Request) string {
 	}
 
 	return ip
+}
+
+func isLocalOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "127.0.0.1" || host == "localhost" ||
+		strings.HasPrefix(host, "192.168.") ||
+		strings.HasPrefix(host, "10.") ||
+		strings.HasPrefix(host, "172.16.") ||
+		strings.HasPrefix(host, "172.17.") ||
+		strings.HasPrefix(host, "172.18.") ||
+		strings.HasPrefix(host, "172.19.") ||
+		strings.HasPrefix(host, "172.2") ||
+		strings.HasPrefix(host, "172.3")
 }

--- a/src/main.go
+++ b/src/main.go
@@ -769,19 +769,38 @@ func getIP(r *http.Request) string {
 	return ip
 }
 
+var privateCIDRs []net.IPNet
+
+func init() {
+	for _, cidr := range []string{
+		"192.168.0.0/16",
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"127.0.0.0/8",
+		"fd00::/8",
+		"::1/128",
+	} {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid CIDR %s: %v", cidr, err))
+		}
+		privateCIDRs = append(privateCIDRs, *n)
+	}
+}
+
 func isLocalOrigin(origin string) bool {
 	u, err := url.Parse(origin)
 	if err != nil {
 		return false
 	}
-	host := u.Hostname()
-	return host == "127.0.0.1" || host == "localhost" ||
-		strings.HasPrefix(host, "192.168.") ||
-		strings.HasPrefix(host, "10.") ||
-		strings.HasPrefix(host, "172.16.") ||
-		strings.HasPrefix(host, "172.17.") ||
-		strings.HasPrefix(host, "172.18.") ||
-		strings.HasPrefix(host, "172.19.") ||
-		strings.HasPrefix(host, "172.2") ||
-		strings.HasPrefix(host, "172.3")
+	ip := net.ParseIP(u.Hostname())
+	if ip == nil {
+		return u.Hostname() == "localhost"
+	}
+	for _, n := range privateCIDRs {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/contract/build-purity.sh
+++ b/tests/contract/build-purity.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Verifies that test-only configuration (TOLLGATE_TEST_CONFIG_DIR) is not
+# compiled into the production binary. Catches the class of bug where a Go
+# source file with an init() that sets test env vars uses a filename that
+# doesn't match *_test.go and lacks a build-tag guard.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+ROOT="$(pwd)"
+SRC="$ROOT/src"
+
+RED='\033[31m'
+GREEN='\033[32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS+1)); echo "  ${GREEN}PASS${RESET}: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ${RED}FAIL${RESET}: $1"; }
+
+echo "${BOLD}=== Build-Purity Contract Tests ===${RESET}"
+echo ""
+
+# --- Test 1: No non-_test.go source file sets TOLLGATE_TEST_CONFIG_DIR ---
+echo "${BOLD}--- source file check ---${RESET}"
+offenders=""
+while IFS= read -r -d '' f; do
+    base="$(basename "$f")"
+    case "$base" in
+        *_test.go) continue ;;
+    esac
+    if grep -q 'os\.Setenv.*TOLLGATE_TEST_CONFIG_DIR' "$f"; then
+        first_line=$(head -1 "$f")
+        if echo "$first_line" | grep -q '^//go:build'; then
+            continue
+        fi
+        offenders="$offenders $f"
+    fi
+done < <(find "$SRC" -name '*.go' -not -path '*/vendor/*' -print0)
+
+if [ -z "$offenders" ]; then
+    pass "no production source file sets TOLLGATE_TEST_CONFIG_DIR (all guarded by build tag or _test.go)"
+else
+    fail "production files set TOLLGATE_TEST_CONFIG_DIR without guard:$offenders"
+fi
+
+# --- Test 2: Any file with test config dir init has a build tag ---
+echo "${BOLD}--- build tag guard check ---${RESET}"
+while IFS= read -r -d '' f; do
+    base="$(basename "$f")"
+    # skip this script's directory
+    if grep -q 'os\.Setenv.*TOLLGATE_TEST_CONFIG_DIR' "$f"; then
+        first_line=$(head -1 "$f")
+        if echo "$first_line" | grep -q '^//go:build'; then
+            pass "$base has build tag guard"
+        else
+            fail "$base sets TOLLGATE_TEST_CONFIG_DIR without build tag"
+        fi
+    fi
+done < <(find "$SRC" -name '*.go' -not -path '*/vendor/*' -print0)
+
+# --- Test 3: Production binary does not contain test config path ---
+echo "${BOLD}--- production binary check ---${RESET}"
+tmpbin=$(mktemp)
+trap 'rm -f "$tmpbin"' EXIT
+
+if GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+    go build -o "$tmpbin" -trimpath -ldflags="-s -w" "$SRC" 2>/dev/null; then
+    if strings "$tmpbin" | grep -q 'tollgate-main-test'; then
+        fail "production binary contains 'tollgate-main-test' test path"
+    else
+        pass "production binary free of test config path"
+    fi
+else
+    # cross-compile may fail on CI without ARM toolchain — skip gracefully
+    echo "  SKIP: cross-compile unavailable (non-ARM CI runner)"
+fi
+
+# --- Test 4: go vet with testenv tag passes ---
+echo "${BOLD}--- go vet ---${RESET}"
+if (cd "$SRC" && go vet -tags testenv ./... 2>&1); then
+    pass "go vet -tags testenv passes"
+else
+    fail "go vet -tags testenv failed"
+fi
+
+echo ""
+echo "${BOLD}=== Results: ${GREEN}${PASS} passed${RESET}, ${RED}${FAIL} failed${RESET} ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/contract/js-schema-lint.mjs
+++ b/tests/contract/js-schema-lint.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..', '..');
+
+const schemaPath = resolve(root, 'src/config_manager/config_schema.go');
+
+const schemaSrc = readFileSync(schemaPath, 'utf8');
+
+const schemaKeyRe = /JSONKey:\s*"([^"]+)"/g;
+const schemaKeys = new Set();
+let m;
+while ((m = schemaKeyRe.exec(schemaSrc)) !== null) {
+	schemaKeys.add(m[1]);
+}
+
+if (schemaKeys.size === 0) {
+	console.error('FAIL: No JSONKey entries found in schema source');
+	process.exit(1);
+}
+
+const structSrc = readFileSync(resolve(root, 'src/config_manager/config_manager_config.go'), 'utf8');
+const jsonTagRe = /json:"([^,"]+)/g;
+const structTags = new Set();
+while ((m = jsonTagRe.exec(structSrc)) !== null) {
+	structTags.add(m[1]);
+}
+
+let failed = false;
+
+for (const tag of structTags) {
+	if (tag === '' || tag === '-') continue;
+	if (schemaKeys.has(tag)) continue;
+
+	const hasSchemaParent = [...schemaKeys].some(k => tag.startsWith(k + '.') || tag.startsWith(k + '_'));
+	if (hasSchemaParent) continue;
+
+	console.error(`FAIL: Config struct has json tag "${tag}" but no matching schema entry`);
+	failed = true;
+}
+
+if (failed) {
+	console.error(`Schema has ${schemaKeys.size} entries, struct has ${structTags.size} json tags`);
+	process.exit(1);
+}
+
+console.log(`PASS: Schema consistency check (${schemaKeys.size} schema entries cover all struct tags)`);


### PR DESCRIPTION
## This is a re-opening of PR #124

PR #124 was merged prematurely and has been reverted from `main`. Re-opening as a new PR to allow team review before merging.

## Original Description

Adds a schema-driven configuration system with CLI JSON commands, enabling admin UI integration. Includes thread safety fixes, input validation, CI pipeline, and a build-purity contract test.

### Key Changes
- Config Schema System (`config_schema.go`, `config_dotpath.go`) — `GetConfigSchema()`, `SetDotPath()` with validation
- CLI `--json` Flag — `tollgate --json config schema/get/set/save`, health, wallet commands
- Production config redirect fix — `000_main_test_env.go` → `000_test_env_testenv.go` with build tag guard
- Thread safety fix — `SetDotPath` uses write lock
- CI test workflow + schema contract lint + build-purity contract test

### Review Requested
- @Origami74 — please review when you have a chance

## Related
- Original PR: #124
- Pre-release checklist: #144
- Frontend delivery: #145