### PR TITLE
ci: skip build/publish pipeline for fork PRs

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -126,6 +126,12 @@ jobs:
 
   compile-binaries:
     needs: [determine-versioning]
+    # The publish pipeline (Blossom upload + Nostr publish) needs the NSEC_HEX
+    # secret, which GitHub withholds from fork PRs. Skip the whole pipeline for
+    # fork PRs so they don't go red on an empty NSEC_HEX; same-repo PRs and
+    # pushes run as normal. Downstream jobs (package-ipk/apk, publish-metadata,
+    # trigger-build-os) inherit this via `needs:`.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.blossom-upload.outputs.hashes }}


### PR DESCRIPTION
## Why

Fork PRs run with an **empty `NSEC_HEX`** secret (GitHub withholds secrets from forks), so `compile-binaries`' Blossom upload fails and the entire **Build and Publish** workflow goes red for every fork PR. This was the cause of the red CI on #163 (before it merged) and will recur on any future fork PR (Amperstrand / alexxie16 / Origami74).

## Change

Gate `compile-binaries` to skip for fork PRs:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

Because `package-ipk` / `package-apk` / `publish-metadata` / `trigger-build-os` all `needs:` `compile-binaries` (and none use `if: always`), the **entire publish pipeline is skipped** for fork PRs. `define-package-matrix` and `determine-versioning` still run (cheap, secret-free). Same-repo PRs and pushes are unaffected.

## Result
Fork PRs will show the publish jobs as **skipped** (gray) instead of **failed** (red); validation still runs via the `Test` and `Validate OpenWrt Feed` workflows.