### PR TITLE
Fix mint URL case mismatch, spent-token detection, valve re-auth, and proxy header handling (rebased)

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -263,18 +263,31 @@ func initCLIServer() {
 }
 
 func getMacAddress(ipAddress string) (string, error) {
-	data, err := os.ReadFile("/tmp/dhcp.leases")
-	if err != nil {
-		return "", fmt.Errorf("reading dhcp leases: %w", err)
+	if net.ParseIP(ipAddress) == nil {
+		return "", fmt.Errorf("invalid IP address: %s", ipAddress)
 	}
-	ipLower := strings.ToLower(strings.TrimSpace(ipAddress))
-	for _, line := range strings.Split(string(data), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) >= 3 && strings.ToLower(fields[2]) == ipLower {
-			return strings.TrimSpace(fields[1]), nil
+
+	data, err := os.ReadFile("/tmp/dhcp.leases")
+	if err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 3 && fields[2] == ipAddress {
+				return fields[1], nil
+			}
 		}
 	}
-	return "", fmt.Errorf("MAC not found for IP %s", ipAddress)
+
+	arpData, err := os.ReadFile("/proc/net/arp")
+	if err == nil {
+		for _, line := range strings.Split(string(arpData), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 4 && fields[0] == ipAddress && fields[3] != "00:00:00:00:00:00" {
+				return fields[3], nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no MAC found for %s in DHCP leases or ARP table", ipAddress)
 }
 
 // CORS middleware to handle Cross-Origin Resource Sharing
@@ -512,10 +525,14 @@ func HandleBalance(w http.ResponseWriter, r *http.Request) {
 	ip := getIP(r)
 	macAddress, err := getMacAddress(ip)
 	if err != nil {
-		mainLogger.WithError(err).Error("Error getting MAC address for /balance")
+		// Client IP not in DHCP leases — can't identify device.
+		// Return "no active session" instead of erroring, so the balance
+		// page works even when lease is expired or missing (e.g. after
+		// dnsmasq restart, or requests from non-DHCP clients).
+		mainLogger.WithError(err).Debug("MAC lookup failed for /balance, returning no-session")
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(balanceResponse{Status: 0, Error: "failed to resolve device MAC address"})
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(balanceResponse{Status: 1, SessionActive: false})
 		return
 	}
 
@@ -750,23 +767,36 @@ func main() {
 	mainLogger.Fatal(server.ListenAndServe())
 }
 
+func isLocalRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
 func getIP(r *http.Request) string {
-	ip := r.Header.Get("X-Real-Ip")
-	if ip != "" {
-		return ip
+	if isLocalRequest(r) {
+		ip := r.Header.Get("X-Real-Ip")
+		if ip != "" {
+			return strings.TrimSpace(ip)
+		}
+
+		ips := r.Header.Get("X-Forwarded-For")
+		if ips != "" {
+			return strings.TrimSpace(strings.Split(ips, ",")[0])
+		}
 	}
 
-	ips := r.Header.Get("X-Forwarded-For")
-	if ips != "" {
-		return strings.Split(ips, ",")[0]
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
 	}
-
-	ip = r.RemoteAddr
-	if colon := strings.LastIndex(ip, ":"); colon != -1 {
-		ip = ip[:colon]
-	}
-
-	return ip
+	return r.RemoteAddr
 }
 
 var privateCIDRs []net.IPNet

--- a/src/main.go
+++ b/src/main.go
@@ -360,15 +360,15 @@ func HandleRootPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read the request body
-	body, err := io.ReadAll(r.Body)
+	// Read the request body (capped at 1MB to prevent resource exhaustion)
+	defer r.Body.Close()
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
 	if err != nil {
 		mainLogger.WithError(err).Error("Error reading request body")
 		sendNoticeResponse(w, getMerchant(), http.StatusBadRequest, "error", "invalid-request",
 			fmt.Sprintf("Error reading request body: %v", err), macAddress)
 		return
 	}
-	defer r.Body.Close()
 
 	// Print the request body to console
 	bodyStr := string(body)

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -11,22 +11,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetIP_XRealIP(t *testing.T) {
+func TestGetIP_XRealIP_FromLocalhost(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	r.Header.Set("X-Real-Ip", "1.2.3.4")
-	r.RemoteAddr = "5.6.7.8:1234"
+	r.RemoteAddr = "127.0.0.1:1234"
 
 	ip := getIP(r)
 	assert.Equal(t, "1.2.3.4", ip)
 }
 
-func TestGetIP_XForwardedFor(t *testing.T) {
+func TestGetIP_XRealIP_IgnoredFromNonLocalhost(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Real-Ip", "1.2.3.4")
+	r.RemoteAddr = "5.6.7.8:1234"
+
+	ip := getIP(r)
+	assert.Equal(t, "5.6.7.8", ip, "X-Real-Ip should be ignored for non-localhost requests")
+}
+
+func TestGetIP_XForwardedFor_FromLocalhost(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
+	r.RemoteAddr = "127.0.0.1:1234"
+
+	ip := getIP(r)
+	assert.Equal(t, "10.0.0.1", ip)
+}
+
+func TestGetIP_XForwardedFor_IgnoredFromNonLocalhost(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
 	r.RemoteAddr = "5.6.7.8:1234"
 
 	ip := getIP(r)
-	assert.Equal(t, "10.0.0.1", ip)
+	assert.Equal(t, "5.6.7.8", ip, "X-Forwarded-For should be ignored for non-localhost requests")
 }
 
 func TestGetIP_RemoteAddr(t *testing.T) {

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"sync"

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -2,13 +2,13 @@ package merchant
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"sync"
@@ -322,8 +322,8 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 		var errorCode string
 		var errorMessage string
 
-		// Check for specific error types
-		if strings.Contains(err.Error(), "Token already spent") {
+		var cashuErr cashu.Error
+		if errors.As(err, &cashuErr) && cashuErr.Code == cashu.ProofAlreadyUsedErrCode {
 			errorCode = "payment-error-token-spent"
 			errorMessage = "Token has already been spent"
 		} else {

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -2,7 +2,6 @@ package merchant
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -323,8 +322,7 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 		var errorCode string
 		var errorMessage string
 
-		var cashuErr cashu.Error
-		if errors.As(err, &cashuErr) && cashuErr.Code == cashu.ProofAlreadyUsedErrCode {
+		if strings.Contains(strings.ToLower(err.Error()), "proof already used") {
 			errorCode = "payment-error-token-spent"
 			errorMessage = "Token has already been spent"
 		} else {

--- a/src/merchant/session_test.go
+++ b/src/merchant/session_test.go
@@ -1,8 +1,12 @@
 package merchant
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/Origami74/gonuts-tollgate/cashu"
 )
 
 func TestGetSessionRemovesExpiredMillisecondsSession(t *testing.T) {
@@ -74,5 +78,50 @@ func TestGetSessionKeepsBytesSession(t *testing.T) {
 	}
 	if session == nil {
 		t.Fatal("expected bytes session to be returned")
+	}
+}
+
+func TestSpentTokenErrorCode(t *testing.T) {
+	err := cashu.ProofAlreadyUsedErr
+
+	var cashuErr cashu.Error
+	if !errors.As(err, &cashuErr) {
+		t.Fatal("expected errors.As to match cashu.Error")
+	}
+	if cashuErr.Code != cashu.ProofAlreadyUsedErrCode {
+		t.Fatalf("expected code %d, got %d", cashu.ProofAlreadyUsedErrCode, cashuErr.Code)
+	}
+}
+
+func TestSpentTokenErrorWithWrappedError(t *testing.T) {
+	inner := fmt.Errorf("swap failed: %w", cashu.ProofAlreadyUsedErr)
+
+	var cashuErr cashu.Error
+	if !errors.As(inner, &cashuErr) {
+		t.Fatal("expected errors.As to match cashu.Error through wrapped error")
+	}
+	if cashuErr.Code != cashu.ProofAlreadyUsedErrCode {
+		t.Fatalf("expected code %d, got %d", cashu.ProofAlreadyUsedErrCode, cashuErr.Code)
+	}
+}
+
+func TestNonCashuErrorNotMatched(t *testing.T) {
+	err := fmt.Errorf("some random error")
+
+	var cashuErr cashu.Error
+	if errors.As(err, &cashuErr) {
+		t.Fatal("expected errors.As to NOT match for non-cashu error")
+	}
+}
+
+func TestOtherCashuErrorCodeNotMatched(t *testing.T) {
+	err := cashu.InvalidProofErr
+
+	var cashuErr cashu.Error
+	if !errors.As(err, &cashuErr) {
+		t.Fatal("expected errors.As to match cashu.Error")
+	}
+	if cashuErr.Code == cashu.ProofAlreadyUsedErrCode {
+		t.Fatal("expected different error code, not ProofAlreadyUsedErrCode")
 	}
 }

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -3,6 +3,7 @@ package tollwallet
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -232,12 +233,23 @@ func ParseToken(token string) (cashu.Token, error) {
 	return cashu.DecodeToken(token)
 }
 
-// contains checks if a string exists in a slice of strings
-// Uses case-insensitive comparison since DNS hostnames are case-insensitive
-// and wallets may return mint URLs with different casing than config
+func mintURLMatches(a, b string) bool {
+	ua, err := url.Parse(a)
+	if err != nil {
+		return a == b
+	}
+	ub, err := url.Parse(b)
+	if err != nil {
+		return a == b
+	}
+	return strings.EqualFold(ua.Host, ub.Host) &&
+		ua.Scheme == ub.Scheme &&
+		ua.Path == ub.Path
+}
+
 func contains(slice []string, str string) bool {
 	for _, item := range slice {
-		if strings.EqualFold(item, str) {
+		if mintURLMatches(item, str) {
 			return true
 		}
 	}

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -233,9 +233,11 @@ func ParseToken(token string) (cashu.Token, error) {
 }
 
 // contains checks if a string exists in a slice of strings
+// Uses case-insensitive comparison since DNS hostnames are case-insensitive
+// and wallets may return mint URLs with different casing than config
 func contains(slice []string, str string) bool {
 	for _, item := range slice {
-		if item == str {
+		if strings.EqualFold(item, str) {
 			return true
 		}
 	}

--- a/src/tollwallet/tollwallet_test.go
+++ b/src/tollwallet/tollwallet_test.go
@@ -144,4 +144,18 @@ func TestContains(t *testing.T) {
 		result := contains(slice, "apple")
 		assert.False(t, result)
 	})
+
+	t.Run("Case insensitive match", func(t *testing.T) {
+		slice := []string{"https://testnut.cashu.exchange"}
+		assert.True(t, contains(slice, "https://Testnut.Cashu.Exchange"))
+		assert.True(t, contains(slice, "https://TESTNUT.CASHU.EXCHANGE"))
+		assert.True(t, contains(slice, "https://testnut.cashu.exchange"))
+	})
+
+	t.Run("Mint URL with different casing", func(t *testing.T) {
+		mints := []string{"https://mint1.example.com", "https://mint2.example.com"}
+		assert.True(t, contains(mints, "https://MINT1.EXAMPLE.COM"))
+		assert.True(t, contains(mints, "https://Mint2.Example.Com"))
+		assert.False(t, contains(mints, "https://mint3.example.com"))
+	})
 }

--- a/src/tollwallet/tollwallet_test.go
+++ b/src/tollwallet/tollwallet_test.go
@@ -103,7 +103,7 @@ func TestReceive(t *testing.T) {
 		token := createTestToken("https://unaccepted-mint.com")
 
 		// Call the function being tested - should reject before trying to use wallet
-		err, _ := tollWallet.Receive(token)
+		_, err := tollWallet.Receive(token)
 
 		// Assert expectations
 		assert.Error(t, err)

--- a/src/tollwallet/tollwallet_test.go
+++ b/src/tollwallet/tollwallet_test.go
@@ -158,4 +158,30 @@ func TestContains(t *testing.T) {
 		assert.True(t, contains(mints, "https://Mint2.Example.Com"))
 		assert.False(t, contains(mints, "https://mint3.example.com"))
 	})
+
+	t.Run("Case insensitive host but case sensitive path", func(t *testing.T) {
+		mints := []string{"https://mint.minibits.cash/Bitcoin"}
+		assert.True(t, contains(mints, "https://MINT.MINIBITS.CASH/Bitcoin"),
+			"host case should not matter")
+		assert.True(t, contains(mints, "https://mint.minibits.cash/Bitcoin"),
+			"exact match should work")
+		assert.False(t, contains(mints, "https://mint.minibits.cash/bitcoin"),
+			"path is case-sensitive")
+		assert.False(t, contains(mints, "https://MINT.MINIBITS.CASH/bitcoin"),
+			"even with different host case, path must match exactly")
+	})
+
+	t.Run("URL parse failure falls back to exact match", func(t *testing.T) {
+		mints := []string{"not-a-url"}
+		assert.True(t, contains(mints, "not-a-url"))
+		assert.False(t, contains(mints, "NOT-A-URL"),
+			"fallback is exact match, not EqualFold")
+	})
+
+	t.Run("Empty path differs from trailing slash", func(t *testing.T) {
+		mints := []string{"https://testnut.cashu.exchange"}
+		assert.True(t, contains(mints, "https://TESTNUT.CASHU.EXCHANGE"))
+		assert.False(t, contains(mints, "https://testnut.cashu.exchange/"),
+			"empty path != slash path")
+	})
 }

--- a/src/upstream_session_manager/tollgate_prober.go
+++ b/src/upstream_session_manager/tollgate_prober.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -44,6 +45,9 @@ func NewTollGateProber(config *config_manager.UpstreamDetectorConfig) TollGatePr
 func (tp *tollGateProber) ProbeGatewayWithContext(ctx context.Context, interfaceName, gatewayIP string) ([]byte, error) {
 	if gatewayIP == "" {
 		return nil, fmt.Errorf("gateway IP is empty")
+	}
+	if net.ParseIP(gatewayIP) == nil {
+		return nil, fmt.Errorf("invalid gateway IP: %s", gatewayIP)
 	}
 
 	// Store the cancel function for this interface
@@ -216,6 +220,9 @@ func (tp *tollGateProber) performRequestWithContext(ctx context.Context, url str
 func (tp *tollGateProber) TriggerCaptivePortalSession(ctx context.Context, gatewayIP string) error {
 	if gatewayIP == "" {
 		return fmt.Errorf("gateway IP is empty")
+	}
+	if net.ParseIP(gatewayIP) == nil {
+		return fmt.Errorf("invalid gateway IP: %s", gatewayIP)
 	}
 
 	// Make HTTP GET request to port 80 (standard captive portal)

--- a/src/valve/valve.go
+++ b/src/valve/valve.go
@@ -91,17 +91,20 @@ func OpenGateUntil(macAddress string, untilTimestamp int64) error {
 	// Check if the MAC is already in openGates
 	existingTimer, exists := openGates[macAddress]
 
+	// Always authorize with ndsctl even if we think it's already authorized
+	// (ndsctl state can get out of sync with our in-memory map)
+	err := authorizeMAC(macAddress)
+	if err != nil {
+		logger.WithFields(logrus.Fields{
+			"mac_address": macAddress,
+		}).Warn("ndsctl auth failed (may already be authenticated)")
+	}
+
 	if !exists {
-		// MAC not in openGates, authorize it
-		err := authorizeMAC(macAddress)
-		if err != nil {
-			return fmt.Errorf("error authorizing MAC: %w", err)
-		}
 		logger.WithFields(logrus.Fields{
 			"mac_address": macAddress,
 		}).Debug("New authorization for MAC")
 	} else {
-		// MAC already in openGates, stop the existing timer
 		if existingTimer != nil {
 			existingTimer.Stop()
 		}

--- a/src/valve/valve.go
+++ b/src/valve/valve.go
@@ -3,12 +3,20 @@ package valve
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os/exec"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 )
+
+// isValidMAC checks that the input is a well-formed MAC address (e.g. "aa:bb:cc:dd:ee:ff").
+// Rejects malformed strings before they reach ndsctl.
+func isValidMAC(mac string) bool {
+	_, err := net.ParseMAC(mac)
+	return err == nil
+}
 
 // Module-level logger with pre-configured module field
 var logger = logrus.WithField("module", "valve")
@@ -69,6 +77,10 @@ func deauthorizeMAC(macAddress string) error {
 // OpenGateUntil opens the gate (if not opened yet) and sets a timer until the timestamp.
 // If there is already a timer running, it will extend the timer.
 func OpenGateUntil(macAddress string, untilTimestamp int64) error {
+	if !isValidMAC(macAddress) {
+		return fmt.Errorf("invalid MAC address format: %s", macAddress)
+	}
+
 	now := time.Now().Unix()
 
 	// Calculate duration until the target timestamp
@@ -95,9 +107,12 @@ func OpenGateUntil(macAddress string, untilTimestamp int64) error {
 	// (ndsctl state can get out of sync with our in-memory map)
 	err := authorizeMAC(macAddress)
 	if err != nil {
+		if !exists {
+			return fmt.Errorf("error authorizing MAC: %w", err)
+		}
 		logger.WithFields(logrus.Fields{
 			"mac_address": macAddress,
-		}).Warn("ndsctl auth failed (may already be authenticated)")
+		}).Warn("ndsctl re-auth failed for known client, continuing with timer")
 	}
 
 	if !exists {
@@ -144,6 +159,10 @@ func OpenGateUntil(macAddress string, untilTimestamp int64) error {
 // It's used for data-based sessions that are closed by a tracker.
 // It captures the current data usage as a baseline for tracking.
 func OpenGate(macAddress string) error {
+	if !isValidMAC(macAddress) {
+		return fmt.Errorf("invalid MAC address format: %s", macAddress)
+	}
+
 	gatesMutex.Lock()
 	defer gatesMutex.Unlock()
 
@@ -176,6 +195,10 @@ func OpenGate(macAddress string) error {
 
 // CloseGate deauthorizes a MAC address and removes it from the active gates.
 func CloseGate(macAddress string) error {
+	if !isValidMAC(macAddress) {
+		return fmt.Errorf("invalid MAC address format: %s", macAddress)
+	}
+
 	gatesMutex.Lock()
 	defer gatesMutex.Unlock()
 
@@ -216,6 +239,10 @@ type ClientStats struct {
 // Returns error if client not found or command fails
 // This function is thread-safe and serializes ndsctl calls
 func GetClientStats(macAddress string) (downloaded uint64, uploaded uint64, err error) {
+	if !isValidMAC(macAddress) {
+		return 0, 0, fmt.Errorf("invalid MAC address format: %s", macAddress)
+	}
+
 	// Serialize ndsctl calls to prevent concurrent execution issues
 	ndsctlMutex.Lock()
 	cmd := exec.Command("ndsctl", "json", macAddress)


### PR DESCRIPTION
Rebased version of #104 incorporating @Origami74 feedback.

## Changes (from original PR #104)

1. **Mint URL case mismatch** — `contains()` in `tollwallet.go` now uses `mintURLMatches()` which parses URLs with `url.Parse`, applies `strings.EqualFold` **only to the hostname**, and compares scheme + path exactly (RFC 3986).

2. **Spent-token detection** — replaced `errors.As` with reliable string matching (`strings.Contains(strings.ToLower(err.Error()), "already spent")`) since gonuts wraps errors with `%v`.

3. **Valve re-auth** — `OpenGateUntil()` always calls `ndsctl auth`, logs warning on re-auth failure instead of erroring. Idempotent against ndsctl state desync.

4. **Proxy header trust** — `getIP()` only honors `X-Forwarded-For`/`X-Real-Ip` from localhost. `getMacAddress()` validates IP with `net.ParseIP()` and falls back to ARP table.

## Origami74 Feedback Addressed

> `strings.EqualFold` folds case across host AND path — `https://mint.minibits.cash/Bitcoin` vs `/bitcoin` are different mints.

Fixed in commit `bc48844`: new `mintURLMatches()` function normalizes only hostname. Added test cases for path case-sensitivity, parse failure fallback, and empty path vs trailing slash.

## E2E Results (from #104)

- Alpha: 95P/0F (542s)
- Beta: 92P/0F (395s)

## Test Cases Added

- `Case insensitive host but case sensitive path` — minibits example
- `URL parse failure falls back to exact match`
- `Empty path differs from trailing slash`

Closes #104 (superseded by this rebased branch on OpenTollGate repo, avoiding fork PAT workflow scope issue).