### PR TITLE
feat(config): split dev profit-share across three maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ The current schema version is **`v0.0.7`**. An abridged example:
   ],
   "profit_share": [
     { "factor": 0.79, "identity": "owner" },
-    { "factor": 0.21, "identity": "developer" }
+    { "factor": 0.07, "identity": "c08r4d0r" },
+    { "factor": 0.07, "identity": "amperstrand" },
+    { "factor": 0.07, "identity": "origami74" }
   ],
   "upstream_detector": {
     "probe_timeout": "10s",

--- a/docs/merchant.md
+++ b/docs/merchant.md
@@ -596,10 +596,10 @@ merchant initialization
     }
   ],
   "profit_share": [
-    {
-      "identity": "owner",
-      "factor": 1.0
-    }
+    { "identity": "owner", "factor": 0.79 },
+    { "identity": "c08r4d0r", "factor": 0.07 },
+    { "identity": "amperstrand", "factor": 0.07 },
+    { "identity": "origami74", "factor": 0.07 }
   ]
 }
 ```

--- a/src/config_manager/config_manager_config.go
+++ b/src/config_manager/config_manager_config.go
@@ -226,8 +226,16 @@ func NewDefaultConfig() *Config {
 				Identity: "owner",
 			},
 			{
-				Factor:   0.21,
-				Identity: "developer",
+				Factor:   0.07,
+				Identity: "c08r4d0r",
+			},
+			{
+				Factor:   0.07,
+				Identity: "amperstrand",
+			},
+			{
+				Factor:   0.07,
+				Identity: "origami74",
 			},
 		},
 		StepSize:     22020096, // 21 MiB

--- a/src/config_manager/config_manager_identities.go
+++ b/src/config_manager/config_manager_identities.go
@@ -43,9 +43,19 @@ func NewDefaultIdentitiesConfig() *IdentitiesConfig {
 		},
 		PublicIdentities: []PublicIdentity{
 			{
-				Name:             "developer",
+				Name:             "c08r4d0r",
 				PubKey:           "not currently used",
-				LightningAddress: "tollgate@minibits.cash",
+				LightningAddress: "c3e23eb5e3d00f18b2f4f588@coinos.io",
+			},
+			{
+				Name:             "amperstrand",
+				PubKey:           "not currently used",
+				LightningAddress: "f1cf0dbfae878ab4ff1a24fab1c6b2712a93ef8b5d8090fde6de738b1f62f16a@lnurl.psbt.me",
+			},
+			{
+				Name:             "origami74",
+				PubKey:           "not currently used",
+				LightningAddress: "iwillnot@getalby.com",
 			},
 			{
 				Name:             "owner",


### PR DESCRIPTION
## Why

The default dev split paid both the `developer` (0.21) and `owner` (0.79) identities to the shared `tollgate@minibits.cash` address. This splits the dev cut so each of the three maintainers is paid to their own Lightning address.

## Changes

| Identity | Factor | Lightning address |
|---|---|---|
| `owner` (operator) | 0.79 | `tollgate@minibits.cash` (unchanged) |
| `c08r4d0r` | 0.07 | `c3e23eb5e3d00f18b2f4f588@coinos.io` |
| `amperstrand` | 0.07 | `npub1pu45ulqgtwetysp2ng8w5xyak8e3gp2vh2a4c952l88csuxatqpqmfny5l@lnurl.psbt.me` |
| `origami74` | 0.07 | `iwillnot@getalby.com` |

Factors sum to **1.00** (0.79 + 0.07×3), satisfying `ValidateProfitShare`.

## Files
- `src/config_manager/config_manager_identities.go` — replace `developer` identity with the three maintainers (each with its `lightning_address`)
- `src/config_manager/config_manager_config.go` — default `profit_share` now owner + three maintainers
- `README.md` + `docs/merchant.md` — `profit_share` JSON examples updated

`c08r4d0r` is the post-rename handle for c03rad0r (per PR #92).

## Verification
- `go build ./...` and `go test ./src/config_manager/...` pass
- No remaining `"developer"` identity references in the tree