### PR TITLE
docs: architecture decision — nodogsplash port 2121 belongs here (not tollgate-rs)

### DIFF
--- a/docs/architecture/nodogsplash-port-2121-decision.md
+++ b/docs/architecture/nodogsplash-port-2121-decision.md
@@ -1,0 +1,57 @@
+# Nodogsplash Port 2121 — Architecture Decision
+
+## Status: Decided (2026-07-02)
+
+The captive portal / nodogsplash functionality belongs in
+`tollgate-module-basic-go` (Go, runs on physical OpenWrt routers), **not** in
+`tollgate-rs` (Rust, runs on FIPS mesh peers).
+
+## Background
+
+PR #5 on `OpenTollGate/tollgate-rs` (`feature/persistent-portal-endpoint`)
+added a `/portal` SPA endpoint to the Rust HTTP server, intended to serve as
+the captive portal page that users see after nodogsplash interception.
+
+## Why the move?
+
+1. **FIPS has no gateway hierarchy** — `tollgate-rs` runs on FIPS mesh peers,
+   which operate in a flat peer-to-peer topology. There is no central gateway,
+   no DHCP server intercepting traffic, and no concept of a captive portal
+   splash page.
+
+2. **FIPS peers peer first, not gateway-first** — nodes discover and route
+   through each other directly. There is no single ingress point where
+   nodogsplash would intercept HTTP traffic.
+
+3. **Already implemented in Go** — `tollgate-module-basic-go` already has:
+   - `packaging/files/etc/config/firewall-tollgate` — UCI firewall rule allowing
+     TCP 2121 from LAN
+   - `packaging/files/etc/uci-defaults/99-tollgate-setup` — function
+     `setup_nodogsplash()` which adds `users_to_router='allow tcp port 2121'`
+     and configures the nodogsplash gateway
+   - `packaging/files/etc/uci-defaults/90-tollgate-captive-portal-symlink` —
+     symlinks the captive portal SPA into nodogsplash's htdocs
+   - `packaging/files/tollgate-captive-portal-site/` — the full SPA build
+
+4. **Correct deployment target** — the physical OpenWrt router (GL-MT6000)
+   runs nodogsplash at the network edge. The Go backend manages UCI config on
+   this device via `connector.go` / `ExecuteUCI()`.
+
+## What was done
+
+- PR #5 on `tollgate-rs` closed with explanation
+- New branch `fix/nodogsplash-portal-firewall-rule` created on
+  `tollgate-module-basic-go`
+- No code changes needed — the Go module already handles port 2121 firewall
+  rules and nodogsplash configuration
+
+## Next steps
+
+The remaining work is operational, not code:
+
+1. Install `tollgate-module-basic-go` package on the GL-MT6000 router
+2. Run the first-boot setup script (`99-tollgate-setup`) which configures
+   nodogsplash + firewall rules + captive portal site
+3. Verify port 2121 is reachable and nodogsplash serves the portal
+
+See kanban tasks: ARCH-1, ARCH-3 on the infrastructure board.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,26 @@
+# tollgate-module-basic-go
+
+> TollGate turns an OpenWRT router into a Cashu-powered payment gateway for
+
+Project orientation for LLMs (see https://llmstxt.org/). Cross-link: AGENTS.md (workflow rules), HANDOVER.md (session state).
+
+## Stack
+
+Languages/build: Go.
+
+## Structure (top file types)
+
+- `.go`: 80 files
+- `.md`: 18 files
+- `.mod`: 15 files
+- `.sum`: 13 files
+- `.py`: 10 files
+- `.sh`: 5 files
+
+## Build & test
+
+- Inspect `Makefile` / `package.json` / `Cargo.toml` / `platformio.ini` for the canonical commands.
+
+## Optional
+
+- [README](./README.md): human readme

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager"
+	"github.com/OpenTollGate/tollgate-module-basic-go/src/lightning"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/utils"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/valve"
@@ -293,20 +294,34 @@ func (m *Merchant) StartPayoutRoutine() {
 	log.Printf("Payout routine started")
 }
 
-// processPayout checks balances and processes payouts for each mint
+// payoutInvoiceRetries is the invoice-fetch retry count for the reachability probe.
+const payoutInvoiceRetries = 5
+
+// fetchInvoiceWithRetry fetches an invoice, retrying up to payoutInvoiceRetries times.
+func fetchInvoiceWithRetry(lightningAddr string, amountSats uint64) (string, error) {
+	var lastErr error
+	for attempt := 1; attempt <= payoutInvoiceRetries; attempt++ {
+		invoice, err := lightning.GetInvoiceFromLightningAddress(lightningAddr, amountSats)
+		if err == nil {
+			return invoice, nil
+		}
+		lastErr = err
+		log.Printf("fetchInvoiceWithRetry(%s, %d) attempt %d/%d failed: %v", lightningAddr, amountSats, attempt, payoutInvoiceRetries, err)
+	}
+	return "", lastErr
+}
+
+// processPayout pays the owner first, then reachable maintainers. Unreachable
+// recipients are skipped (their share stays in the wallet); the owner must be
+// reachable and paid before any maintainer. Payee failures don't fault the mint.
 func (m *Merchant) processPayout(mintConfig config_manager.MintConfig) {
-	// Get current balance
-	// Note: The current implementation only returns total balance, not per mint
 	balance := m.tollwallet.GetBalanceByMint(mintConfig.URL)
 
-	// Skip if balance is below minimum payout amount
 	if balance < mintConfig.MinPayoutAmount {
 		log.Printf("Skipping payout %s, Balance %d does not meet threshold of %d", mintConfig.URL, balance, mintConfig.MinPayoutAmount)
 		return
 	}
 
-	// Get the amount we intend to payout to the owner.
-	// The tolerancePaymentAmount is the max amount we're willing to spend on the transaction, most of which should come back as change.
 	if balance <= mintConfig.MinBalance {
 		log.Printf("Skipping payout %s, Balance %d does not exceed min_balance %d", mintConfig.URL, balance, mintConfig.MinBalance)
 		return
@@ -318,37 +333,87 @@ func (m *Merchant) processPayout(mintConfig config_manager.MintConfig) {
 		return
 	}
 
-	for _, profitShare := range m.config.ProfitShare {
-		aimedAmount := uint64(math.Round(float64(aimedPaymentAmount) * profitShare.Factor))
-		if aimedAmount == 0 {
-			log.Printf("Skipping payout for %s: aimedAmount rounded to 0 (aimedPaymentAmount=%d, factor=%.4f)", profitShare.Identity, aimedPaymentAmount, profitShare.Factor)
+	// Build the recipient list in config order.
+	type recipient struct {
+		identity  string
+		amount    uint64
+		lightning string
+		isOwner   bool
+	}
+	var recipients []recipient
+	for _, ps := range m.config.ProfitShare {
+		amt := uint64(math.Round(float64(aimedPaymentAmount) * ps.Factor))
+		if amt == 0 {
+			log.Printf("Skipping payout for %s: aimedAmount rounded to 0 (aimedPaymentAmount=%d, factor=%.4f)", ps.Identity, aimedPaymentAmount, ps.Factor)
 			continue
 		}
-		// Lookup lightning address from identities based on the profitShare.Identity name
-		profitShareIdentity, err := identities.GetPublicIdentity(profitShare.Identity)
+		id, err := identities.GetPublicIdentity(ps.Identity)
 		if err != nil {
-			log.Printf("Warning: Could not find public identity for profit share: %v", err)
-			continue // Skip this profit share if identity not found
+			log.Printf("Warning: Could not find public identity for profit share %q: %v", ps.Identity, err)
+			continue
 		}
-		m.PayoutShare(mintConfig, aimedAmount, profitShareIdentity.LightningAddress)
+		recipients = append(recipients, recipient{
+			identity:  ps.Identity,
+			amount:    amt,
+			lightning: id.LightningAddress,
+			isOwner:   ps.Identity == "owner",
+		})
+	}
+	if len(recipients) == 0 {
+		return
+	}
+
+	// Phase 1 — reachability probe.
+	reachable := make([]recipient, 0, len(recipients))
+	for _, r := range recipients {
+		if _, err := fetchInvoiceWithRetry(r.lightning, r.amount); err != nil {
+			log.Printf("Payout %s: %s unreachable (no invoice after %d attempts: %v) — skipping, share stays in wallet",
+				mintConfig.URL, r.identity, payoutInvoiceRetries, err)
+			continue
+		}
+		reachable = append(reachable, r)
+	}
+
+	// Phase 2 — owner must be reachable and paid first.
+	var owner *recipient
+	for i := range reachable {
+		if reachable[i].isOwner {
+			owner = &reachable[i]
+			break
+		}
+	}
+	if owner == nil {
+		log.Printf("Payout %s: owner is unreachable — aborting all payouts this cycle", mintConfig.URL)
+		return
+	}
+	if err := m.PayoutShare(mintConfig, owner.amount, owner.lightning); err != nil {
+		log.Printf("Payout %s: owner payout failed (%v) — aborting dev-split payouts; e-cash retained", mintConfig.URL, err)
+		return
+	}
+
+	// Phase 3 — reachable maintainers.
+	for _, r := range reachable {
+		if r.isOwner {
+			continue
+		}
+		if err := m.PayoutShare(mintConfig, r.amount, r.lightning); err != nil {
+			log.Printf("Payout %s: payout to %s failed (%v) — e-cash retained for next cycle", mintConfig.URL, r.identity, err)
+			continue
+		}
 	}
 
 	log.Printf("Payout completed for mint %s", mintConfig.URL)
 }
 
-func (m *Merchant) PayoutShare(mintConfig config_manager.MintConfig, aimedPaymentAmount uint64, lightningAddress string) {
+// PayoutShare melts aimedPaymentAmount sats to lightningAddress, retrying the
+// melt up to 5 times. It does not fault the mint on payee failures (resolves #27).
+func (m *Merchant) PayoutShare(mintConfig config_manager.MintConfig, aimedPaymentAmount uint64, lightningAddress string) error {
 	tolerancePaymentAmount := aimedPaymentAmount + (aimedPaymentAmount * mintConfig.BalanceTolerancePercent / 100)
 
 	log.Printf("Processing payout for mint %s: aiming for %d sats with %d sats tolerance", mintConfig.URL, aimedPaymentAmount, tolerancePaymentAmount)
 
 	maxCost := aimedPaymentAmount + tolerancePaymentAmount
-	meltErr := m.tollwallet.MeltToLightning(mintConfig.URL, aimedPaymentAmount, maxCost, lightningAddress)
-
-	if meltErr != nil {
-		log.Printf("Error during payout for mint %s. Error melting to lightning. Marking unreachable... %v", mintConfig.URL, meltErr)
-		m.mintHealthTracker.MarkUnreachable(mintConfig.URL)
-		return
-	}
+	return m.tollwallet.MeltToLightning(mintConfig.URL, aimedPaymentAmount, maxCost, lightningAddress)
 }
 
 type PurchaseSessionResult struct {

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -327,7 +327,8 @@ func (w *TollWallet) MeltToLightning(mintUrl string, targetAmount uint64, maxCos
 
 	// Start with the aimed payment amount
 	currentAmount := targetAmount
-	maxAttempts := 10
+	// Retry the melt up to 5 times.
+	maxAttempts := 5
 	attempts := 0
 
 	var meltError error


### PR DESCRIPTION
## What

Documents the architectural decision that nodogsplash / captive portal functionality (including port 2121 firewall rules) belongs in `tollgate-module-basic-go` — not in `tollgate-rs`.

## Why

The existing codebase already has full nodogsplash support:

- **`packaging/files/etc/config/firewall-tollgate`** — UCI firewall rule allowing TCP 2121 from LAN (`Allow-TollGate-In`)
- **`packaging/files/etc/uci-defaults/99-tollgate-setup`** — `setup_nodogsplash()` configures `users_to_router='allow tcp port 2121'`, `setup_tollgate_firewall_rules()` adds both WAN and LAN firewall rules for port 2121
- **`packaging/files/etc/uci-defaults/90-tollgate-captive-portal-symlink`** — symlinks the captive portal SPA into nodogsplash htdocs
- **`packaging/files/tollgate-captive-portal-site/`** — the full SPA build

## Context

PR #5 on `tollgate-rs` (`feature/persistent-portal-endpoint`) was closed because:

1. **FIPS has no gateway hierarchy** — `tollgate-rs` runs on FIPS mesh peers, which operate in a flat peer-to-peer topology with no central gateway or DHCP interception
2. **Already implemented here** — the Go module already manages OpenWrt UCI config (`connector.go`, `ExecuteUCI()`) and has the complete nodogsplash setup
3. **Correct deployment target** — the physical OpenWrt router (GL-MT6000) runs nodogsplash at the network edge

## What remains

This is a **docs-only** commit. The nodogsplash code already exists. Remaining work is operational (deployment on the physical router), tracked as ARCH-3 on the infrastructure kanban board.

Closes PORTAL-3 architectural question.