### PR TITLE
feat(config): list multiple testnut mints for redundancy

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -154,10 +154,13 @@ jobs:
           set -euo pipefail
           BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           GIT_COMMIT=$(git rev-parse --short HEAD)
+          GIT_BRANCH="${GITHUB_REF#refs/heads/}"
+          [ "$GIT_BRANCH" = "$GITHUB_REF" ] && GIT_BRANCH="${GITHUB_REF_NAME:-unknown}"
           LDFLAGS="-s -w \
             -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.Version=$PACKAGE_VERSION' \
             -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.GitCommit=$GIT_COMMIT' \
-            -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.BuildTime=$BUILD_TIME'"
+            -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.BuildTime=$BUILD_TIME' \
+            -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager.GitBranch=$GIT_BRANCH'"
 
           TARGETS='[
             {"key":"arm64","goarch":"arm64"},

--- a/scripts/build-sdk-package.sh
+++ b/scripts/build-sdk-package.sh
@@ -93,7 +93,8 @@ printf 'Build log path=%s\n' "$HOST_LOG_PATH"
 
 BUILD_TIME="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
 GIT_COMMIT="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || printf 'unknown\n')"
-LDFLAGS="-s -w -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.Version=$PACKAGE_VERSION' -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.GitCommit=$GIT_COMMIT' -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.BuildTime=$BUILD_TIME'"
+GIT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'unknown\n')"
+LDFLAGS="-s -w -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.Version=$PACKAGE_VERSION' -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.GitCommit=$GIT_COMMIT' -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/cli.BuildTime=$BUILD_TIME' -X 'github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager.GitBranch=$GIT_BRANCH'"
 
 printf '%s\n' 'Building target binaries locally before invoking the OpenWrt SDK.'
 (

--- a/src/config_manager/buildinfo_test.go
+++ b/src/config_manager/buildinfo_test.go
@@ -41,6 +41,14 @@ func TestNewDefaultConfig_MintsForBranch(t *testing.T) {
 	original := GitBranch
 	defer func() { GitBranch = original }()
 
+	// Map of test mint URLs that must only appear in dev builds
+	testMintURLs := map[string]bool{
+		"https://testnut.cashu.exchange":     true,
+		"https://testnut.cashu.space":        true,
+		"https://nofee.testnut.cashu.space":  true,
+	}
+	nTestMints := len(testMintURLs)
+
 	t.Run("main branch has only production mints", func(t *testing.T) {
 		GitBranch = "main"
 		cfg := NewDefaultConfig()
@@ -49,44 +57,45 @@ func TestNewDefaultConfig_MintsForBranch(t *testing.T) {
 			t.Fatalf("expected 2 accepted mints on main, got %d", len(cfg.AcceptedMints))
 		}
 		for _, m := range cfg.AcceptedMints {
-			if m.URL == "https://nofee.testnut.cashu.space" {
-				t.Error("test mint should not be present on main branch")
+			if testMintURLs[m.URL] {
+				t.Errorf("test mint %s should not be present on main branch", m.URL)
 			}
 		}
 	})
 
-	t.Run("non-main branch includes test mint", func(t *testing.T) {
+	t.Run("non-main branch includes test mints", func(t *testing.T) {
 		GitBranch = "feature/test-branch"
 		cfg := NewDefaultConfig()
 
-		if len(cfg.AcceptedMints) != 3 {
-			t.Fatalf("expected 3 accepted mints on feature branch, got %d", len(cfg.AcceptedMints))
+		expectedCount := 2 + nTestMints // 2 prod + N test
+		if len(cfg.AcceptedMints) != expectedCount {
+			t.Fatalf("expected %d accepted mints on feature branch, got %d", expectedCount, len(cfg.AcceptedMints))
 		}
 
-		found := false
+		found := 0
 		for _, m := range cfg.AcceptedMints {
-			if m.URL == "https://nofee.testnut.cashu.space" {
-				found = true
+			if testMintURLs[m.URL] {
+				found++
 				if m.MinBalance != 0 {
-					t.Errorf("expected test mint MinBalance=0, got %d", m.MinBalance)
+					t.Errorf("expected test mint %s MinBalance=0, got %d", m.URL, m.MinBalance)
 				}
 				if m.PayoutIntervalSeconds != 999999 {
-					t.Errorf("expected test mint PayoutIntervalSeconds=999999, got %d", m.PayoutIntervalSeconds)
+					t.Errorf("expected test mint %s PayoutIntervalSeconds=999999, got %d", m.URL, m.PayoutIntervalSeconds)
 				}
-				break
 			}
 		}
-		if !found {
-			t.Error("test mint not found in non-main branch config")
+		if found != nTestMints {
+			t.Errorf("expected %d test mints, found %d", nTestMints, found)
 		}
 	})
 
-	t.Run("unknown branch (tests) includes test mint", func(t *testing.T) {
+	t.Run("unknown branch (tests) includes test mints", func(t *testing.T) {
 		GitBranch = "unknown"
 		cfg := NewDefaultConfig()
 
-		if len(cfg.AcceptedMints) != 3 {
-			t.Fatalf("expected 3 accepted mints for unknown branch, got %d", len(cfg.AcceptedMints))
+		expectedCount := 2 + nTestMints
+		if len(cfg.AcceptedMints) != expectedCount {
+			t.Fatalf("expected %d accepted mints for unknown branch, got %d", expectedCount, len(cfg.AcceptedMints))
 		}
 	})
 
@@ -112,16 +121,34 @@ func TestNewDefaultConfig_MintsForBranch(t *testing.T) {
 	})
 }
 
-func TestDefaultTestMint(t *testing.T) {
-	mint := defaultTestMint()
-	if mint.URL != "https://nofee.testnut.cashu.space" {
-		t.Errorf("expected test mint URL, got %s", mint.URL)
+func TestDefaultTestMints(t *testing.T) {
+	mints := defaultTestMints()
+	if len(mints) < 2 {
+		t.Fatalf("expected at least 2 test mints for redundancy, got %d", len(mints))
 	}
-	if mint.PricePerStep != 1 {
-		t.Errorf("expected PricePerStep=1, got %d", mint.PricePerStep)
+
+	// Verify all test mints have sane config
+	for _, m := range mints {
+		if m.PricePerStep != 1 {
+			t.Errorf("expected PricePerStep=1 for %s, got %d", m.URL, m.PricePerStep)
+		}
+		if m.PriceUnit != "sats" {
+			t.Errorf("expected PriceUnit=sats for %s, got %s", m.URL, m.PriceUnit)
+		}
+		if m.MinBalance != 0 {
+			t.Errorf("expected MinBalance=0 for %s, got %d", m.URL, m.MinBalance)
+		}
 	}
-	if mint.PriceUnit != "sats" {
-		t.Errorf("expected PriceUnit=sats, got %s", mint.PriceUnit)
+
+	// Verify testnut.cashu.exchange is present (primary Spilman channel test mint)
+	foundExchange := false
+	for _, m := range mints {
+		if m.URL == "https://testnut.cashu.exchange" {
+			foundExchange = true
+		}
+	}
+	if !foundExchange {
+		t.Error("testnut.cashu.exchange should be in test mints (used for Spilman channels)")
 	}
 }
 

--- a/src/config_manager/config_manager_config.go
+++ b/src/config_manager/config_manager_config.go
@@ -189,16 +189,41 @@ func defaultProductionMints() []MintConfig {
 	}
 }
 
-func defaultTestMint() MintConfig {
-	return MintConfig{
-		URL:                     "https://nofee.testnut.cashu.space",
-		MinBalance:              0,
-		BalanceTolerancePercent: 0,
-		PayoutIntervalSeconds:   999999,
-		MinPayoutAmount:         999999,
-		PricePerStep:            1,
-		PriceUnit:               "sats",
-		MinPurchaseSteps:        0,
+// defaultTestMints returns a list of public Cashu testnet mints for
+// development/non-stable builds. Multiple are listed because individual
+// test mints are often unreliable or rate-limited.
+func defaultTestMints() []MintConfig {
+	return []MintConfig{
+		{
+			URL:                     "https://testnut.cashu.exchange",
+			MinBalance:              0,
+			BalanceTolerancePercent: 0,
+			PayoutIntervalSeconds:   999999,
+			MinPayoutAmount:         999999,
+			PricePerStep:            1,
+			PriceUnit:               "sats",
+			MinPurchaseSteps:        0,
+		},
+		{
+			URL:                     "https://testnut.cashu.space",
+			MinBalance:              0,
+			BalanceTolerancePercent: 0,
+			PayoutIntervalSeconds:   999999,
+			MinPayoutAmount:         999999,
+			PricePerStep:            1,
+			PriceUnit:               "sats",
+			MinPurchaseSteps:        0,
+		},
+		{
+			URL:                     "https://nofee.testnut.cashu.space",
+			MinBalance:              0,
+			BalanceTolerancePercent: 0,
+			PayoutIntervalSeconds:   999999,
+			MinPayoutAmount:         999999,
+			PricePerStep:            1,
+			PriceUnit:               "sats",
+			MinPurchaseSteps:        0,
+		},
 	}
 }
 
@@ -211,9 +236,11 @@ func IsDevBuild() bool {
 func NewDefaultConfig() *Config {
 	mints := defaultProductionMints()
 	if IsDevBuild() {
-		testMint := defaultTestMint()
-		log.Printf("WARN: dev build detected (branch=%s), injecting test mint: %s", GitBranch, testMint.URL)
-		mints = append(mints, testMint)
+		testMints := defaultTestMints()
+		for _, tm := range testMints {
+			log.Printf("WARN: dev build detected (branch=%s), injecting test mint: %s", GitBranch, tm.URL)
+			mints = append(mints, tm)
+		}
 	}
 
 	return &Config{


### PR DESCRIPTION
## Problem

Individual testnut mints are often unreliable or rate-limited. When one is down, dev/alpha builds lose all test mint support.

## Solution

List **three** testnut mints instead of one, injected only for non-main (dev) builds:

| Mint | Notes |
|------|-------|
| `testnut.cashu.exchange` | Primary Spilman channel test mint |
| `testnut.cashu.space` | Alternate testnut endpoint |
| `nofee.testnut.cashu.space` | No-fee variant |

## Changes

- `config_manager_config.go`: `defaultTestMint()` → `defaultTestMints()` (plural, returns slice)
- `buildinfo_test.go`: Tests updated for multiple test mints, count-derived assertions
- `build-sdk-package.sh`: Inject `GitBranch` via `-ldflags -X` so CI/local builds correctly detect branch
- `build-package.yml`: Inject `GitBranch` from `GITHUB_REF` in the `compile-binaries` step

## Existing Infrastructure

The `IsDevBuild()` + `GitBranch` mechanism already existed but was never wired to the build system. The `GitBranch` var defaulted to `"unknown"` (treated as dev) for all builds. This PR makes the ldflags injection work so main builds correctly get `GitBranch=main` and skip test mints.

## Test Results

```
=== RUN   TestIsDevBuild_DefaultBranch ✓
=== RUN   TestNewDefaultConfig_MintsForBranch ✓
=== RUN   TestDefaultTestMints ✓
PASS
```

📎 *This update is also mirrored on Nostr via ngit. If you use ngit/nostr, feel free to respond there — relay.ngit.dev*