### PR TITLE
docs: document degraded mode architecture and TIP naming updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ Changes on `main` since `v0.4.0` (tagged 2026-04-06).
 
 ### Added
 
+- **Degraded mode with dynamic upgrade/downgrade.** When no Cashu mints are
+  reachable at startup, the router boots into a degraded merchant that keeps the
+  HTTP API alive (returning signed notice events asking clients to retry) and
+  can spend existing ecash from the cached BoltDB wallet. When the health
+  tracker detects a reachable mint, the merchant upgrades in-process to a full
+  merchant with payout and data-usage monitoring — no service restart required.
+  If all mints go offline mid-operation, the merchant downgrades dynamically
+  back to degraded mode
+  ([#140](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/140)).
+- **Mint health tracker.** Probes each configured mint via `GET /v1/info` on a
+  5-minute interval with hysteresis: a mint is marked unreachable after a
+  single probe failure, but requires 3 consecutive successes to recover. Fires
+  `onFirstReachable` (for degraded→full upgrade) and `onReachableSetChanged`
+  (for full→degraded downgrade) callbacks
+  ([#139](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/139)).
+- **Merchant provider with atomic swap.** `MutexMerchantProvider` wraps the
+  current merchant behind an RWMutex so all HTTP handlers, CLI commands, and
+  the upstream session manager see a consistent merchant — even during
+  degraded↔full transitions. Replaces direct `merchant` variable access
+  throughout `main.go`
+  ([#139](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/139),
+   [#140](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/140)).
+- **`merchant_types` package.** Zero-dependency Go module
+  (`src/merchant_types/`) defining the `PaymentMerchant` and
+  `MerchantProvider` interfaces. Decouples `upstream_session_manager` from the
+  full `merchant` package, eliminating ~490 lines of transitive dependencies
+  from the USM dependency tree
+  ([#138](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/138)).
+- **Sentinel error for spent tokens.** `tollwallet.ErrTokenAlreadySpent` wraps
+  the upstream Cashu library's spent-token error at the package boundary.
+  `merchant.PurchaseSession()` uses `errors.Is()` to detect duplicate spends
+  and returns a proper notice event instead of a generic error
+  ([#140](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/140)).
 - **Upstream WiFi management.** New manager that detects and connects to
   upstream gateways, with a startup connectivity check, TollGate-aware probing,
   and a cross-radio DHCP nudge to recover stuck links
@@ -47,7 +80,8 @@ Changes on `main` since `v0.4.0` (tagged 2026-04-06).
 
 - **Transport reliability on OpenWrt:** force TLS 1.2 and set HTTP client
   timeouts so requests no longer hang on constrained routers
-  ([#137](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/137)).
+  ([#137](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/137),
+   [#139](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/139)).
 - **Security:** generate passwords with `crypto/rand` instead of time-based
   (`math/rand`) entropy
   ([#111](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/111)).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ is generated from
 ## Feature highlights
 
 - Accept Cashu tokens for internet access, by time **or** by data.
+- **Degraded-mode boot and automatic recovery.** If mints are unreachable at
+  startup, the router boots into degraded mode (keeps the API alive, returns
+  signed notice events asking clients to retry) and upgrades in-process when
+  the health tracker detects a reachable mint — no service restart required
+  ([#140](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/140)).
 - Automatic Lightning payouts split across any number of profit-share
   identities.
 - Upstream autopay — a TollGate can detect an upstream TollGate and
@@ -45,12 +50,13 @@ Source lives under [src/](src/). Go tooling runs from there
 
 | Module | Role |
 |---|---|
-| [merchant](src/merchant/) | Prices advertisements, validates incoming Cashu payments, and hands off started sessions to the session manager. Also drives Lightning payouts. See [docs/merchant.md](docs/merchant.md). |
+| [merchant](src/merchant/) | Prices advertisements, validates incoming Cashu payments, and hands off started sessions to the session manager. Also drives Lightning payouts. Boots into degraded mode when mints are unreachable and upgrades dynamically when they recover. See [docs/merchant.md](docs/merchant.md). |
 | [upstream_session_manager](src/upstream_session_manager/) | Owns the customer session lifecycle on this router — creates usage trackers (time or bytes), instructs the Valve when to open/close, handles renewal near limit. Formerly the `chandler` package. See [docs/upstream_session_manager.md](docs/upstream_session_manager.md). |
 | [upstream_detector](src/upstream_detector/) | Probes WAN interfaces to discover an upstream TollGate, decides whether to buy from it, and coordinates the reseller flow. Formerly `crowsnest`. The cross-component flow is documented under "Cross-component flow" in [docs/upstream_session_manager.md](docs/upstream_session_manager.md). |
 | [wireless_gateway_manager](src/wireless_gateway_manager/) | Wi-Fi gateway selection, connection/reconnection, scanning, reseller-mode network orchestration. See [docs/wireless_gateway_manager.md](docs/wireless_gateway_manager.md). |
 | [valve](src/valve/) | Thin wrapper over `ndsctl` that opens/closes gates and authorizes/deauthorizes MACs. |
 | [config_manager](src/config_manager/) | Schema, loading, migrations, validation, backups of `/etc/tollgate/config.json`. |
+| [merchant_types](src/merchant_types/) | Zero-dependency package defining the `PaymentMerchant` and `MerchantProvider` interfaces. Decouples `upstream_session_manager` from the full `merchant` package. |
 | [tollwallet](src/tollwallet/) | Cashu wallet operations (mint client, balance tracking, melt). |
 | [lightning](src/lightning/) | LNURL-p / Lightning address resolution and invoice fetching for payouts. |
 | [cli](src/cli/) | `tollgate` CLI for `status`, `start`/`stop`/`restart`, `logs`, `version`. Entry point: [src/cmd/tollgate-cli](src/cmd/tollgate-cli/). |

--- a/docs/data-session-management.md
+++ b/docs/data-session-management.md
@@ -188,6 +188,29 @@ The architecture maintains clear separation:
 
 The Merchant works independently for downstream customers without requiring UpstreamSessionManager dependencies.
 
+### Degraded Mode Caveat
+
+When the merchant is in degraded mode (all mints unreachable), the following
+behaviors change:
+
+- `StartDataUsageMonitoring()` is a no-op — no background goroutine is started.
+  Existing sessions continue until they exhaust their allotment, but no new
+  usage checks are performed.
+- `PurchaseSession()` returns a signed notice event instead of a session event,
+  so new customers cannot purchase access.
+- `AddAllotment()` returns an error — existing sessions cannot be extended.
+- `GetSession()` returns an error — no session state is maintained.
+
+When the health tracker detects a reachable mint and the merchant upgrades to
+full mode, `StartDataUsageMonitoring()` is called on the new full merchant and
+monitoring resumes. However, any sessions that were active before the downgrade
+are lost — customers must re-authenticate.
+
+See the [merchant documentation](merchant.md) for the full degraded-mode
+lifecycle and the [MintHealthTracker](merchant.md#mint-health-tracker) section
+for probe interval and recovery thresholds
+([PR #140](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/140)).
+
 ## Key Benefits
 
 1. **Accurate Tracking**: Per-customer statistics from NoDogSplash

--- a/docs/merchant.md
+++ b/docs/merchant.md
@@ -1,757 +1,857 @@
-# Merchant - Wallet Provider for Upstream Payments
+# Merchant — Wallet Provider, Payment Processor, and Session Manager
 
 ## Overview
 
-The `merchant` module serves as the wallet provider for the [`upstream_session_manager`](upstream_session_manager.md) module when making upstream payments. While its primary purpose is managing downstream customer payments and sessions, this document focuses on its role in supporting upstream TollGate connections.
+The `merchant` module is the financial core of the TollGate router. It handles three
+concerns:
 
-**Key Responsibilities (Upstream Context)**:
-- Provide wallet functionality for upstream_session_manager
-- Create Cashu payment tokens for upstream payments
-- Manage wallet balance across multiple mints
-- Handle automatic payouts to configured recipients
-- Coordinate wallet operations with upstream_session_manager's payment needs
+1. **Customer-facing payment processing** — accepts Cashu tokens, validates them with
+   mints, calculates allotments (time or data), and authorizes network access via the
+   valve (ndsctl).
+2. **Wallet operations** — manages Cashu wallet balances across multiple mints, creates
+   payment tokens for upstream TollGate purchases, and funds the wallet from external
+   sources.
+3. **Lightning payouts** — automatically sweeps accumulated balances to configured
+   Lightning addresses on a per-mint schedule, split according to profit-share
+   configuration.
+
+### Degraded Mode
+
+When mints are unreachable at startup (or during runtime), the merchant boots into
+**degraded mode** (`MerchantDegraded`) instead of crashing. In degraded mode:
+
+- The HTTP API stays alive — clients receive signed notice events (kind 21023) asking
+  them to retry later.
+- `GetAdvertisement()` and `CreateNoticeEvent()` work normally (they only need the
+  merchant private key, not wallet access).
+- All wallet and session operations return errors or zero values.
+- A background `MintHealthTracker` probes mints every 5 minutes. When a mint recovers
+  (3 consecutive successful probes), the tracker fires a callback that upgrades the
+  process to a full merchant — **no service restart required**.
+
+This degraded-mode architecture was introduced in three PRs:
+
+- [PR #138](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/138) —
+  `merchant_types` package: zero-dependency interfaces (`PaymentMerchant`,
+  `MerchantProvider`) to decouple `upstream_session_manager` from the full merchant.
+- [PR #139](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/139) —
+  `MintHealthTracker` and `MutexMerchantProvider`: health probing and atomic merchant
+  swap.
+- [PR #140](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/140) —
+  `MerchantDegraded`: degraded-mode boot, dynamic upgrade/downgrade lifecycle.
 
 ## Component Architecture
 
 ```mermaid
 graph TB
-    subgraph merchant
-        MR[Merchant Core]
-        TW[TollWallet]
-        PO[Payout Routine]
+    subgraph "merchant package"
+        MI["MerchantInterface<br/>(18 methods)"]
+        M["Merchant<br/>(full)"]
+        MD["MerchantDegraded"]
+        MP["MutexMerchantProvider"]
+        MHT["MintHealthTracker"]
     end
-    
-    subgraph External
-        CH[upstream_session_manager]
-        CFG[ConfigManager]
-        MINT[Cashu Mints]
-        LN[Lightning Network]
+
+    subgraph "Consumers"
+        HTTP["HTTP Handlers"]
+        CLI["CLI Commands"]
+        USM["Upstream Session Manager"]
     end
-    
-    CH -->|CreatePaymentToken| MR
-    CH -->|GetBalanceByMint| MR
-    MR -->|Manage tokens| TW
-    TW -->|Swap/Receive| MINT
-    TW -->|Melt| LN
-    MR -->|Get config| CFG
-    PO -->|Check balance| TW
-    PO -->|Trigger payout| TW
-    
-    style MR fill:#e1ffe1
-    style TW fill:#e1f5ff
-    style PO fill:#fff4e1
+
+    subgraph "Internal Dependencies"
+        TW["TollWallet"]
+        CFG["ConfigManager"]
+        V["Valve (ndsctl)"]
+    end
+
+    subgraph "External"
+        MINT["Cashu Mints"]
+        LN["Lightning Network"]
+    end
+
+    MI -.->|implemented by| M
+    MI -.->|implemented by| MD
+
+    MP -->|wraps| MI
+    HTTP -->|GetMerchant()| MP
+    CLI -->|GetMerchant()| MP
+    USM -->|GetMerchant()| MP
+
+    M --> TW
+    M --> CFG
+    M --> V
+    TW -->|swap/receive/melt| MINT
+    TW -->|melt| LN
+
+    MHT -->|probes| MINT
+    MHT -->|onFirstReachable| MP
+    MHT -->|onReachableSetChanged| MP
+
+    style MI fill:#e1ffe1
+    style M fill:#c8f7c8
+    style MD fill:#ffe1e1
+    style MP fill:#e1f5ff
+    style MHT fill:#fff4e1
 ```
 
-## Behavioral Flow Descriptions
+### Relationship Between Components
 
-### 1. Payment Token Creation for UpstreamSessionManager
+| Component | Role | File |
+|---|---|---|
+| `MerchantInterface` | 18-method interface all consumers call | `merchant.go` |
+| `Merchant` | Full implementation with wallet, sessions, payouts | `merchant.go` |
+| `MerchantDegraded` | Stub implementation when mints are unreachable | `merchant_degraded.go` |
+| `MutexMerchantProvider` | RWMutex-protected atomic swap of the current merchant | `merchant_provider.go` |
+| `MintHealthTracker` | Background health probes with hysteresis | `mint_health_tracker.go` |
 
-**Trigger**: `upstream_session_manager.CreatePaymentToken()` called during session creation or renewal
+## Merchant Lifecycle
 
-**Purpose**: Generate Cashu token for upstream payment
-
-**Flow**:
-1. Receive request with mint URL and amount
-2. Check wallet balance for specified mint
-3. If insufficient balance, return error
-4. Create Cashu token from wallet:
-   - Select proofs totaling requested amount
-   - May include overpayment if exact amount unavailable
-   - Create token string
-5. Return token to upstream_session_manager
-6. Wallet balance decreased by token amount
-
-**State Changes**:
-- Wallet proofs consumed
-- Balance decreased for mint
-- Token created (not yet spent)
-
-**Error Conditions**:
-- Insufficient balance
-- Mint not available
-- Token creation failure
-
-### 2. Balance Checking
-
-**Trigger**: UpstreamSessionManager checks balance before payment
-
-**Purpose**: Verify sufficient funds available
-
-**Flow**:
-1. Receive mint URL from upstream_session_manager
-2. Query tollwallet for balance at that mint
-3. Return current balance
-4. No state changes (read-only)
-
-**Balance Calculation**:
-- Sum of all unspent proofs for the mint
-- Does not include pending/reserved funds
-- Real-time calculation
-
-### 3. Automatic Payout Routine
-
-**Trigger**: Timer tick every 1 minute (per mint)
-
-**Purpose**: Automatically pay out profits to configured recipients
-
-**Flow**:
-1. For each configured mint:
-   - Get current balance
-   - Check if balance >= minimum payout amount
-   - If below threshold, skip
-   - Calculate payout amount: `balance - min_balance`
-   - For each profit share recipient:
-     - Calculate share: `payout_amount * factor`
-     - Get Lightning address from identities
-     - Melt tokens to Lightning
-     - Send to recipient's Lightning address
-   - Log payout completion
-
-**State Changes**:
-- Wallet balance decreased
-- Tokens melted to Lightning
-- Funds sent to recipients
-
-**Coordination Issue**: Runs independently of upstream_session_manager payment needs
-
-### 4. Wallet Funding (Receiving Tokens)
-
-**Trigger**: Receiving Cashu tokens (from downstream customers or external sources)
-
-**Purpose**: Add funds to wallet
-
-**Flow**:
-1. Receive Cashu token string
-2. Decode token
-3. Swap with mint (verify proofs not spent)
-4. Store new proofs in wallet
-5. Return amount received
-6. Balance increased
-
-**State Changes**:
-- New proofs added to wallet
-- Balance increased for mint
-
-**Note**: This is primarily for downstream customer payments, but affects balance available for upstream payments
-
-## Sequence Diagrams
-
-### Payment Token Creation Flow
+The merchant goes through a well-defined lifecycle at boot and during runtime. This is
+orchestrated by `init()` in `src/main.go`.
 
 ```mermaid
-sequenceDiagram
-    participant CH as upstream_session_manager
-    participant MR as merchant
-    participant TW as TollWallet
-    participant MINT as Cashu Mint
-    
-    CH->>MR: CreatePaymentToken(mint_url, amount)
-    MR->>TW: GetBalanceByMint(mint_url)
-    TW-->>MR: current_balance
-    
-    alt Insufficient balance
-        MR-->>CH: Error: Insufficient funds
-    end
-    
-    MR->>TW: CreateToken(mint_url, amount)
-    TW->>TW: Select proofs >= amount
-    TW->>TW: Create token string
-    TW-->>MR: cashu_token
-    
-    MR-->>CH: cashu_token
-    
-    Note over TW: Balance decreased
+stateDiagram-v2
+    [*] --> Boot: config loaded
+
+    Boot --> ProbeMints: merchant.New(configManager)
+    ProbeMints --> FullMerchant: wallet init succeeds
+    ProbeMints --> DegradedMerchant: wallet init fails
+
+    FullMerchant --> Runtime: StartPayoutRoutine()<br/>StartDataUsageMonitoring()
+    DegradedMerchant --> WaitForRecovery: healthTracker.Start()
+
+    WaitForRecovery --> UpgradeAttempt: onFirstReachable fires<br/>(3 consecutive successes)
+    UpgradeAttempt --> FullMerchant: merchant.New() succeeds
+    UpgradeAttempt --> WaitForRecovery: merchant.New() fails or<br/>returns degraded again
+
+    Runtime --> Runtime: payout ticks,<br/>data monitoring,<br/>payment processing
+
+    Runtime --> DowngradeCheck: onReachableSetChanged fires<br/>(reachable count changes)
+
+    DowngradeCheck --> Runtime: mints still reachable
+    DowngradeCheck --> DegradedMerchant: all mints go down
+
+    Runtime --> [*]
+    DegradedMerchant --> [*]
 ```
 
-### Balance Check Flow
+### Boot Sequence
 
-```mermaid
-sequenceDiagram
-    participant CH as upstream_session_manager
-    participant MR as merchant
-    participant TW as TollWallet
-    
-    CH->>MR: GetBalanceByMint(mint_url)
-    MR->>TW: GetBalanceByMint(mint_url)
-    TW->>TW: Sum unspent proofs
-    TW-->>MR: balance
-    MR-->>CH: balance
-    
-    Note over MR,TW: Read-only, no state change
+The boot sequence in `init()` (lines 96-186 of `src/main.go`):
+
+1. **Load configuration** — `ConfigManager` reads `/etc/tollgate/config.json` and
+   `/etc/tollgate/identities.json`.
+2. **Attempt full merchant** — `merchant.New()` tries to initialize the TollWallet by
+   connecting to all configured mints. If the wallet initializes, a full `Merchant` is
+   returned.
+3. **Fallback to degraded** — If `tollwallet.New()` fails (mints unreachable), `New()`
+   internally calls `NewDegraded()` which returns a `MerchantDegraded`. This does not
+   return an error — the caller receives `MerchantDegraded` as a `MerchantInterface`.
+4. **Create provider** — `NewMerchantProvider()` wraps the merchant instance in a
+   `MutexMerchantProvider`.
+5. **Create health tracker** — `NewMintHealthTracker()` is created with the configured
+   mint URLs.
+6. **Run initial probe** — `RunInitialProbe()` checks all mints synchronously to
+   populate initial state.
+7. **Wire callbacks** (degraded path only) — If the merchant is `MerchantDegraded`:
+   - `onFirstReachable` callback is set to create a new full merchant and swap it via
+     `merchantProvider.SetMerchant()`.
+8. **Start routines** (full path only) — If the merchant is full `Merchant`:
+   - `StartPayoutRoutine()` and `StartDataUsageMonitoring()` are called immediately.
+9. **Start health tracker** — `healthTracker.Start()` begins background probing every 5
+   minutes.
+10. **Initialize subsystems** — `initUpstreamManager()`, `initUpstreamDetector()`,
+    `initCLIServer()`.
+
+### Upgrade: Degraded → Full
+
+When the health tracker detects the first mint becoming reachable (3 consecutive
+successful probes):
+
+1. `onFirstReachable` callback fires on the timer goroutine.
+2. `merchant.New(configManager)` is called to attempt creating a full merchant.
+3. If the new merchant is also degraded (wallet still can't connect), the callback calls
+   `healthTracker.ResetFirstReachable()` and returns — the upgrade is retried on the next
+   probe cycle.
+4. If the new merchant is a full `Merchant`:
+   - `merchantProvider.SetMerchant(newMerchant)` atomically swaps the merchant under an
+     RWMutex write lock.
+   - `newMerchant.StartPayoutRoutine()` starts Lightning payout goroutines.
+   - `newMerchant.StartDataUsageMonitoring()` starts data usage checking.
+   - All subsequent `GetMerchant()` calls from HTTP handlers, CLI, and USM see the new
+     full merchant.
+
+### Downgrade: Full → Degraded
+
+When the health tracker detects that the reachable set has changed (e.g., all mints go
+down), `onReachableSetChanged` fires. In the current implementation, this callback is
+available but the downgrade path is less developed than the upgrade path. A future
+improvement could create a new `MerchantDegraded` and swap it in.
+
+### BoltDB Lock Consideration
+
+When upgrading from degraded to full, the degraded merchant does **not** hold a BoltDB
+lock (it has no wallet). The new full merchant opens the wallet fresh. This means there
+is no lock contention during upgrade. However, the old degraded merchant is not
+explicitly shut down — it simply becomes garbage-collectable once no goroutine holds a
+reference.
+
+## MerchantInterface
+
+The `MerchantInterface` defines 18 methods. Both `Merchant` and `MerchantDegraded`
+implement this interface.
+
+```go
+type MerchantInterface interface {
+    // Token creation
+    CreatePaymentToken(mintURL string, amount uint64) (string, error)
+    CreatePaymentTokenWithOverpayment(mintURL string, amount uint64, maxOverpaymentPercent uint64, maxOverpaymentAbsolute uint64) (string, error)
+    DrainMint(mintURL string) (string, uint64, error)
+
+    // Lightning invoices
+    RequestLightningInvoice(macAddress, mintURL string, amount uint64) (*LightningInvoice, error)
+    GetLightningInvoiceStatus(quoteID, macAddress string) (*LightningQuoteStatus, error)
+
+    // Mint and balance info
+    GetAcceptedMints() []config_manager.MintConfig
+    GetBalance() uint64
+    GetBalanceByMint(mintURL string) uint64
+    GetAllMintBalances() map[string]uint64
+
+    // Payment processing
+    PurchaseSession(cashuToken string, macAddress string) (*nostr.Event, error)
+    GetAdvertisement() string
+
+    // Background routines
+    StartPayoutRoutine()
+    StartDataUsageMonitoring()
+
+    // Notice events
+    CreateNoticeEvent(level, code, message, customerPubkey string) (*nostr.Event, error)
+
+    // Session management
+    GetSession(macAddress string) (*CustomerSession, error)
+    AddAllotment(macAddress, metric string, amount uint64) (*CustomerSession, error)
+    GetUsage(macAddress string) (string, error)
+
+    // Wallet funding
+    Fund(cashuToken string) (uint64, error)
+}
 ```
 
-### Payout Routine Flow
+### Method Behavior Comparison
+
+| Method | `Merchant` (full) | `MerchantDegraded` |
+|---|---|---|
+| `CreatePaymentToken` | Creates Cashu token from wallet | Returns `errDegraded` |
+| `CreatePaymentTokenWithOverpayment` | Creates token with overpayment tolerance | Returns `errDegraded` |
+| `DrainMint` | Drains all balance from a mint | Returns `errDegraded` |
+| `RequestLightningInvoice` | Creates Lightning invoice via mint | Returns `errDegraded` |
+| `GetLightningInvoiceStatus` | Checks invoice status | Returns `errDegraded` |
+| `GetAcceptedMints` | Returns configured mints | Returns `nil` |
+| `GetBalance` | Returns total wallet balance | Returns `0` |
+| `GetBalanceByMint` | Returns per-mint balance | Returns `0` |
+| `GetAllMintBalances` | Returns all mint balances | Returns `nil` |
+| `PurchaseSession` | Full payment processing flow | Returns `errDegraded` |
+| `GetAdvertisement` | Returns signed kind 10021 ad | Returns signed kind 10021 ad |
+| `StartPayoutRoutine` | Starts payout goroutines | No-op |
+| `StartDataUsageMonitoring` | Starts data usage checking | No-op |
+| `CreateNoticeEvent` | Creates signed kind 21023 notice | Creates signed kind 21023 notice |
+| `GetSession` | Returns session or expiry error | Returns "no active sessions" error |
+| `AddAllotment` | Creates/extends session | Returns `errDegraded` |
+| `GetUsage` | Returns "usage/allotment" string | Returns `errDegraded` |
+| `Fund` | Receives token into wallet | Returns `errDegraded` |
+
+**Key insight**: `GetAdvertisement()` and `CreateNoticeEvent()` work in both modes
+because they only need the merchant private key from `identities.json`, not wallet
+access. This is what allows the HTTP API to stay alive and return meaningful responses
+during degraded mode.
+
+## MerchantDegraded
+
+`MerchantDegraded` is a lightweight stub that satisfies `MerchantInterface` without any
+wallet, network, or session state.
+
+### Construction
+
+```go
+func NewDegraded(configManager *config_manager.ConfigManager) (MerchantInterface, error)
+```
+
+- Creates an advertisement using the same `CreateAdvertisement()` function as the full
+  merchant (only needs identities, not wallet).
+- Initializes an empty (unused) sessions map.
+- Logs a warning: `"Merchant starting in DEGRADED mode (mints unreachable)"`.
+
+### Error Returned
+
+All wallet and session operations return a sentinel error:
+
+```go
+var errDegraded = fmt.Errorf("service degraded: wallet unavailable, mints unreachable")
+```
+
+Consumers that receive this error can present it to the user as a temporary condition.
+
+### What Works
+
+- **`GetAdvertisement()`** — Returns a valid signed kind 10021 advertisement. Clients
+  can see pricing and mint URLs even in degraded mode.
+- **`CreateNoticeEvent()`** — Creates signed kind 21023 notice events. Used by HTTP
+  handlers to tell clients "service temporarily unavailable, retry later."
+- **`GetBalance()`, `GetBalanceByMint()`** — Return `0` (not errors). Allows balance
+  queries to succeed without misleading clients.
+
+### What Is Stubbed
+
+- **All token operations** (`CreatePaymentToken`, `CreatePaymentTokenWithOverpayment`,
+  `DrainMint`) — return `errDegraded`.
+- **`PurchaseSession()`** — returns `errDegraded`. No payment processing occurs.
+- **`StartPayoutRoutine()`, `StartDataUsageMonitoring()`** — no-ops. No goroutines
+  started.
+- **Session management** (`GetSession`, `AddAllotment`, `GetUsage`) — return errors.
+- **`Fund()`** — returns `errDegraded`. Wallet cannot receive tokens.
+- **`GetAcceptedMints()`** — returns `nil`. No mints available.
+
+## MintHealthTracker
+
+`MintHealthTracker` probes all configured mints in the background and fires callbacks
+when reachability changes.
+
+### Construction and Configuration
+
+```go
+func NewMintHealthTracker(mintConfigs []config_manager.MintConfig) *MintHealthTracker
+```
+
+| Parameter | Value | Notes |
+|---|---|---|
+| Probe interval | 5 minutes | `probeInterval: 5 * time.Minute` |
+| Probe timeout | 5 seconds | `probeTimeout: 5 * time.Second` |
+| Required consecutive successes | 3 | `requiredConsecutive: 3` |
+| Probe endpoint | `{mintURL}/v1/info` | HTTP GET, expects 200 OK |
+
+### Hysteresis
+
+The tracker uses a consecutive-success counter with hysteresis to avoid flapping:
+
+- **Recovery** (unreachable → reachable): Requires **3 consecutive** successful probes.
+  A single failure resets the counter to 0.
+- **Downgrade** (reachable → unreachable): A **single failure** resets the counter to
+  0, which immediately marks the mint as unreachable.
+
+This asymmetric hysteresis means recovery is slow (conservative) but failure detection
+is fast. See [follow-up issue #26](https://github.com/Amperstrand/tollgate-module-basic-go/issues/26)
+for concerns about 1-failure downgrade causing flapping.
+
+### Initial Probe
+
+`RunInitialProbe()` probes all mints synchronously before starting background checks.
+It populates the `reachable` map and sets `hadReachableMint = true` if any mint
+responds. This method must be called before `Start()` — it is not thread-safe.
+
+### Background Probing
+
+`Start()` launches a goroutine that probes all mints every 5 minutes. The probe
+sequence:
+
+1. Probe all mints concurrently (HTTP GET to `{mintURL}/v1/info`, 5s timeout).
+2. Lock the mutex and update `consecutiveSuccess` counters.
+3. Determine reachability transitions:
+   - If `consecutiveSuccess >= 3` and was unreachable → mark reachable, log.
+   - If `consecutiveSuccess < 3` and was reachable → mark unreachable, log.
+4. Check if `reachableCount` changed.
+5. Check if `hadReachableMint` was false and is now true → fire `onFirstReachable`.
+6. If reachable count changed → fire `onReachableSetChanged`.
+7. Unlock, then fire collected callbacks outside the lock.
+
+### Callbacks
+
+| Callback | Trigger | Used For |
+|---|---|---|
+| `onFirstReachable` | First mint comes back after total outage | Upgrade from degraded to full merchant |
+| `onReachableSetChanged` | Number of reachable mints changes | Downgrade detection, logging |
+
+`SetOnFirstReachable(fn)` and `SetOnReachableSetChanged(fn)` set these callbacks. They
+are called under the mutex, so they must be set before `Start()`.
+
+`ResetFirstReachable()` resets the `hadReachableMint` flag, allowing the
+`onFirstReachable` callback to fire again on the next successful probe. This is used
+when an upgrade attempt fails (e.g., `merchant.New()` returns degraded again).
+
+### State Query
+
+- `GetReachableMintConfigs()` — returns `[]MintConfig` of currently reachable mints.
+- `GetReachableCount()` — returns the number of reachable mints.
+- `String()` — returns `"MintHealthTracker{url1=reachable, url2=unreachable, ...}"`.
+
+## MutexMerchantProvider
+
+`MutexMerchantProvider` provides thread-safe access to the current merchant with atomic
+swap capability.
+
+### Interface
+
+```go
+type MerchantProvider interface {
+    GetMerchant() MerchantInterface
+    SetMerchant(MerchantInterface)
+}
+```
+
+### Implementation
+
+```go
+type MutexMerchantProvider struct {
+    mu       sync.RWMutex
+    merchant MerchantInterface
+}
+```
+
+- `GetMerchant()` takes an `RLock` — multiple concurrent readers can access the merchant
+  simultaneously.
+- `SetMerchant()` takes a full `Lock` — blocks all readers during the swap.
+
+### Why All Consumers Use `GetMerchant()`
+
+Long-lived consumers (HTTP handlers, CLI commands, the upstream session manager) hold a
+reference to the `MerchantProvider`, not to a specific merchant. At operation time, they
+call `GetMerchant()` to get the current merchant. This means:
+
+- Before upgrade: `GetMerchant()` returns `MerchantDegraded` — operations fail with
+  `errDegraded`.
+- After upgrade: `GetMerchant()` returns the new full `Merchant` — operations succeed.
+- No restart, no reconnection, no stale references.
+
+### Thread Safety
+
+The swap is atomic from the perspective of consumers. A goroutine calling
+`GetMerchant()` during an upgrade will either see the old degraded merchant or the new
+full merchant — never a partially initialized one. The `merchant.New()` call creates a
+fully initialized merchant before `SetMerchant()` is called.
+
+## Payout Routine
+
+The payout routine automatically sweeps accumulated balances to configured Lightning
+addresses. It only runs on a full `Merchant` — `MerchantDegraded.StartPayoutRoutine()`
+is a no-op.
+
+### Flow
 
 ```mermaid
 sequenceDiagram
     participant Timer as 1min Timer
-    participant MR as merchant
+    participant M as Merchant
     participant TW as TollWallet
     participant CFG as ConfigManager
     participant LN as Lightning Network
-    
-    Timer->>MR: Tick (per mint)
-    MR->>TW: GetBalanceByMint(mint_url)
-    TW-->>MR: balance
-    
+
+    Timer->>M: Tick (per mint)
+    M->>TW: GetBalanceByMint(mintURL)
+    TW-->>M: balance
+
     alt Balance < min_payout_amount
-        MR->>MR: Skip payout
+        M->>M: Skip payout
     end
-    
-    MR->>MR: Calculate payout amount
-    MR->>CFG: Get profit share config
-    CFG-->>MR: profit_shares[]
-    
+
+    M->>M: Calculate payout: balance - min_balance
+    M->>CFG: GetIdentities()
+    CFG-->>M: identities
+
     loop For each profit share
-        MR->>MR: Calculate share amount
-        MR->>CFG: Get Lightning address
-        CFG-->>MR: lightning_address
-        
-        MR->>TW: MeltToLightning(mint, amount, max_cost, ln_addr)
-        TW->>TW: Select proofs
-        TW->>TW: Create melt request
+        M->>M: share = payout * factor
+        M->>CFG: GetPublicIdentity(name)
+        CFG-->>M: lightning_address
+        M->>TW: MeltToLightning(mint, amount, max_cost, ln_addr)
         TW->>LN: Pay Lightning invoice
-        LN-->>TW: Payment success
-        TW-->>MR: Success
+        LN-->>TW: Result
     end
-    
-    Note over TW: Balance decreased by payout
+end
 ```
 
-### Race Condition Scenario
-
-```mermaid
-sequenceDiagram
-    participant CH as upstream_session_manager
-    participant MR as merchant
-    participant TW as TollWallet
-    participant PO as Payout Routine
-    
-    Note over CH: Session creation starting
-    CH->>MR: GetBalanceByMint(mint)
-    MR->>TW: GetBalanceByMint(mint)
-    TW-->>MR: 10000 sats
-    MR-->>CH: 10000 sats
-    
-    Note over CH: Balance sufficient, proceeding
-    
-    Note over PO: Timer tick
-    PO->>TW: GetBalanceByMint(mint)
-    TW-->>PO: 10000 sats
-    PO->>PO: Calculate payout: 9000 sats
-    PO->>TW: MeltToLightning(9000 sats)
-    TW->>TW: Balance now 1000 sats
-    
-    Note over CH: Creating payment
-    CH->>MR: CreatePaymentToken(mint, 5000)
-    MR->>TW: CreateToken(5000)
-    TW-->>MR: Error: Insufficient balance
-    MR-->>CH: Error: Insufficient funds
-    
-    Note over CH: Session creation failed!
-```
-
-## Events Sent to Other Components
-
-### To UpstreamSessionManager (via function returns)
-
-| Event | Trigger | Data | Purpose |
-|-------|---------|------|---------|
-| Token created | `CreatePaymentToken()` | Cashu token string | Provide payment token |
-| Balance returned | `GetBalanceByMint()` | Balance amount | Inform available funds |
-| Error returned | Insufficient funds | Error message | Indicate payment impossible |
-
-### From UpstreamSessionManager
-
-| Event | Trigger | Data | Purpose |
-|-------|---------|------|---------|
-| `CreatePaymentToken()` | Payment needed | mint URL, amount | Request payment token |
-| `GetBalanceByMint()` | Before payment | mint URL | Check available balance |
-
-## Edge Cases & State Issues
-
-### Issue 1: Race Condition Between Payout and Payment
-
-**Scenario**: Payout routine drains wallet while upstream_session_manager is creating payment
-
-**Root Cause**:
-- Payout runs every 1 minute independently
-- UpstreamSessionManager checks balance, then creates payment
-- Payout happens between check and creation
-- No locking or coordination mechanism
-- No fund reservation system
-
-**Current Behavior**:
-- UpstreamSessionManager: Balance check shows sufficient funds
-- Payout: Drains wallet to minimum balance
-- UpstreamSessionManager: Payment creation fails
-- Session creation fails
-- No retry mechanism
-
-**Impact**:
-- Upstream session creation fails
-- Device connected but not paying
-- User experience degraded
-- Requires manual intervention or wait for next discovery
-
-**Detection**:
-```bash
-# Check logs for timing
-logread | grep -E "(upstream_session_manager|merchant)" | grep -E "(balance|payout)"
-
-# Look for pattern:
-# 1. UpstreamSessionManager balance check: 10000 sats
-# 2. Merchant payout: 9000 sats
-# 3. UpstreamSessionManager payment creation: Error insufficient funds
-```
-
-**Potential Fixes**:
-
-1. **Fund Reservation System** (Recommended):
-```go
-// In merchant
-type FundReservation struct {
-    MintURL   string
-    Amount    uint64
-    ExpiresAt time.Time
-}
-
-func (m *Merchant) ReserveFunds(mintURL string, amount uint64) error {
-    // Reserve funds for 30 seconds
-    // Payout routine checks reserved funds
-}
-
-func (m *Merchant) GetAvailableBalance(mintURL string) uint64 {
-    total := m.GetBalanceByMint(mintURL)
-    reserved := m.getReservedFunds(mintURL)
-    return total - reserved
-}
-```
-
-2. **Mutex Locking**:
-```go
-// Add mutex around balance operations
-var walletMutex sync.Mutex
-
-func (m *Merchant) CreatePaymentToken(...) {
-    walletMutex.Lock()
-    defer walletMutex.Unlock()
-    // Create token...
-}
-
-func (m *Merchant) processPayout(...) {
-    walletMutex.Lock()
-    defer walletMutex.Unlock()
-    // Process payout...
-}
-```
-
-3. **Payout Coordination**:
-```go
-// Check for active sessions before payout
-func (m *Merchant) processPayout(mintConfig) {
-    // Check if upstream_session_manager has active sessions needing this mint
-    if m.upstream_session_manager.HasActiveSessionsForMint(mintConfig.URL) {
-        // Skip payout or reduce amount
-        return
-    }
-    // Proceed with payout...
-}
-```
-
-4. **Two-Phase Commit**:
-```go
-// Reserve, then commit
-func (m *Merchant) CreatePaymentToken(...) {
-    // Phase 1: Reserve
-    reservation := m.reserveFunds(mintURL, amount)
-    defer m.releaseFunds(reservation)
-    
-    // Phase 2: Create token
-    token := m.createToken(...)
-    
-    // Phase 3: Commit
-    m.commitReservation(reservation)
-    return token
-}
-```
-
-### Issue 2: Insufficient Balance for Minimum Purchase
-
-**Scenario**: Wallet has funds but not enough for upstream minimum purchase
-
-**Root Cause**:
-- Upstream requires minimum purchase (e.g., 1000 sats)
-- Wallet has 500 sats
-- UpstreamSessionManager checks balance, sees insufficient
-- Session creation fails
-- No notification or alert
-
-**Current Behavior**:
-- Balance check fails
-- Session creation aborted
-- Error logged
-- No user notification
-- No automatic funding mechanism
-
-**Detection**:
-```bash
-# Check upstream_session_manager logs
-logread | grep "Insufficient funds for minimum purchase"
-
-# Shows:
-# Required: 1000 sats
-# Available: 500 sats
-```
-
-**Potential Fixes**:
-1. Add balance monitoring and alerts
-2. Implement automatic funding from external source
-3. Add user notification for low balance
-4. Support partial payments if upstream allows
-5. Add balance threshold warnings
-
-### Issue 3: Payout Timing Configuration
-
-**Scenario**: Payout interval too frequent for usage patterns
-
-**Root Cause**:
-- Payout runs every 1 minute
-- May be too frequent for low-volume usage
-- Increases Lightning network fees
-- May interfere with upstream payments
-
-**Current Behavior**:
-- Frequent payout attempts
-- Higher transaction costs
-- Potential payment conflicts
-- Inefficient use of funds
-
-**Potential Fixes**:
-1. Make payout interval configurable
-2. Implement adaptive payout timing
-3. Coordinate with session activity
-4. Add payout scheduling logic
-5. Implement batch payouts
-
-### Issue 4: Multiple Mint Balance Fragmentation
-
-**Scenario**: Funds spread across multiple mints, none sufficient alone
-
-**Root Cause**:
-- Wallet supports multiple mints
-- Funds distributed across mints
-- Upstream requires specific mint
-- No cross-mint consolidation
-
-**Current Behavior**:
-- Total balance sufficient
-- Per-mint balance insufficient
-- Payment fails
-- No automatic consolidation
-
-**Detection**:
-```bash
-# Check all mint balances
-tollgate-cli wallet balance
-
-# Shows:
-# Mint A: 300 sats
-# Mint B: 400 sats
-# Mint C: 300 sats
-# Total: 1000 sats
-
-# But upstream requires 800 sats from Mint A
-# Payment fails despite total balance
-```
-
-**Potential Fixes**:
-1. Implement cross-mint swapping
-2. Add balance consolidation
-3. Support multiple mint payments
-4. Add mint selection logic
-5. Implement automatic rebalancing
-
-### Issue 5: Payout Configuration Errors
-
-**Scenario**: Profit share configuration invalid or missing
-
-**Root Cause**:
-- Lightning address not configured
-- Identity not found
-- Profit share factors don't sum to 1.0
-- Configuration errors
-
-**Current Behavior**:
-- Payout routine logs error
-- Continues to next profit share
-- Funds may not be distributed correctly
-- No alerts or notifications
-
-**Detection**:
-```bash
-# Check merchant logs
-logread | grep "Could not find public identity"
-
-# Or check for payout errors
-logread | grep "Error during payout"
-```
-
-**Potential Fixes**:
-1. Validate configuration on startup
-2. Add configuration health checks
-3. Implement fallback payout addresses
-4. Add configuration validation
-5. Alert on payout failures
-
-### Issue 6: Wallet State Persistence
-
-**Scenario**: Wallet state lost on restart
-
-**Root Cause**:
-- Wallet stores proofs in memory or file
-- File corruption or loss
-- Restart loses pending operations
-- No transaction log
-
-**Current Behavior**:
-- Wallet state may be inconsistent
-- Proofs may be lost
-- Balance may be incorrect
-- No recovery mechanism
-
-**Potential Fixes**:
-1. Implement robust persistence
-2. Add transaction logging
-3. Implement wallet backup
-4. Add state recovery
-5. Implement proof verification on startup
-
-## Integration with Other Components
-
-### Relationship with UpstreamSessionManager
-
-**Connection**: Direct function calls (wallet provider)
-
-**Flow**:
-```
-upstream_session_manager needs payment
-  → merchant.CreatePaymentToken()
-    → Token created and returned
-
-upstream_session_manager checks balance
-  → merchant.GetBalanceByMint()
-    → Balance returned
-```
-
-**Dependency**: Merchant must be initialized before upstream_session_manager
-
-**Critical Path**: Payment token creation is blocking operation
-
-### Relationship with TollWallet
-
-**Connection**: Internal component
-
-**Flow**:
-```
-merchant operations
-  → tollwallet.CreateToken()
-  → tollwallet.GetBalance()
-  → tollwallet.MeltToLightning()
-  → tollwallet.Receive()
-```
-
-**Dependency**: TollWallet manages actual Cashu operations
-
-### Relationship with ConfigManager
-
-**Connection**: Configuration access
-
-**Flow**:
-```
-merchant initialization
-  → configManager.GetConfig()
-    → Accepted mints
-    → Profit share config
-    → Payout settings
-```
-
-**Dependency**: Configuration must be loaded before merchant
-
-## Configuration
-
-### Merchant Config (Relevant to Upstream Payments)
+### Per-Mint Processing
+
+For each configured mint, a separate goroutine runs:
+
+1. **Check balance** — `GetBalanceByMint(mintURL)` returns the sum of unspent proofs.
+2. **Threshold check** — Skip if balance < `min_payout_amount`.
+3. **Calculate payout** — `aimedPaymentAmount = balance - min_balance`.
+4. **Split by profit share** — For each entry in `profit_share` config:
+   - `shareAmount = aimedPaymentAmount * factor`
+   - Look up Lightning address from `identities.json`.
+   - `MeltToLightning(mintURL, shareAmount, maxCost, lightningAddress)`.
+5. **Tolerance** — `maxCost = shareAmount + (shareAmount * tolerancePercent / 100)`.
+
+### Configuration
 
 ```json
 {
-  "accepted_mints": [
-    {
-      "url": "https://mint.example.com",
-      "price_per_step": 100,
-      "price_unit": "sat",
-      "min_purchase_steps": 10,
-      "min_payout_amount": 5000,
-      "min_balance": 1000,
-      "balance_tolerance_percent": 10
-    }
-  ],
+  "accepted_mints": [{
+    "min_payout_amount": 128,
+    "min_balance": 64,
+    "balance_tolerance_percent": 10
+  }],
   "profit_share": [
-    {
-      "identity": "owner",
-      "factor": 1.0
-    }
+    { "factor": 0.79, "identity": "owner" },
+    { "factor": 0.21, "identity": "developer" }
   ]
 }
 ```
 
-**Key Parameters**:
-- `accepted_mints`: Mints the wallet can use
-- `min_payout_amount`: Minimum balance before payout
-- `min_balance`: Minimum balance to maintain after payout
-- `balance_tolerance_percent`: Overpayment tolerance for melting
+- `min_payout_amount` — minimum balance before any payout is attempted (per mint).
+- `min_balance` — minimum balance to retain after payout.
+- `balance_tolerance_percent` — overpayment tolerance for melt operations (Lightning
+  routing fees).
+- `profit_share[].factor` — share of payout for each recipient. Should sum to 1.0.
+- `profit_share[].identity` — maps to an entry in `identities.json` with a
+  `lightning_address` field.
 
-### Payout Timing
+### Payout Interval
 
-**Current**: Hardcoded 1 minute interval per mint
-
-**Location**: `merchant.go` in `StartPayoutRoutine()`
+Hardcoded at 1 minute per mint:
 
 ```go
 ticker := time.NewTicker(1 * time.Minute)
 ```
 
-**Recommendation**: Make configurable
+### Degraded Mode Behavior
 
----
+In degraded mode, `StartPayoutRoutine()` is a no-op. No payout goroutines are started.
+After upgrade, the new full merchant starts its own payout routines.
 
-## Technical Implementation Details
+## Data Usage Monitoring
 
-### Key Functions
+The data usage monitoring routine checks active data-based sessions every 2 seconds and
+closes the gate when allotment is reached. It only runs on a full `Merchant` —
+`MerchantDegraded.StartDataUsageMonitoring()` is a no-op.
 
-#### CreatePaymentToken()
+### Flow
+
+1. Every 2 seconds, iterate all sessions with `metric == "bytes"`.
+2. For each session, check if a data baseline exists (gate is open).
+3. `valve.GetDataUsageSinceBaseline(mac)` returns bytes consumed since gate opened.
+4. If `usage >= allotment`:
+   - `valve.CloseGate(mac)` deauthorizes the MAC via ndsctl.
+   - Remove the session from the map.
+5. Otherwise, log progress periodically (~every 10 MB).
+
+### Degraded Mode Behavior
+
+In degraded mode, `StartDataUsageMonitoring()` is a no-op. No monitoring goroutine is
+started. After upgrade, the new full merchant starts its own monitoring routine.
+
+## Payment Processing (PurchaseSession)
+
+`PurchaseSession()` is the main customer-facing operation. It processes a Cashu payment
+and grants network access.
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant M as Merchant
+    participant TW as TollWallet
+    participant V as Valve (ndsctl)
+    participant MINT as Cashu Mint
+
+    Client->>M: PurchaseSession(cashuToken, macAddress)
+    M->>M: Validate MAC address
+    M->>M: Decode Cashu token
+    M->>TW: Receive(token)
+    TW->>MINT: Swap proofs (verify not spent)
+    MINT-->>TW: New proofs
+    TW-->>M: amountReceived
+
+    M->>M: calculateAllotment(amount, mintURL)
+    Note over M: steps = amount / price_per_step<br/>allotment = steps * step_size
+
+    M->>M: grantSessionAccess(mac, allotment)
+    M->>V: OpenGate(mac)
+    V->>V: ndsctl auth mac
+    V-->>M: Success
+
+    M->>M: createSessionEvent(session, mac)
+    M-->>Client: nostr Event (kind 1022)
+```
+
+### Allotment Calculation
+
+1. `steps = amountSats / pricePerStep`
+2. Check `steps >= minPurchaseSteps` (minimum purchase requirement).
+3. Based on configured metric:
+   - `"milliseconds"`: `allotment = steps * stepSize`
+   - `"bytes"`: `allotment = steps * stepSize`
+
+### Session Management
+
+Sessions are stored in-memory (`map[string]*CustomerSession`). Each session tracks:
+- `MacAddress` — device identifier.
+- `StartTime` — Unix timestamp when session was created/extended.
+- `Metric` — `"milliseconds"` or `"bytes"`.
+- `Allotment` — total allotment for this session.
+
+`AddAllotment()` extends an existing session or creates a new one. For existing sessions,
+the allotment is added and the start time is reset to now.
+
+`GetSession()` returns the session or an error if not found. For time-based sessions, it
+checks if the allotment has been exceeded and auto-expires the session.
+
+`GetUsage()` returns a string `"usage/allotment"` for display. For data sessions, it
+queries `valve.GetDataUsageSinceBaseline()`. For time sessions, it calculates elapsed
+milliseconds since session start.
+
+### Error Handling
+
+`PurchaseSession()` returns Nostr events (not Go errors) for user-facing errors:
+- Invalid MAC address → kind 21023 notice with code `"invalid-mac-address"`.
+- Invalid token → kind 21023 notice with code `"payment-error-invalid-token"`.
+- Already-spent token → kind 21023 notice with code `"payment-error-token-spent"`.
+- Receive failure → kind 21023 notice with code `"payment-processing-failed"`.
+- Gate open failure → kind 21023 notice with code `"gate-open-failed"`.
+
+## Wallet Operations
+
+### CreatePaymentToken
+
 ```go
 func (m *Merchant) CreatePaymentToken(mintURL string, amount uint64) (string, error)
 ```
 
-**Purpose**: Create Cashu token for upstream payment
+Creates a Cashu token for upstream payment. Checks balance, calls
+`tollwallet.Send()`, serializes the token.
 
-**Call Path**:
-```
-CreatePaymentToken()
-  → tollwallet.GetBalanceByMint()
-  → tollwallet.CreateToken()
-    → Select proofs
-    → Create token string
-  → Return token
-```
+### CreatePaymentTokenWithOverpayment
 
-**Error Conditions**:
-- Insufficient balance
-- Mint not available
-- Token creation failure
-
-#### GetBalanceByMint()
 ```go
-func (m *Merchant) GetBalanceByMint(mintURL string) uint64
+func (m *Merchant) CreatePaymentTokenWithOverpayment(mintURL string, amount uint64, maxOverpaymentPercent uint64, maxOverpaymentAbsolute uint64) (string, error)
 ```
 
-**Purpose**: Get current balance for specific mint
+Creates a payment token with overpayment tolerance. Used when exact amounts are
+unavailable and the caller can accept slight overpayment.
 
-**Call Path**:
-```
-GetBalanceByMint()
-  → tollwallet.GetBalanceByMint()
-    → Sum unspent proofs
-  → Return balance
-```
+### DrainMint
 
-**Note**: Read-only, no state changes
-
-#### StartPayoutRoutine()
 ```go
-func (m *Merchant) StartPayoutRoutine()
+func (m *Merchant) DrainMint(mintURL string) (string, uint64, error)
 ```
 
-**Purpose**: Start automatic payout goroutines
+Drains all available balance from a specific mint. Unlike `CreatePaymentToken`, this does
+not include fees — it extracts the full balance. Used for wallet migration or
+administrative purposes.
 
-**Call Path**:
-```
-StartPayoutRoutine()
-  → For each mint:
-    → go payoutRoutine()
-      → ticker.Tick (1 minute)
-        → processPayout()
-          → GetBalanceByMint()
-          → Calculate payout
-          → MeltToLightning()
-```
+### Fund
 
-**Runs**: Continuously in background goroutines
-
-#### processPayout()
 ```go
-func (m *Merchant) processPayout(mintConfig config_manager.MintConfig)
+func (m *Merchant) Fund(cashuToken string) (uint64, error)
 ```
 
-**Purpose**: Process payout for single mint
+Receives a Cashu token into the wallet. Decodes the token, calls
+`tollwallet.Receive()`, and returns the amount received.
 
-**Operations**:
-1. Get current balance
-2. Check minimum payout threshold
-3. Calculate payout amount
-4. For each profit share:
-   - Calculate share amount
-   - Get Lightning address
-   - Melt to Lightning
-5. Log completion
+## Edge Cases
 
-### Data Structures
+### Race Condition Between Payout and Payment
 
-#### MintConfig
-```go
-type MintConfig struct {
-    URL                      string
-    PricePerStep             uint64
-    PriceUnit                string
-    MinPurchaseSteps         uint64
-    MinPayoutAmount          uint64
-    MinBalance               uint64
-    BalanceTolerancePercent  uint64
+**Scenario**: Payout routine drains wallet while a customer payment is being processed.
+
+**Root Cause**: No locking or fund reservation between balance check and token creation.
+
+```
+1. USM checks balance: 10000 sats (sufficient)
+2. Payout routine melts 9000 sats to Lightning
+3. USM tries to create 5000 sat token → fails: insufficient balance
+```
+
+**Current Mitigation**: None. The `min_balance` parameter reduces but does not eliminate
+this window.
+
+**Potential Fixes**:
+1. Fund reservation system (reserve funds for 30s before payout can touch them).
+2. Mutex around balance + token creation operations.
+3. Payout coordination (skip payout if active sessions need the mint).
+
+### BoltDB Lock During Upgrade
+
+When upgrading from degraded to full, the degraded merchant has no wallet and thus no
+BoltDB lock. The new full merchant opens the wallet fresh. There is no lock contention.
+However, if the old merchant had been a full merchant that was downgraded mid-operation,
+the old BoltDB file would need to be cleanly closed first. The current code does not
+call `Shutdown()` on the old merchant during upgrade.
+
+### Wallet Drain in Degraded Mode
+
+There is no guardrail preventing the wallet from being fully drained during degraded
+mode if `CreatePaymentTokenWithOverpayment()` were called with large overpayment
+tolerances. In practice this is mitigated by the degraded merchant returning
+`errDegraded` for all token operations, but if a future change allows limited offline
+spending, this could become an issue. See
+[follow-up issue #29](https://github.com/Amperstrand/tollgate-module-basic-go/issues/29).
+
+### Health Tracker Callbacks on Timer Goroutine
+
+`onFirstReachable` and `onReachableSetChanged` fire on the timer goroutine. If
+`onFirstReachable` performs heavy work (e.g., `merchant.New()` which does wallet loading
+and network I/O), the timer goroutine blocks until recovery completes. This prevents
+subsequent proactive checks. Acceptable today because the callback is one-shot and the
+probe interval is 5 minutes.
+
+### RunInitialProbe Thread Safety
+
+`RunInitialProbe()` is not thread-safe — it modifies internal state without holding the
+mutex. It must be called before `Start()`. Currently safe because `init()` calls
+`RunInitialProbe() → SetOnFirstReachable() → Start()` in strict sequence.
+
+### Shutdown Gap
+
+`Merchant.Shutdown()` cleanly stops the wallet DB, but is not wired into any signal
+handler or defer. On process exit, the wallet DB may not get a clean shutdown. Adding a
+SIGTERM/SIGINT handler that calls `Shutdown()` on the current merchant (obtained via
+`MerchantProvider`) should be a follow-up.
+
+## Known Follow-Ups
+
+Filed on [Amperstrand/tollgate-module-basic-go](https://github.com/Amperstrand/tollgate-module-basic-go):
+
+| Issue | Title | Description |
+|---|---|---|
+| [#26](https://github.com/Amperstrand/tollgate-module-basic-go/issues/26) | 1-failure downgrade may cause flapping | Consider sliding window or increased threshold instead of immediate downgrade on single probe failure. |
+| [#27](https://github.com/Amperstrand/tollgate-module-basic-go/issues/27) | `PayoutShare()` calls `MarkUnreachable()` on non-connectivity errors | Scope to transport errors only — a 4xx response should not mark a mint unreachable. |
+| [#28](https://github.com/Amperstrand/tollgate-module-basic-go/issues/28) | Degraded mode returns kind 21023 instead of 10021 | May break clients expecting the standard advertisement kind. |
+| [#29](https://github.com/Amperstrand/tollgate-module-basic-go/issues/29) | Offline wallet spending has no drain guardrail | Add reserve floor, max offline spend per outage window. |
+
+## Configuration
+
+### Merchant Config (Relevant Fields)
+
+```json
+{
+  "metric": "bytes",
+  "step_size": 22020096,
+  "margin": 0.1,
+  "accepted_mints": [
+    {
+      "url": "https://mint.coinos.io",
+      "price_per_step": 1,
+      "price_unit": "sats",
+      "purchase_min_steps": 0,
+      "min_payout_amount": 128,
+      "min_balance": 64,
+      "balance_tolerance_percent": 10,
+      "payout_interval_seconds": 60
+    }
+  ],
+  "profit_share": [
+    { "factor": 0.79, "identity": "owner" },
+    { "factor": 0.21, "identity": "developer" }
+  ]
 }
 ```
 
-#### ProfitShare
-```go
-type ProfitShare struct {
-    Identity string  // Identity name in identities.json
-    Factor   float64 // Percentage of profits (0.0-1.0)
-}
+| Field | Location | Description |
+|---|---|---|
+| `metric` | Top-level | `"bytes"` for data-based, `"milliseconds"` for time-based sessions. |
+| `step_size` | Top-level | Units per step (bytes or ms). |
+| `margin` | Top-level | Margin applied to pricing. |
+| `accepted_mints[].url` | Per-mint | Cashu mint URL. |
+| `accepted_mints[].price_per_step` | Per-mint | Satoshis per step. |
+| `accepted_mints[].purchase_min_steps` | Per-mint | Minimum number of steps per purchase. |
+| `accepted_mints[].min_payout_amount` | Per-mint | Minimum balance before payout triggers. |
+| `accepted_mints[].min_balance` | Per-mint | Minimum balance to retain after payout. |
+| `accepted_mints[].balance_tolerance_percent` | Per-mint | Overpayment tolerance for melt operations (%). |
+| `accepted_mints[].payout_interval_seconds` | Per-mint | Interval between payout checks (currently hardcoded to 60s). |
+| `profit_share[].factor` | Per-recipient | Share of payout (0.0-1.0, should sum to 1.0). |
+| `profit_share[].identity` | Per-recipient | Identity name in `identities.json` with `lightning_address`. |
+
+### Health Tracker Constants (Hardcoded)
+
+| Constant | Value | Description |
+|---|---|---|
+| `probeInterval` | 5 minutes | Time between background probe cycles. |
+| `probeTimeout` | 5 seconds | HTTP timeout for each probe. |
+| `requiredConsecutive` | 3 | Consecutive successes needed to mark a mint reachable. |
+
+## Integration with Other Components
+
+### Relationship with UpstreamSessionManager
+
+The USM uses the merchant as a wallet provider for upstream TollGate payments:
+
+```
+USM needs to pay upstream TollGate
+  → merchantProvider.GetMerchant()
+  → merchant.CreatePaymentTokenWithOverpayment()
+  → Cashu token created and sent upstream
 ```
 
-### Wallet Operations
+The USM holds a `MerchantProvider` (from the `merchant_types` package), not a direct
+`MerchantInterface`. This decouples the USM from the full `merchant` package.
 
-**Balance Check**:
-```go
-balance := merchant.GetBalanceByMint(mintURL)
+### Relationship with TollWallet
+
+The full `Merchant` wraps a `TollWallet` instance for all Cashu operations:
+
+- `tollwallet.Send()` / `SendWithOverpayment()` — create payment tokens.
+- `tollwallet.Receive()` — receive tokens into wallet.
+- `tollwallet.MeltToLightning()` — pay to Lightning addresses.
+- `tollwallet.GetBalance()` / `GetBalanceByMint()` — query balances.
+- `tollwallet.Drain()` — drain all balance from a mint.
+
+The `MerchantDegraded` has no `TollWallet` instance.
+
+### Relationship with ConfigManager
+
+Both `Merchant` and `MerchantDegraded` hold a reference to `ConfigManager` for:
+- Configuration access (`GetConfig()` — mints, pricing, profit share).
+- Identity resolution (`GetIdentities()` — merchant private key, Lightning addresses).
+
+### Relationship with Valve
+
+The full `Merchant` uses the `valve` package for gate operations:
+- `valve.OpenGate(mac)` — authorize a MAC via ndsctl.
+- `valve.CloseGate(mac)` — deauthorize a MAC.
+- `valve.GetDataUsageSinceBaseline(mac)` — get bytes consumed.
+- `valve.HasDataBaseline(mac)` — check if gate is open.
+
+## Debugging
+
+### Check Merchant Mode
+
+```bash
+# Boot logs show which mode was selected
+logread | grep -E "(DEGRADED|Merchant ready)"
+# "Merchant starting in DEGRADED mode" = degraded
+# "=== Merchant ready ===" = full
 ```
 
-**Token Creation**:
-```go
-token, err := merchant.CreatePaymentToken(mintURL, amount)
+### Check Health Tracker State
+
+```bash
+# Health tracker logs reachability transitions
+logread | grep "MintHealthTracker"
+# "mint X became reachable" = recovery
+# "mint X became unreachable" = downgrade
 ```
 
-**Payout**:
-```go
-err := tollwallet.MeltToLightning(mintURL, amount, maxCost, lightningAddress)
+### Check Upgrade Events
+
+```bash
+# Upgrade from degraded to full
+logread | grep -E "(upgraded|recovery|degraded)"
+# "Mint became reachable — attempting to upgrade from degraded mode"
+# "Upgraded from degraded to full merchant"
 ```
 
-### Coordination Points
+### Check Payout Status
 
-**Critical Sections** (need protection):
-1. Balance check + token creation
-2. Payout calculation + execution
-3. Token reception + balance update
+```bash
+logread | grep -E "(payout|Skipping payout|Payout completed)"
+```
 
-**Current Protection**: None (race conditions possible)
+### Check Session Status
 
-**Recommended Protection**: Mutex or reservation system
+```bash
+# Via CLI
+tollgate status
+
+# Via logs
+logread | grep -E "(session|allotment|gate)"
+```

--- a/docs/protocol/HTTP-01.md
+++ b/docs/protocol/HTTP-01.md
@@ -1,4 +1,4 @@
-# HTTP-01 - Http server
+# TIP-03 (HTTP-01) - Http server
 
 ---
 

--- a/docs/protocol/HTTP-02.md
+++ b/docs/protocol/HTTP-02.md
@@ -1,4 +1,4 @@
-# HTTP-02 - Restrictive OS compatibility
+# TIP-04 (HTTP-02) - Restrictive OS compatibility
 
 ---
 

--- a/docs/protocol/HTTP-03.md
+++ b/docs/protocol/HTTP-03.md
@@ -1,4 +1,4 @@
-# HTTP-03 - Usage endpoint
+# TIP-11 (HTTP-03) - Usage endpoint
 
 ---
 

--- a/docs/protocol/NOSTR-01.md
+++ b/docs/protocol/NOSTR-01.md
@@ -1,4 +1,4 @@
-# NOSTR-01 - Nostr Relay
+# TIP-06 (NOSTR-01) - Nostr Relay
 
 ---
 

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -39,29 +39,31 @@ The TollGate protocol is organized into three layers. A working TollGate combine
 
 The abstract data model. Event kinds, tag structures, payment asset definitions, session semantics. Protocol specs never mention how messages are delivered — only what they contain.
 
-| # | Description |
-|---|-------------|
-| [TIP-01](TIP-01.md) | Base Events (Advertisement, Session, Notice) |
-| [TIP-02](TIP-02.md) | Cashu payments |
+| TIP | Upstream name | Description |
+|-----|---------------|-------------|
+| [TIP-01](TIP-01.md) | — | Base Events (Advertisement, Session, Notice) |
+| [TIP-02](TIP-02.md) | — | Cashu payments |
 
 ### Interface — *how* do customer and TollGate talk?
 
 The communication method used for negotiation (advertisement, payment, session management) between customer and TollGate. An interface runs over a medium, but the relationship is not 1:1. A single medium can support multiple interfaces — an Ethernet link can carry HTTP requests, Nostr relay messages, or raw UDP packets. And a single interface (like HTTP) can run over different media.
 
-| # | Description |
-|---|-------------|
-| [HTTP-01](HTTP-01.md) | HTTP server |
-| [HTTP-02](HTTP-02.md) | Restrictive OS compatibility |
-| [HTTP-03](HTTP-03.md) | Usage endpoint |
-| [NOSTR-01](NOSTR-01.md) | Nostr relay |
+| TIP | Upstream name | Description |
+|-----|---------------|-------------|
+| [TIP-03](HTTP-01.md) | HTTP-01 | HTTP server |
+| [TIP-04](HTTP-02.md) | HTTP-02 | Restrictive OS compatibility |
+| [TIP-11](HTTP-03.md) | HTTP-03 | Usage endpoint |
+| [TIP-06](NOSTR-01.md) | NOSTR-01 | Nostr relay |
 
 ### Medium — *what physical link* carries the sold data?
 
 The physical or link-layer technology over which the TollGate sells connectivity. A medium may constrain which interfaces are available, but the medium itself is not the interface.
 
-| # | Description |
-|---|-------------|
-| [WIFI-01](WIFI-01.md) | Discovery through Beacon Frames |
+| TIP | Upstream name | Description |
+|-----|---------------|-------------|
+| [TIP-10](WIFI-01.md) | WIFI-01 | Discovery through Beacon Frames |
+
+> **Naming note**: Specs were originally numbered as TIPs (TollGate Improvement Proposals). The upstream spec repo (`OpenTollGate/tollgate`) introduced categorized names (HTTP-01, NOSTR-01, etc.) in March 2026. Implementations still advertise TIP numbers in the `tips` discovery tag. This index uses TIP numbers as the primary identifier with upstream names as aliases.
 
 ---
 

--- a/docs/protocol/WIFI-01.md
+++ b/docs/protocol/WIFI-01.md
@@ -1,4 +1,4 @@
-# WIFI-01 - Beacon Frame Advertisement
+# TIP-10 (WIFI-01) - Beacon Frame Advertisement
 
 ---
 - RESERVED: advertise tollgate in WIFI beaconframe

--- a/docs/protocol/transport-layer-distinction.md
+++ b/docs/protocol/transport-layer-distinction.md
@@ -46,7 +46,7 @@ Important: the interface used for negotiation does not have to run over the same
 │  Event kinds, tags, payment assets           │
 ├─────────────────────────────────────────────┤
 │  Interface                                  │
-│  (TIP-03, TIP-06, future BLE/UDP TIPs)      │
+│  (HTTP-01, NOSTR-01, future BLE/UDP)         │
 │  How messages are sent/received              │
 ├─────────────────────────────────────────────┤
 │  Medium                                     │
@@ -64,12 +64,12 @@ A TollGate implementation picks:
 
 | Scenario | Medium (sold) | Interface (negotiation) | In-band? |
 |----------|---------------|------------------------|----------|
-| WiFi hotspot with captive portal | WiFi | HTTP server (TIP-03) | Yes |
-| WiFi hotspot with relay | WiFi | Nostr relay (TIP-06) | No (relay is on the internet) |
+| WiFi hotspot with captive portal | WiFi | HTTP server (HTTP-01) | Yes |
+| WiFi hotspot with relay | WiFi | Nostr relay (NOSTR-01) | No (relay is on the internet) |
 | WiFi hotspot with both | WiFi | HTTP + Nostr relay | Mixed |
 | BLE-tethered internet | Bluetooth | BLE GATT | Yes |
 | LoRa mesh node | LoRa | Raw UDP or custom | Yes |
-| Ethernet port at a café | Ethernet | HTTP server (TIP-03) | Yes |
+| Ethernet port at a café | Ethernet | HTTP server (HTTP-01) | Yes |
 
 ## In-band vs out-of-band
 
@@ -88,22 +88,24 @@ In-band interfaces have a device identification advantage — the TollGate can d
 | Term | Meaning | TIP examples |
 |------|---------|-------------|
 | **Protocol** | Data model and semantics | TIP-01 (events), TIP-02 (Cashu) |
-| **Interface** | Negotiation method between customer and TollGate | TIP-03 (HTTP), TIP-06 (Nostr relay) |
-| **Medium** | Physical link over which data is sold | Not currently TIP-scoped |
+| **Interface** | Negotiation method between customer and TollGate | HTTP-01 (HTTP server), HTTP-02 (/whoami), NOSTR-01 (Nostr relay) |
+| **Medium** | Physical link over which data is sold | WIFI-01 (beacon frames) |
 
 The word "transport" is ambiguous — it could mean the physical medium or the interface. TIPs should avoid it in favor of the specific term.
 
 ## Mapping current TIPs
 
-| TIP | Layer | Description |
-|-----|-------|-------------|
-| 01  | Protocol | Base events (Discovery, Session, Notice) |
-| 02  | Protocol | Cashu payment asset |
-| 03  | Interface | HTTP server |
-| 04  | Interface | HTTP `/whoami` (extends TIP-03) |
-| 05  | Protocol | Encrypted events (reserved) |
-| 06  | Interface | Nostr relay |
-| 10  | Interface | Beacon frame advertisement |
+| TIP | Upstream name | Layer | Description |
+|-----|---------------|-------|-------------|
+| 01  | — | Protocol | Base events (Discovery, Session, Notice) |
+| 02  | — | Protocol | Cashu payment asset |
+| 03  | HTTP-01 | Interface | HTTP server |
+| 04  | HTTP-02 | Interface | HTTP `/whoami` (extends HTTP-01) |
+| 11  | HTTP-03 | Interface | HTTP `/usage` endpoint |
+| 06  | NOSTR-01 | Interface | Nostr relay |
+| 10  | WIFI-01 | Medium | Beacon frame advertisement |
+
+> **Naming note**: Specs were originally numbered as TIPs. The upstream spec repo introduced categorized names in March 2026. This table uses TIP numbers as primary identifiers with upstream names as aliases.
 
 ## What each Interface TIP must define
 
@@ -117,7 +119,7 @@ An Interface TIP is responsible for specifying:
 ## Open questions
 
 - Should TIPs explicitly label themselves `protocol` or `interface` in their header metadata?
-- Should TIP-04 (`/whoami`) fold into TIP-03 as an HTTP interface detail?
-- Does TIP-10 (beacon frames) belong to Interface or is it a discovery-only mechanism that crosses layers?
+- Should HTTP-02 (`/whoami`) fold into HTTP-01 as an HTTP interface detail?
+- Does WIFI-01 (beacon frames) belong to Interface or is it a discovery-only mechanism that crosses layers?
 - Should there be Medium TIPs, or is the medium always implicit / out of scope?
 - How to handle the bootstrapping problem for out-of-band interfaces?

--- a/docs/upstream_session_manager.md
+++ b/docs/upstream_session_manager.md
@@ -12,6 +12,20 @@ The `upstream_session_manager` module manages upstream TollGate sessions on beha
 - Manage session lifecycle (active, paused, expired)
 - Coordinate with [`merchant`](merchant.md) for wallet operations
 
+## Merchant Provider Indirection
+
+The USM does **NOT** hold a direct reference to a `Merchant` or `MerchantInterface`. Instead, it holds a `merchant.MerchantProvider` — a zero-dependency interface (from the `merchant_types` package, introduced in [PR #138](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/138)) with `GetMerchant()` and `SetMerchant()` methods.
+
+**Why the indirection exists**: The merchant can be in one of two states at runtime — a fully functional `Merchant` with live mint connections, or a `MerchantDegraded` that keeps the HTTP API alive but returns errors for wallet operations. The provider enables the degraded-mode lifecycle: when mints are unreachable at boot, a degraded merchant is created; when mints recover, the provider atomically swaps in a full merchant. This swap is transparent to the USM — no restart, no code changes, no session interruption.
+
+**How it works in practice**:
+- `main.go` creates a `MutexMerchantProvider` (RWMutex-protected) and passes it to `NewUpstreamSessionManager()`
+- Every time the USM needs to create a payment token or check a balance, it calls `merchantProvider.GetMerchant()` to resolve the current merchant
+- During degraded mode, `GetMerchant()` returns a `MerchantDegraded` — `CreatePaymentToken()` returns an error, so upstream session creation fails gracefully
+- When the health tracker detects a reachable mint, the provider swaps in a full `Merchant` via `SetMerchant()` — the next `GetMerchant()` call returns the new instance
+
+**References**: [PR #138](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/138) (merchant_types package), [PR #139](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/139) (USM decoupling), [PR #140](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/140) (degraded mode).
+
 ## Cross-component flow
 
 This section gives the end-to-end picture of how an upstream connection
@@ -26,7 +40,7 @@ zooms into `upstream_session_manager`'s internals.
 | **wireless_gateway_manager** | WiFi network scanning and connection | Scans for and connects to upstream TollGate WiFi networks (reseller mode) |
 | **upstream_detector** | Network change detection and TollGate discovery | Detects new network connections and probes gateways for TollGate advertisements |
 | **upstream_session_manager** | Upstream session management | Creates and maintains payment sessions with upstream TollGates |
-| **merchant** | Wallet and payment provider | Provides wallet functionality for upstream_session_manager to make upstream payments |
+| **merchant** | Wallet and payment provider, accessed via MerchantProvider for dynamic degraded-to-full transitions | Provides wallet functionality for upstream_session_manager to make upstream payments |
 
 ### Component interaction map
 
@@ -35,7 +49,7 @@ graph TB
     WGM[wireless_gateway_manager]
     CS[upstream_detector]
     CH[upstream_session_manager]
-    MR[merchant]
+    MP[MerchantProvider]
     NL[Netlink Events]
     GW[Upstream Gateway]
 
@@ -45,14 +59,14 @@ graph TB
     CS -->|Probes :2121| GW
     GW -->|Advertisement| CS
     CS -->|HandleUpstreamTollgate| CH
-    CH -->|CreatePaymentToken| MR
+    CH -->|GetMerchant → CreatePaymentToken| MP
     CH -->|POST payment| GW
     GW -->|Session event| CH
 
     style WGM fill:#e1f5ff
     style CS fill:#fff4e1
     style CH fill:#ffe1f5
-    style MR fill:#e1ffe1
+    style MP fill:#e1ffe1
 ```
 
 ### Sequence: WiFi connection to session creation
@@ -64,7 +78,7 @@ sequenceDiagram
     participant CS as upstream_detector
     participant GW as Upstream Gateway
     participant CH as upstream_session_manager
-    participant MR as merchant
+    participant MP as MerchantProvider
 
     Note over WGM: Reseller Mode Enabled
     WGM->>WGM: Periodic scan (30s)
@@ -91,8 +105,8 @@ sequenceDiagram
     CH->>CH: Check trust policy
     CH->>CH: Select pricing option
     CH->>CH: Calculate payment steps
-    CH->>MR: CreatePaymentToken()
-    MR-->>CH: Cashu token
+    CH->>MP: GetMerchant() → CreatePaymentToken()
+    MP-->>CH: Cashu token
     CH->>CH: Create payment event (kind 21000)
     CH->>GW: POST payment to :2121/
     GW-->>CH: Session event (kind 1022)
@@ -112,7 +126,7 @@ sequenceDiagram
     participant CS as upstream_detector
     participant GW as Upstream Gateway
     participant CH as upstream_session_manager
-    participant MR as merchant
+    participant MP as MerchantProvider
 
     Cable->>OS: Physical connection
     OS->>CS: InterfaceUp event (eth0, netlink)
@@ -126,8 +140,8 @@ sequenceDiagram
     Note over CH: Session Creation (same as WiFi)
     CH->>CH: Check trust policy
     CH->>CH: Select pricing option
-    CH->>MR: CreatePaymentToken()
-    MR-->>CH: Cashu token
+    CH->>MP: GetMerchant() → CreatePaymentToken()
+    MP-->>CH: Cashu token
     CH->>GW: POST payment to :2121/
     GW-->>CH: Session event (kind 1022)
     CH->>CH: Start usage tracker
@@ -140,7 +154,7 @@ sequenceDiagram
     participant UT as UsageTracker
     participant GW as Upstream Gateway
     participant CH as upstream_session_manager
-    participant MR as merchant
+    participant MP as MerchantProvider
 
     Note over UT: Monitoring usage (every 1s for data)
     UT->>GW: GET :2121/usage
@@ -152,8 +166,8 @@ sequenceDiagram
         UT->>CH: HandleUpcomingRenewal()
         CH->>CH: Check budget constraints
         CH->>CH: Create renewal proposal
-        CH->>MR: CreatePaymentToken()
-        MR-->>CH: Cashu token
+        CH->>MP: GetMerchant() → CreatePaymentToken()
+        MP-->>CH: Cashu token
         CH->>CH: Create payment event
         CH->>GW: POST renewal payment
         GW-->>CH: Updated session event
@@ -176,7 +190,7 @@ graph TB
     
     subgraph External
         CS[upstream_detector]
-        MR[merchant]
+        MP[MerchantProvider]
         GW[Upstream Gateway]
         CFG[ConfigManager]
     end
@@ -185,8 +199,8 @@ graph TB
     CS -->|HandleDisconnect| CH
     CH -->|Check trust| CFG
     CH -->|Check budget| CFG
-    CH -->|CreatePaymentToken| MR
-    CH -->|GetBalanceByMint| MR
+    CH -->|GetMerchant → CreatePaymentToken| MP
+    CH -->|GetMerchant → GetBalanceByMint| MP
     CH -->|POST payment| GW
     GW -->|Session event| CH
     CH -->|Store session| SM
@@ -199,6 +213,8 @@ graph TB
     style PD fill:#fff4e1
     style UT fill:#e1ffe1
 ```
+
+> **Note**: The USM does not hold a direct reference to a `Merchant`. It holds a `MerchantProvider` and calls `GetMerchant()` at operation time to resolve the current merchant instance. This enables transparent degraded-to-full merchant swaps without restarting the USM.
 
 ## Behavioral Flow Descriptions
 
@@ -457,7 +473,7 @@ sequenceDiagram
     participant CS as upstream_detector
     participant CH as upstream_session_manager
     participant CFG as ConfigManager
-    participant MR as merchant
+    participant MP as MerchantProvider
     participant GW as Upstream Gateway
     participant UT as UsageTracker
     
@@ -478,8 +494,8 @@ sequenceDiagram
         CH-->>CS: Error: No matching mints
     end
     
-    CH->>MR: GetBalanceByMint(mint_url)
-    MR-->>CH: Balance
+    CH->>MP: GetMerchant() → GetBalanceByMint(mint_url)
+    MP-->>CH: Balance
     
     alt Insufficient balance
         CH-->>CS: Error: Insufficient funds
@@ -495,8 +511,8 @@ sequenceDiagram
     end
     
     CH->>CH: Generate customer private key
-    CH->>MR: CreatePaymentToken(mint, amount)
-    MR-->>CH: Cashu token
+    CH->>MP: GetMerchant() → CreatePaymentToken(mint, amount)
+    MP-->>CH: Cashu token
     
     CH->>CH: Create payment event (kind 21000)
     CH->>GW: POST payment to :2121/
@@ -527,7 +543,7 @@ sequenceDiagram
     participant UT as UsageTracker
     participant CH as upstream_session_manager
     participant CFG as ConfigManager
-    participant MR as merchant
+    participant MP as MerchantProvider
     participant GW as Upstream Gateway
     
     Note over UT: Monitoring usage
@@ -549,8 +565,8 @@ sequenceDiagram
         CH-->>UT: Error: Budget exhausted
     end
     
-    CH->>MR: CreatePaymentToken(mint, amount)
-    MR-->>CH: Cashu token
+    CH->>MP: GetMerchant() → CreatePaymentToken(mint, amount)
+    MP-->>CH: Cashu token
     
     CH->>CH: Create payment event
     CH->>GW: POST renewal payment
@@ -604,12 +620,12 @@ sequenceDiagram
 
 ## Events Sent to Other Components
 
-### To Merchant
+### To Merchant (via MerchantProvider)
 
 | Event | Trigger | Data | Purpose |
 |-------|---------|------|---------|
-| `CreatePaymentToken()` | Payment needed | mint URL, amount | Get Cashu token for payment |
-| `GetBalanceByMint()` | Before payment | mint URL | Check available balance |
+| `GetMerchant() → CreatePaymentToken()` | Payment needed | mint URL, amount | Get Cashu token for payment |
+| `GetMerchant() → GetBalanceByMint()` | Before payment | mint URL | Check available balance |
 
 ### To Usage Tracker
 
@@ -749,6 +765,8 @@ func (c *UpstreamSessionManager) createPayment() error {
     // Create payment...
 }
 ```
+
+> **Note on MerchantProvider's RWMutex**: The `MerchantProvider`'s `RWMutex` protects the merchant *swap* itself (preventing reads of a half-initialized merchant during degraded-to-full transitions), but does **NOT** protect the balance-check-then-pay race described in this issue. That race is between concurrent wallet operations within the same merchant instance and requires its own synchronization (e.g., a wallet reservation system as shown above).
 
 ### Issue 3: Renewal Failure Handling
 
@@ -1185,20 +1203,31 @@ upstream_detector detects disconnect
 
 ### Relationship with Merchant
 
-**Connection**: Direct function calls (wallet provider)
+**Connection**: Indirect via `MerchantProvider` interface
+
+The USM does NOT hold a direct reference to a `Merchant` or `MerchantInterface`. It holds a `merchant.MerchantProvider` — an interface with `GetMerchant()` and `SetMerchant()` methods — injected at construction time. Each operation that needs wallet access calls `GetMerchant()` to resolve the current merchant instance.
 
 **Flow**:
 ```
 upstream_session_manager needs payment
+  → merchantProvider.GetMerchant()
+    → returns current merchant (full or degraded)
   → merchant.CreatePaymentToken()
-    → Cashu token returned
+    → Cashu token returned (or error if degraded)
 
 upstream_session_manager checks balance
+  → merchantProvider.GetMerchant()
+    → returns current merchant (full or degraded)
   → merchant.GetBalanceByMint()
     → Balance returned
 ```
 
-**Dependency**: Merchant must be initialized before upstream_session_manager
+**Degraded mode behavior**:
+- During degraded mode, `GetMerchant()` returns a `MerchantDegraded` whose `CreatePaymentToken()` returns an error, so upstream session creation fails gracefully
+- When mints recover, the provider atomically swaps in a full `Merchant` — no USM code changes or restarts required
+- The `MerchantProvider`'s RWMutex protects the swap itself (prevents reading a half-initialized merchant)
+
+**Dependency**: MerchantProvider must be initialized before upstream_session_manager. In `main.go`, a `MutexMerchantProvider` is created and passed to `NewUpstreamSessionManager()`.
 
 ### Relationship with Usage Trackers
 


### PR DESCRIPTION
## Why This Matters

PRs #138, #139, and #140 introduced a fundamentally new architecture — degraded mode, merchant health tracking, and dynamic upgrade/downgrade. **None of this was documented.** Without this PR, anyone reading the docs would have no idea that:

- The router can boot without mints and upgrade itself when they come back
- There is a MintHealthTracker with hysteresis and callbacks
- MerchantProvider is the new indirection layer between USM and the concrete merchant
- Sessions are lost on downgrade and what that means for customers

Additionally, protocol spec files used only the new upstream names (HTTP-01, NOSTR-01) without mentioning the TIP numbers that the code actually emits (`"tips": ["1","2","3","4"]`). This was confusing for anyone trying to correlate code ↔ docs.

**No source code changes.** Pure documentation.

---

## Commit 1: `docs: update documentation for degraded mode architecture`

| File | Change | Why |
|------|--------|-----|
| `CHANGELOG.md` | Entries for #138 (merchant_types), #139 (health tracker, provider, sentinel error), #140 (degraded mode) | Changelog must reflect what shipped |
| `README.md` | Degraded-mode boot + auto-recovery in feature highlights; merchant_types in module table; updated merchant description | First thing a new reader sees |
| `docs/merchant.md` | **Full rewrite** (757→857 lines). Covers MerchantDegraded, MintHealthTracker (hysteresis, callbacks), MutexMerchantProvider, the full boot→degraded→upgrade→full→downgrade lifecycle, edge cases. 4 mermaid diagrams. | The merchant module changed fundamentally (3 PRs, ~2000 lines of code) — old docs described a simple wallet provider |
| `docs/upstream_session_manager.md` | "Merchant Provider Indirection" section. All 6 sequence diagrams and 2 architecture diagrams updated for MerchantProvider. | USM no longer talks to merchant directly — goes through provider |
| `docs/data-session-management.md` | "Degraded Mode Caveat" — no-op behavior during degraded mode, session loss on downgrade | Operational gotcha: sessions are lost on downgrade, customers must re-authenticate |

## Commit 2: `docs: add dual TIP/upstream naming to protocol specs`

| File | Change |
|------|--------|
| `docs/protocol/HTTP-01.md` | Title: `HTTP-01` → `TIP-03 (HTTP-01)` |
| `docs/protocol/HTTP-02.md` | Title: `HTTP-02` → `TIP-04 (HTTP-02)` |
| `docs/protocol/HTTP-03.md` | Title: `HTTP-03` → `TIP-11 (HTTP-03)` |
| `docs/protocol/NOSTR-01.md` | Title: `NOSTR-01` → `TIP-06 (NOSTR-01)` |
| `docs/protocol/WIFI-01.md` | Title: `WIFI-01` → `TIP-10 (WIFI-01)` |
| `docs/protocol/README.md` | Index table now shows both TIP number and upstream name. Added naming note explaining the dual system. |
| `docs/protocol/transport-layer-distinction.md` | All references updated from old TIP-only to dual format. Added naming note. |

**Why**: The upstream spec repo renamed TIPs to categorized names in March 2026, but implementations still advertise TIP numbers on the wire. Docs need to bridge both naming systems.

---

## Merge Order

After #140 (already merged). No source code changes — can merge independently of #161, #162, #163.

## Follow-up Issues

Filed on Amperstrand/tollgate-module-basic-go:
- [#26](https://github.com/Amperstrand/tollgate-module-basic-go/issues/26) — 1-failure downgrade may cause flapping
- [#27](https://github.com/Amperstrand/tollgate-module-basic-go/issues/27) — `PayoutShare()` false `MarkUnreachable()` on non-connectivity errors
- [#28](https://github.com/Amperstrand/tollgate-module-basic-go/issues/28) — Degraded ad returns kind 21023 instead of 10021
- [#29](https://github.com/Amperstrand/tollgate-module-basic-go/issues/29) — Offline wallet spending has no drain guardrail