### PR TITLE
test: make root-module test hermetic via fresh temp config dir (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,12 @@ interfaces *the router itself serves on* to prevent self-probing.
 Unit tests, from the [src/](src/) directory:
 
 ```sh
-cd src && go test ./...
+cd src && go test -tags testenv ./...
 ```
+
+The `testenv` build tag provisions a hermetic temp config dir so the main
+package's `init()` does not depend on `/etc/tollgate/config.json` — letting the
+suite run off-router (CI, dev machines). The tag is a no-op for subpackages.
 
 A single package:
 

--- a/src/000_test_env_testenv.go
+++ b/src/000_test_env_testenv.go
@@ -2,12 +2,34 @@
 
 package main
 
-import (
-	"os"
-	"path/filepath"
-)
+import "os"
 
+// testEnvConfigDir holds the hermetic temp config dir auto-provisioned for
+// this test run (empty when the caller supplied TOLLGATE_TEST_CONFIG_DIR
+// explicitly). testenv_cleanup_test.go's TestMain removes it after the run.
+var testEnvConfigDir string
+
+// init provisions a fresh, hermetic temp config dir before main.go's init()
+// runs, so `go test -tags testenv` passes off-router (CI, dev machines)
+// without depending on /etc/tollgate/config.json existing on the router.
+//
+// A fresh directory per invocation avoids the stale-state and concurrent-run
+// collisions that the previous fixed path ($TMPDIR/tollgate-main-test)
+// suffered from — that is what made the root-module test non-hermetic.
+//
+// If TOLLGATE_TEST_CONFIG_DIR is already exported (e.g. CI pointing at a
+// pinned dir), it is respected unchanged and no temp dir is created.
+//
+// This file is guarded by the `testenv` build tag so it is never compiled
+// into the production binary (enforced by tests/contract/build-purity.sh).
 func init() {
-	os.Setenv("TOLLGATE_TEST_CONFIG_DIR", filepath.Join(os.TempDir(), "tollgate-main-test"))
-	os.MkdirAll(os.Getenv("TOLLGATE_TEST_CONFIG_DIR"), 0755)
+	if os.Getenv("TOLLGATE_TEST_CONFIG_DIR") != "" {
+		return
+	}
+	dir, err := os.MkdirTemp("", "tollgate-testenv-")
+	if err != nil {
+		panic("testenv: failed to create temp config dir: " + err.Error())
+	}
+	testEnvConfigDir = dir
+	os.Setenv("TOLLGATE_TEST_CONFIG_DIR", dir)
 }

--- a/src/testenv_cleanup_test.go
+++ b/src/testenv_cleanup_test.go
@@ -1,0 +1,24 @@
+//go:build testenv
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain removes the hermetic temp config dir provisioned by
+// 000_test_env_testenv.go's init() after the test run completes, so repeated
+// `go test -tags testenv` invocations do not accumulate stale config dirs
+// under the system temp dir. If the caller supplied TOLLGATE_TEST_CONFIG_DIR
+// explicitly, testEnvConfigDir is empty and nothing is removed.
+//
+// Only present under the `testenv` tag (paired with 000_test_env_testenv.go);
+// plain `go test` uses the default TestMain.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if testEnvConfigDir != "" {
+		_ = os.RemoveAll(testEnvConfigDir)
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
Clears tag-readiness caveat 2 from #169 (the off-router test half).

## What
- **Fix 3 — hermetic root-module test**: the main-package `go test` depended on `/etc/tollgate/config.json` existing on the router, so it fatally aborted during `init()` off-router (CI / dev machines). The `testenv` build-tag guard already redirected config to a temp dir but used a *fixed* path (`$TMPDIR/tollgate-main-test`), which leaked stale state across runs and collided under concurrent invocation. Now provisions a fresh `os.MkdirTemp` dir per run and removes it in `TestMain`; an explicit `TOLLGATE_TEST_CONFIG_DIR` is still honoured unchanged. README documents `go test -tags testenv ./...`.

## Note on Fix 2 (upstream_detector `go mod tidy`)
The other half of caveat 2 is already resolved on `main`: `src/upstream_detector/go.mod` is tidy (`go mod tidy` → no diff) and `go build ./...` + `go vet ./...` are clean. Verified again on this branch — nothing to commit.

## Verification (off-router, go1.26)
- `go test -tags testenv ./...` → `ok` (22/22 main-package tests pass)
- `go vet -tags testenv` → clean
- build-purity contract (3/3): prod arm64 binary free of `tollgate-main-test` / `tollgate-testenv-` sentinels
- hermeticity: 0 leftover temp dirs after consecutive runs

Refs #169.