### PR TITLE
fix(valve): retry ndsctl auth to harden two-router autopay gate-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ Changes on `main` since `v0.4.0` (tagged 2026-04-06).
   division-by-zero, prevent a `uint64` underflow in payout, and stop a stale
   valve timer callback from deleting its replacement
   ([#161](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/161)).
+- **Two-router autopay reliability:** retry `ndsctl auth` briefly in the valve
+  so a payment's gate-open no longer fails on the first attempt when NoDogSplash
+  has not yet registered the reseller client (previously failed with "failed to
+  open gate" and recovered only via the token-recovery path ~60–90s later).
 - **BOLT11 / NoDogSplash:** make BOLT11 decode non-fatal and set the NoDogSplash
   gateway port to 2050
   ([#158](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/158)).

--- a/src/valve/valve.go
+++ b/src/valve/valve.go
@@ -17,9 +17,25 @@ import (
 // deadlocks (issue #387) that can cause ndsctl to hang indefinitely.
 const ndsctlTimeout = 5 * time.Second
 
+// authMaxAttempts bounds the number of authorizeMAC attempts.
+//
+// NoDogSplash does not always have a client session registered the instant we
+// try to authorize it — most notably in the two-router reseller flow, where the
+// upstream's NDS creates the client session asynchronously (see
+// upstream_session_manager/tollgate_prober.go's captive-portal trigger). Without
+// a retry the first payment attempt fails with "failed to open gate" and only
+// recovers via the token-recovery path ~60-90s later. The auth operation is
+// idempotent, so a bounded retry is safe.
+const authMaxAttempts = 5
+
+// authRetryDelay is the wait between authorizeMAC retries. It is a var so tests
+// can shrink it to keep the suite fast.
+var authRetryDelay = 400 * time.Millisecond
+
 // runNdsctl executes an ndsctl command with a timeout.
 // It returns the combined stdout+stderr output and any error.
-func runNdsctl(args ...string) (string, error) {
+// It is a var (not a func) so tests can stub it without a real ndsctl binary.
+var runNdsctl = func(args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ndsctlTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "ndsctl", args...)
@@ -46,25 +62,47 @@ var (
 // ndsctlMutex ensures only one ndsctl command runs at a time
 var ndsctlMutex = &sync.Mutex{}
 
-// authorizeMAC authorizes a MAC address using ndsctl
+// authorizeMAC authorizes a MAC address using ndsctl.
+//
+// It retries up to authMaxAttempts because NoDogSplash may not have registered
+// the client session yet at the moment of the call (e.g. the reseller client's
+// session is still being created by an upstream captive-portal trigger). This
+// removes the transient first-attempt "failed to open gate" observed in the
+// two-router autopay flow.
 func authorizeMAC(macAddress string) error {
-	ndsctlMutex.Lock()
-	output, err := runNdsctl("auth", macAddress)
-	ndsctlMutex.Unlock()
+	var lastErr error
+	for attempt := 1; attempt <= authMaxAttempts; attempt++ {
+		ndsctlMutex.Lock()
+		output, err := runNdsctl("auth", macAddress)
+		ndsctlMutex.Unlock()
 
-	if err != nil {
+		if err == nil {
+			logger.WithFields(logrus.Fields{
+				"mac_address": macAddress,
+				"output":      output,
+				"attempts":    attempt,
+			}).Info("Authorization successful for MAC")
+			return nil
+		}
+
+		lastErr = err
+		if attempt == authMaxAttempts {
+			break
+		}
 		logger.WithFields(logrus.Fields{
 			"mac_address": macAddress,
+			"attempt":     attempt,
+			"output":      output,
 			"error":       err,
-		}).Error("Error authorizing MAC address")
-		return err
+		}).Debug("ndsctl auth failed, retrying (NoDogSplash may not have registered the client yet)")
+		time.Sleep(authRetryDelay)
 	}
 
 	logger.WithFields(logrus.Fields{
 		"mac_address": macAddress,
-		"output":      output,
-	}).Info("Authorization successful for MAC")
-	return nil
+		"error":       lastErr,
+	}).Error("Error authorizing MAC address")
+	return lastErr
 }
 
 // deauthorizeMAC deauthorizes a MAC address using ndsctl

--- a/src/valve/valve_test.go
+++ b/src/valve/valve_test.go
@@ -2,6 +2,7 @@ package valve
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"sync"
 	"testing"
@@ -195,5 +196,58 @@ func TestGetClientStatsRejectsInvalidMAC(t *testing.T) {
 	_, _, err := GetClientStats("not-a-mac")
 	if err == nil {
 		t.Fatal("expected error for invalid MAC")
+	}
+}
+
+// TestAuthorizeMACRetriesThenSucceeds verifies that authorizeMAC tolerates the
+// transient "client not registered yet" condition (the two-router autopay race)
+// by retrying until ndsctl succeeds.
+func TestAuthorizeMACRetriesThenSucceeds(t *testing.T) {
+	origNdsctl, origDelay := runNdsctl, authRetryDelay
+	defer func() {
+		runNdsctl = origNdsctl
+		authRetryDelay = origDelay
+	}()
+	authRetryDelay = time.Millisecond // keep the test fast
+
+	calls := 0
+	runNdsctl = func(args ...string) (string, error) {
+		calls++
+		if args[0] == "auth" && calls < 3 {
+			return "Client not found", fmt.Errorf("exit status 1")
+		}
+		return "ok", nil
+	}
+
+	if err := authorizeMAC("aa:bb:cc:dd:ee:ff"); err != nil {
+		t.Fatalf("expected authorizeMAC to succeed after retry, got %v", err)
+	}
+	if calls < 3 {
+		t.Fatalf("expected at least 3 attempts (fail,fail,ok), got %d", calls)
+	}
+}
+
+// TestAuthorizeMACFailsAfterMaxAttempts verifies authorizeMAC gives up after
+// authMaxAttempts and returns the last error rather than retrying forever.
+func TestAuthorizeMACFailsAfterMaxAttempts(t *testing.T) {
+	origNdsctl, origDelay := runNdsctl, authRetryDelay
+	defer func() {
+		runNdsctl = origNdsctl
+		authRetryDelay = origDelay
+	}()
+	authRetryDelay = time.Millisecond
+
+	calls := 0
+	runNdsctl = func(args ...string) (string, error) {
+		calls++
+		return "", fmt.Errorf("exit status 1")
+	}
+
+	err := authorizeMAC("aa:bb:cc:dd:ee:01")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != authMaxAttempts {
+		t.Fatalf("expected exactly %d attempts, got %d", authMaxAttempts, calls)
 	}
 }


### PR DESCRIPTION
## Problem

In the v0.5.0 reseller (router-to-router) flow, the upstream router's first gate-open after a payment fails:

```
Payment failed, attempting token recovery
error="payment rejected: failed to open gate: exit status 1"
❌ Renewal failed error="payment failed: payment rejected by upstream: failed to open gate: exit status 1"
```

It then recovers via the token-recovery path ~60–90s later. Verified end-to-end during the `main @ 04ae54e` tag-readiness campaign (issue #169) — the purchase works, but with this flaky first attempt.

## Root cause

The upstream's NoDogSplash does not always have the client session registered the instant the valve tries to authorize it. The session is created asynchronously by the captive-portal trigger in `upstream_session_manager/tollgate_prober.go` (the explicitly-labeled `TEMPORARY WORKAROUND`). That races with the valve's one-shot `ndsctl auth` in `authorizeMAC` → `OpenGate` returns the `exit status 1` → payment rejected.

## Fix

Make `authorizeMAC` retry `ndsctl auth` up to `authMaxAttempts` (5) with a short backoff. Authorize is idempotent, so a bounded retry is safe and removes the transient first-attempt failure.

- `runNdsctl` is now a stubbable package `var` so the retry is unit-testable without a real `ndsctl`.
- New tests: `TestAuthorizeMACRetriesThenSucceeds`, `TestAuthorizeMACFailsAfterMaxAttempts`. All existing valve tests still pass; `go build`/`go vet` clean.

## Scope / follow-up

This is the targeted reliability fix. The **proper long-term fix** (separate, larger PR) is to stop relying on the `tollgate_prober.go:106` `TEMPORARY WORKAROUND` portal-trigger entirely and have the upstream create the NDS client session inside the payment-acceptance path (idempotent). This PR makes the current architecture reliable; that follow-up retires the tech debt.

## Validation

Unit tests green. Hardware repro exists in the test-automation repo (`two_router_funded_upstream` fixture, PR [physical-router-test-automation#38](https://github.com/OpenTollGate/physical-router-test-automation/pull/38)) — once merged, that fixture will regression-guard this fix on real routers.