### PR TITLE
fix(setup): disable IPv6 on LAN to prevent captive portal bypass

### DIFF
--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -171,6 +171,17 @@ fi
 EOF
 }
 
+# Nodogsplash only manages IPv4 iptables. If IPv6 Router Advertisements are
+# active on LAN, WiFi clients get global IPv6 addresses and Android validates
+# connectivity over IPv6 — completely bypassing the captive portal.
+# https://github.com/OpenTollGate/tollgate-module-basic-go/issues/148
+setup_disable_ipv6_lan() {
+    uci set dhcp.lan.ra='disabled'
+    uci set dhcp.lan.dhcpv6='disabled'
+    uci set network.lan.ip6assign='0'
+    log "IPv6 disabled on LAN (captive portal bypass prevention)"
+}
+
 enable_modems() {
     local section
     for section in $(uci show network 2>/dev/null | awk -F'[.=]' '/^network\.modem_/ {print $2}' | sort -u); do
@@ -277,6 +288,7 @@ setup_public_wifi            # exports RANDOM_SUFFIX, GATEWAY_NAME
 setup_nodogsplash
 setup_tollgate_firewall_rules
 setup_profile_hook
+setup_disable_ipv6_lan
 enable_modems
 setup_private_network        # consumes RANDOM_SUFFIX
 commit_all


### PR DESCRIPTION
## Problem

Closes #148.

Android clients can bypass the captive portal entirely via IPv6. Nodogsplash only manages IPv4 iptables — it has no `ip6tables` integration. OpenWrt enables IPv6 Router Advertisements on LAN by default, so WiFi clients receive a global IPv6 address via SLAAC that completely bypasses nodogsplash's rules.

The nodogsplash documentation states: "NoDogSplash MUST run on a device configured as an IPv4 router."

## Fix

Disable IPv6 RA, DHCPv6, and prefix assignment on `br-lan` (the captive portal interface) during first-boot setup via `uci-defaults`:

```
uci set dhcp.lan.ra=disabled
uci set dhcp.lan.dhcpv6=disabled
uci set network.lan.ip6assign=0
```

This only affects `br-lan`. The private admin bridge (`br-private`) retains IPv6.

## Testing

- Existing UCI defaults continue to run (additive change)
- `shellcheck` clean (only pre-existing warnings in the file)
- This is the standard workaround used across OpenWrt deployments with nodogsplash

## Not a long-term decision

When nodogsplash/openNDS adds `ip6tables` support, or TollGate moves to a different captive portal implementation, these lines can be removed.