### PR TITLE
ci: expand test matrix to cover standalone-buildable modules

### DIFF
--- a/.github/scripts/go-test-summary.sh
+++ b/.github/scripts/go-test-summary.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Run `go test` and append a Markdown summary to the GitHub Actions job summary.
+#
+# Usage: go-test-summary.sh <label> [go test args...]
+#
+# The script mirrors test output to stdout (so the live job log is unchanged),
+# captures it, and writes a compact pass/fail/skip table plus any failing test
+# names to $GITHUB_STEP_SUMMARY. It exits with the underlying `go test` status
+# so the job still fails when tests fail.
+#
+# Portable across GitHub-hosted runners and `act`: depends only on bash, grep
+# and tee (no jq/python), and falls back to stdout when $GITHUB_STEP_SUMMARY is
+# unset (e.g. when run locally).
+set -uo pipefail
+
+label="${1:?usage: go-test-summary.sh <label> [go test args...]}"
+shift
+
+out="$(mktemp)"
+trap 'rm -f "$out"' EXIT
+
+set -o pipefail
+go test "$@" 2>&1 | tee "$out"
+status=${PIPESTATUS[0]}
+
+# grep -c exits non-zero when there are no matches; `|| true` keeps the count.
+pass=$(grep -c '^[[:space:]]*--- PASS:' "$out" || true)
+fail=$(grep -c '^[[:space:]]*--- FAIL:' "$out" || true)
+skip=$(grep -c '^[[:space:]]*--- SKIP:' "$out" || true)
+notest=$(grep -c '\[no test files\]' "$out" || true)
+
+if [ "$status" -eq 0 ]; then icon="✅"; else icon="❌"; fi
+
+summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+{
+  echo "### ${icon} ${label}"
+  echo ""
+  echo "| Passed | Failed | Skipped | Pkgs without tests |"
+  echo "|-------:|-------:|--------:|-------------------:|"
+  echo "| ${pass} | ${fail} | ${skip} | ${notest} |"
+  echo ""
+  if [ "$fail" -ne 0 ]; then
+    echo "<details><summary>Failing tests</summary>"
+    echo ""
+    echo '```'
+    grep '^[[:space:]]*--- FAIL:' "$out" || true
+    echo '```'
+    echo ""
+    echo "</details>"
+    echo ""
+  fi
+} >> "$summary"
+
+exit "$status"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,17 @@ jobs:
           - src/config_manager
           - src/utils
           - src/cmd/tollgate-cli
+          - src/lightning
+          - src/tollgate_protocol
+          - src/tollwallet
+          - src/valve
+          - src/wireless_gateway_manager
+          # NOTE: src/merchant, src/cli, src/upstream_detector and
+          # src/upstream_session_manager are intentionally omitted. They
+          # transitively pull in the lnd -> ltcsuite/ltcd chain, which only
+          # builds standalone after an invasive go.mod rewrite (an `exclude`
+          # directive plus a full re-tidy). They still build/test as part of
+          # the root module's build; adding them here is tracked separately.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,30 +28,30 @@ jobs:
           # directive plus a full re-tidy). They still build/test as part of
           # the root module's build; adding them here is tracked separately.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: src/go.mod
       - name: Run tests
         working-directory: ${{ matrix.module }}
-        run: go test ./... -v -count=1 -race
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/go-test-summary.sh" "${{ matrix.module }}" ./... -v -count=1 -race
 
   main-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: src/go.mod
       - name: Run main package tests
         working-directory: src
-        run: go test -v -count=1 -race -tags testenv .
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/go-test-summary.sh" "main package (testenv)" -v -count=1 -race -tags testenv .
 
   contract-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Schema lint
@@ -60,8 +60,8 @@ jobs:
   build-purity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: src/go.mod
       - name: Build purity check

--- a/src/tollwallet/tollwallet_test.go
+++ b/src/tollwallet/tollwallet_test.go
@@ -103,7 +103,7 @@ func TestReceive(t *testing.T) {
 		token := createTestToken("https://unaccepted-mint.com")
 
 		// Call the function being tested - should reject before trying to use wallet
-		err, _ := tollWallet.Receive(token)
+		_, err := tollWallet.Receive(token)
 
 		// Assert expectations
 		assert.Error(t, err)


### PR DESCRIPTION
## Why

`test.yml`'s `go-test` job only ran `src/config_manager`, `src/utils`, and `src/cmd/tollgate-cli`. Because this is a multi-module repo, the root `main-test` job (`go test ... .`) can't reach sibling modules either, so **test files in every other module were never executed in CI** — they could silently rot into non-compiling states.

Concretely, `src/tollwallet/tollwallet_test.go` had not compiled for some time: `Receive` returns `(uint64, error)` but the test bound the error to the first return value. Nothing caught it because `tollwallet` wasn't in the matrix.

While in here, also addressed the Node 20 runner deprecation and added test summaries.

## What

- **Expand the matrix** to every module that builds & tests cleanly as its own module, so their tests run now and any *future* tests run automatically without further CI changes:
  `lightning`, `tollgate_protocol`, `tollwallet`, `valve`, `wireless_gateway_manager`.
  (Modules without tests yet are included intentionally — `go test ./...` is a green no-op until tests land.)
- **Fix the latent `tollwallet` test** (`err, _ :=` → `_, err :=`).
- **Bump actions to Node 24 majors**: `actions/checkout`, `actions/setup-go`, `actions/setup-node` → `@v6` (matching `build-package.yml`). v4/v5 run on the deprecated Node 20 runtime.
- **Markdown test summaries**: new `.github/scripts/go-test-summary.sh` runs `go test`, mirrors output to the live log, and appends a pass/fail/skip table (plus failing test names) to `$GITHUB_STEP_SUMMARY`. Used by both the `go-test` matrix and `main-test`. It exits with the underlying `go test` status, so failures still fail the job. Depends only on bash/grep/tee and falls back to stdout when `$GITHUB_STEP_SUMMARY` is unset, so it also runs under [`act`](https://github.com/nektos/act).

## Intentionally omitted (for now)

`merchant`, `cli`, `upstream_detector`, `upstream_session_manager` transitively pull in the `lnd → ltcsuite/ltcd` chain, which hits an *ambiguous import* and only builds standalone after an invasive `go.mod` rewrite (`exclude` directive + full re-tidy, ~250 line churn, plus a pre-existing `copylocks` vet finding in `merchant.go`). They still build as part of the root module's build. Adding them is worth a separate, dedicated PR.

## Verification

Ran each matrix entry locally exactly as CI does (`go test ./... -count=1 -race`) — all green (no-test modules report `[no test files]`, exit 0). The summary script was tested directly against passing, no-test, and failing modules (correct table, exit-code propagation, and failing-test block).