### PR TITLE
fix: non-fatal BOLT11 decode + nodogsplash gatewayport 2050

### DIFF
--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -134,8 +134,11 @@ setup_nodogsplash() {
     if ! echo "$nds_users" | grep -q "port 8080"; then
         uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 8080'
     fi
+    if ! echo "$nds_users" | grep -q "port 2050"; then
+        uci add_list nodogsplash.@nodogsplash[0].users_to_router='allow tcp port 2050'
+    fi
     uci set nodogsplash.@nodogsplash[0].gatewaydomainname='TollGate.lan'
-    uci set nodogsplash.@nodogsplash[0].gatewayport='80'
+    uci set nodogsplash.@nodogsplash[0].gatewayport='2050'
 }
 
 setup_tollgate_firewall_rules() {

--- a/src/go.mod
+++ b/src/go.mod
@@ -26,7 +26,7 @@ replace (
 	github.com/OpenTollGate/tollgate-module-basic-go/src/utils => ./utils
 	github.com/OpenTollGate/tollgate-module-basic-go/src/valve => ./valve
 	github.com/OpenTollGate/tollgate-module-basic-go/src/wireless_gateway_manager => ./wireless_gateway_manager
-	github.com/Origami74/gonuts-tollgate => github.com/net4sats/gonuts-tollgate v0.7.1
+	github.com/Origami74/gonuts-tollgate => github.com/OpenTollGate/gonuts-tollgate v0.7.1
 )
 
 require (

--- a/src/go.mod
+++ b/src/go.mod
@@ -26,7 +26,7 @@ replace (
 	github.com/OpenTollGate/tollgate-module-basic-go/src/utils => ./utils
 	github.com/OpenTollGate/tollgate-module-basic-go/src/valve => ./valve
 	github.com/OpenTollGate/tollgate-module-basic-go/src/wireless_gateway_manager => ./wireless_gateway_manager
-	github.com/Origami74/gonuts-tollgate => github.com/Amperstrand/gonuts-tollgate v0.7.0
+	github.com/Origami74/gonuts-tollgate => github.com/net4sats/gonuts-tollgate v0.7.1
 )
 
 require (

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Amperstrand/gonuts-tollgate v0.7.0 h1:pp7Cqt3TFH3h7c8tFhNM9aSHJ89D5dUmJ5WqBo3oiF8=
-github.com/Amperstrand/gonuts-tollgate v0.7.0/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3 h1:ClzzXMDDuUbWfNNZqGeYq4PnYOlwlOVIvSyNaIy0ykg=
@@ -10,6 +8,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/OpenTollGate/gonuts-tollgate v0.7.1 h1:1D7GRpu1SwyQCbx70wVomOpzMVi6W7E3yGfc/gCxAvM=
+github.com/OpenTollGate/gonuts-tollgate v0.7.1/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=


### PR DESCRIPTION
## Summary

Two fixes for on-device stability:

### 1. Non-fatal BOLT11 decoding in gonuts-tollgate

Test mints (e.g. `testnut.cashu.exchange`) return dummy strings instead of real BOLT11 invoices. The `decodepay.Decodepay()` call in `gonuts-tollgate` was failing hard on these, aborting the entire `RequestMint` flow — even though the mint successfully created the quote.

The fix makes BOLT11 decoding non-fatal in `RequestMint()`, falling back to `time.Now().Unix()` for `CreatedAt`. Other `decodepay` usages (`RequestMeltQuote`, `MultiMintPayment`, `GetMintQuoteByPaymentRequest`) remain strict since they require valid invoices.

**Source:** Cherry-picked from @Amperstrand's commit `9b2b843` on `feature/v2-keyset-ids`, now maintained at `OpenTollGate/gonuts-tollgate v0.7.1`.

### 2. NoDogSplash gatewayport 80→2050

`tollgate-module-basic-go`'s first-boot setup was setting `nodogsplash.gatewayport='80'`, conflicting with uhttpd on the same port. Changed to `2050` and added the corresponding `users_to_router` allow rule.

## Changes

- `src/go.mod` — replace directive: `net4sats/gonuts-tollgate` → `OpenTollGate/gonuts-tollgate v0.7.1`
- `packaging/files/etc/uci-defaults/99-tollgate-setup` — `gatewayport='2050'` + `allow tcp port 2050`

## Testing

- Built `tollgate-wrt` binary for `aarch64_cortex-a53` — compiles cleanly
- Deployed to router — `POST /ln-invoice` with testnut succeeds
- `tollgate --json health` returns `status: ok`

## Related

- `OpenTollGate/gonuts-tollgate` v0.7.1 (the org fork with the fix)
- Issue #156
- `net4sats/configurationwizzard` PR #10 (frontend fixes for same issues)