### PR TITLE
ci: downgrade artifact actions to v3 for act compatibility (DRAFT)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -199,7 +199,7 @@ jobs:
           ls -lh bin/
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v3
         with:
           name: binaries-${{ matrix.compile_key }}
           path: bin/
@@ -220,7 +220,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v3
         with:
           name: binaries-${{ matrix.compile_key }}
           path: bin/
@@ -284,7 +284,7 @@ jobs:
             packaging/build-ipk.sh "$PAYLOAD" "artifacts/$PACKAGE_FILENAME"
 
       - name: Upload package artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PACKAGE_FILENAME }}
           path: artifacts/${{ env.PACKAGE_FILENAME }}
@@ -310,7 +310,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v3
         with:
           name: binaries-${{ matrix.compile_key }}
           path: bin/
@@ -379,7 +379,7 @@ jobs:
           cp "$PACKAGE_PATH" "/github/workspace/artifacts/${PACKAGE_FILENAME}"
 
       - name: Upload package artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PACKAGE_FILENAME }}
           path: /github/workspace/artifacts/${{ env.PACKAGE_FILENAME }}
@@ -414,7 +414,7 @@ jobs:
           nak --version
 
       - name: Download all package artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v3
         with:
           # Matches both ipk and apk artifacts uploaded by package-ipk
           # and package-apk.


### PR DESCRIPTION
## Purpose

Downgrade `actions/upload-artifact` and `actions/download-artifact` to v3 for compatibility with [nektos/act](https://github.com/nektos/act) local CI runner.

## ⚠️ GitHub CI Will Fail

GitHub has deprecated v3 of the artifact actions and automatically fails any workflow using them. This PR is a **DRAFT** and will remain so until one of:
1. `act` adds v4+ artifact protocol support
2. A conditional workflow is implemented that uses v3 for act and v7/v8 for GitHub
3. A custom artifact server is set up for local testing

## What Changed

- 3x `actions/upload-artifact@v7` → `@v3`
- 3x `actions/download-artifact@v8` → `@v3`

## Related

- Issue: # TBD (act v3 compatibility tracking)
- PR #143 — main CI infra PR (uses v7/v8)