### PR TITLE
fix: multi-mint wallet registration + always open gate for bytes sessions

### DIFF
--- a/src/merchant/lightning.go
+++ b/src/merchant/lightning.go
@@ -369,10 +369,12 @@ func openGateForSession(macAddress string, session *CustomerSession) error {
 			return fmt.Errorf("failed to open gate: %w", err)
 		}
 	case "bytes":
-		if !valve.HasDataBaseline(macAddress) {
-			if err := valve.OpenGate(macAddress); err != nil {
-				return fmt.Errorf("failed to open gate: %w", err)
-			}
+		// Always call OpenGate — ndsctl auth is idempotent.
+		// Previous code skipped this when a data baseline existed, but after
+		// a deauth the gate is closed while the baseline persists, causing
+		// Cashu payments to return success without actually opening the gate.
+		if err := valve.OpenGate(macAddress); err != nil {
+			return fmt.Errorf("failed to open gate: %w", err)
 		}
 	default:
 		return fmt.Errorf("unsupported metric: %s", session.Metric)

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/lightning"
 	"github.com/Origami74/gonuts-tollgate/cashu"
@@ -15,11 +16,12 @@ import (
 
 var ErrTokenAlreadySpent = errors.New("Token already spent")
 
-// TollWallet represents a Cashu wallet that can receive, swap, and send tokens
 type TollWallet struct {
 	wallet                     *wallet.Wallet
 	acceptedMints              []string
 	allowAndSwapUntrustedMints bool
+	registeredMints            map[string]bool
+	mu                         sync.Mutex
 }
 
 // New creates a new Cashu wallet instance
@@ -46,11 +48,58 @@ func New(walletPath string, acceptedMints []string, allowAndSwapUntrustedMints b
 		return nil, fmt.Errorf("failed to create wallet: %w", err)
 	}
 
-	return &TollWallet{
+	tw := &TollWallet{
 		wallet:                     cashuWallet,
 		acceptedMints:              acceptedMints,
 		allowAndSwapUntrustedMints: allowAndSwapUntrustedMints,
-	}, nil
+		registeredMints:            map[string]bool{normalizeMintURL(acceptedMints[0]): true},
+	}
+
+	for _, mintURL := range acceptedMints[1:] {
+		tw.registerMint(mintURL)
+	}
+
+	return tw, nil
+}
+
+func normalizeMintURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	return u.String()
+}
+
+func (w *TollWallet) registerMint(mintURL string) {
+	normalized := normalizeMintURL(mintURL)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.registeredMints[normalized] {
+		return
+	}
+
+	if _, err := w.wallet.AddMint(mintURL); err != nil {
+		log.Printf("TollWallet: failed to register mint %s: %v", mintURL, err)
+		return
+	}
+
+	w.registeredMints[normalized] = true
+	log.Printf("TollWallet: registered mint %s", mintURL)
+}
+
+func (w *TollWallet) ensureMintRegistered(mintURL string) {
+	normalized := normalizeMintURL(mintURL)
+
+	w.mu.Lock()
+	if w.registeredMints[normalized] {
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Unlock()
+
+	w.registerMint(mintURL)
 }
 
 func (w *TollWallet) Shutdown() error {
@@ -72,6 +121,8 @@ func (w *TollWallet) Receive(token cashu.Token) (uint64, error) {
 		}
 		swapToTrusted = true
 	}
+
+	w.ensureMintRegistered(mint)
 
 	amountAfterSwap, err := w.wallet.Receive(token, swapToTrusted)
 	if err != nil {
@@ -208,6 +259,7 @@ func (w *TollWallet) SendWithOverpayment(amount uint64, mintUrl string, maxOverp
 }
 
 func (w *TollWallet) RequestMintQuote(amount uint64, mintURL string) (*nut04.PostMintQuoteBolt11Response, error) {
+	w.ensureMintRegistered(mintURL)
 	return w.wallet.RequestMint(amount, mintURL)
 }
 


### PR DESCRIPTION
## Problem

Two bugs discovered during physical router testing (D-Link COVR-X1860, OpenWrt 24.10.2, nodogsplash 5.0.2).

### Bug 1: Only the first mint in config works

`tollwallet.New()` passes `acceptedMints[0]` as `CurrentMintURL` to `wallet.LoadWallet()`. The gonuts wallet supports multiple mints via `AddMint()`, but it was never called for the remaining mints. This causes `RequestMint()` (Lightning invoices) and `Receive()` (Cashu tokens) to fail with `"mint does not exist"` for any mint that isn't first in `accepted_mints`.

**Workaround used**: reorder `accepted_mints` in `config.json` to put the desired mint first. Fragile and confusing.

### Bug 2: Cashu payments return success but don't open the gate

`openGateForSession()` skips `OpenGate` when `valve.HasDataBaseline()` returns true, assuming the gate is already open. But after an `ndsctl deauth`, NDS closes the gate while the data baseline persists. Cashu payments return `kind=1022` (success) but the client stays `Preauthenticated` with no internet.

Lightning payments are unaffected because they're typically the first payment (no prior baseline exists).

## Fix

### Multi-mint (tollwallet.go)
- **Startup**: calls `AddMint()` for all accepted mints during initialization
- **Lazy fallback**: `ensureMintRegistered()` retries `AddMint` on demand if a mint wasn't reachable at startup (handles mints that become available after WiFi connects)
- Tracks registered mints in a `map[string]bool` to avoid redundant network calls
- Thread-safe via `sync.Mutex`

### Gate-open (lightning.go)
- Removes the `HasDataBaseline` check — always calls `OpenGate`
- `ndsctl auth` is idempotent; re-authenticating an already-authenticated client is harmless

## Testing Evidence

Both bugs were discovered and fixed during end-to-end testing on physical hardware (D-Link COVR-X1860 A1 router, Motorola moto g8 plus phone).

**Without Fix 1** (multi-mint):
```
POST /ln-invoice {"amount":5,"mint_url":"https://nofee.testnut.cashu.space"}
→ {"error":"mint does not exist"}

# mint.coinos.io worked because it was acceptedMints[0]
POST /ln-invoice {"amount":5,"mint_url":"https://mint.coinos.io"}
→ {"quote":"...","invoice":"lnbc..."}  (success)
```

**With Fix 1** (any mint works regardless of order):
```
POST /ln-invoice {"amount":5,"mint_url":"https://nofee.testnut.cashu.space"}
→ {"quote":"...","invoice":"lnbc..."}  (success)
```

**Without Fix 2** (gate stays closed):
```
POST / <cashu-token>
→ {"kind":1022}  (session event = success)

ndsctl clients | grep state
→ state=Preauthenticated  (gate never opened!)

ping 8.8.8.8
→ 100% packet loss
```

**With Fix 2** (gate opens correctly):
```
POST / <cashu-token>
→ {"kind":1022}

ndsctl clients | grep state
→ state=Authenticated

ping 8.8.8.8
→ 0% loss, 31ms RTT
```

**Full test sequence** (factory reset → install → verify):
1. ✅ Factory reset router (`firstboot`)
2. ✅ Install nodogsplash + tollgate-wrt from scratch
3. ✅ Lightning payment: invoice → FakeWallet instant pay → internet (0% loss)
4. ✅ Deauth → Cashu payment: token → gate opens → internet (0% loss, 31ms)
5. ✅ Reboot router → hotplug fires → mints probed → Merchant ready in 5s
6. ✅ Post-reboot Lightning: instant pay → internet (0% loss, 37ms)

## Files Changed

- `src/tollwallet/tollwallet.go` — multi-mint registration (startup + lazy)
- `src/merchant/lightning.go` — remove HasDataBaseline check in openGateForSession