### PR TITLE
docs: add roadmap, TollGate Review Club, and FIPS integration direction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,19 @@ For implementation questions specific to your PR, ask in the PR
 itself. For design or roadmap questions that don't have a clear PR
 home yet, file a GitHub issue.
 
+## TollGate Review Club
+
+Inspired by the [Bitcoin Review Club](https://bitcoincore.reviews/). The
+TollGate Review Club is a community program for TollGate enthusiasts who
+want to go deeper — testing alpha releases, validating features before
+they're marked stable, and learning how TollGate works under the hood.
+
+**What you'll do**: Get hands-on with new features before anyone else, run
+them on real hardware, report bugs, and directly shape what ships in the
+next stable release.
+
+**Join**: [TollGate Review Club on Signal](https://signal.group/#CjQKIBMfNzyL5IXRRG_R6JVl3rFEjDsN7x6ITt_CoFjjePC7EhCg8VnskJZJRNRSNKQ-GR4i)
+
 ## Further reading
 
 - [PR-REVIEW.md](PR-REVIEW.md) — the 13-criteria PR review checklist

--- a/README.md
+++ b/README.md
@@ -193,6 +193,29 @@ Design and protocol docs live under [docs/](docs/):
 - [docs/data-session-management.md](docs/data-session-management.md)
 - [docs/wireless_gateway_manager.md](docs/wireless_gateway_manager.md)
 
+## Roadmap
+
+### v0.6.x — Mesh Networking & FIPS Integration
+
+TollGate is moving beyond single-router deployments. The next major
+direction is peer-to-peer mesh networking with
+[FIPS](https://github.com/nicobao/fips):
+
+- **FIPS peering**: TollGate routers become FIPS nodes in a
+  self-organizing mesh. Cryptographic peer IDs (from npubs), end-to-end
+  encrypted forwarding, no centralized addressing.
+- **FIPS internet exit**: FIPS-only nodes route to the legacy internet
+  through GRE tunnels to other TollGate nodes that have WAN connectivity.
+- **Per-FIPS-instance pricing**: Multiple FIPS instances with per-peer
+  pricing profiles (different rates for LoRa vs fiber peers).
+- **Native Android app**: Rust + Kotlin, running FIPS natively (no
+  WebView/Tauri), FIPS-based notifications without central servers.
+- **TollGate Review Club**: Community alpha testing program.
+
+See [ROADMAP.md](ROADMAP.md) for the full versioned roadmap and
+[tollgate-rs](https://github.com/OpenTollGate/tollgate-rs) for the
+FIPS integration design documents.
+
 ## License
 
 GPL-3.0 — see [LICENSE](LICENSE).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# TollGate Roadmap
+
+This roadmap tracks the versioned evolution of TollGate for OpenWrt routers
+(`tollgate-module-basic-go`). For the FIPS mesh integration design, see
+[tollgate-rs](https://github.com/OpenTollGate/tollgate-rs).
+
+---
+
+## v0.5.0 ✅ Released 2026-07-03
+
+**Resilience & hardening** — a TollGate now degrades gracefully instead of
+falling over. Mint fallback, merchant degraded mode, HTTPS, schema-driven
+config, .apk packaging for OpenWrt 25.x, security hardening.
+
+Full release notes: https://github.com/OpenTollGate/tollgate-module-basic-go/releases/tag/v0.5.0
+
+---
+
+## v0.6.0 — Mesh & FIPS Integration (In Design)
+
+TollGate routers join FIPS mesh networks as forwarding nodes.
+
+- FIPS peering: cryptographic peer IDs, end-to-end encrypted forwarding
+- Per-peer forwarding policy via FIPS control socket
+- 802.11s mesh backbone for router-to-router connectivity
+- TollGate Review Club alpha testing program begins
+
+---
+
+## v0.7.0 — Internet Exit & Tunneling
+
+FIPS-only TollGate nodes reach the legacy internet through GRE tunnels
+to other TollGate nodes with WAN connectivity.
+
+- GRE tunnel bridge: FIPS → legacy internet
+- Binary allow/deny on tunnel access (Phase 1)
+- TollGate RS pricing on tunnel interfaces (Phase 2)
+- Jump host pattern for SSH through FIPS nodes
+
+---
+
+## v0.8.0 — Native Android
+
+Native Android TollGate client built on FIPS.
+
+- Rust core (nostril-native + Cashu NIP-60) via `cargo-ndk`
+- Kotlin/Jetpack Compose UI via UniFFI (no Tauri)
+- FIPS-based notifications without central servers (no FCM/APNS)
+- FIPS solves the Android hotspot VPN bypass problem (access control at
+  protocol layer, not IP layer)
+
+---
+
+## Future
+
+- **Full FIPS-only mesh**: Remove all IP internally — only loopback + FIPS + GRE
+- **Multiple exit nodes**: Reputation markets for exit access
+- **Per-FIPS-instance pricing**: Different rates for heterogeneous peers (LoRa vs fiber)
+- **Wi-Fi Direct mobile mesh**: Phone-to-router FIPS connections without hotspot
+- **Gamification**: Ham radio style FIPS node "call sign" collection and mapping (opt-in)
+- **microFIPS**: ESP32 build target in main FIPS repo via feature flags
+- **TTL/Ping proximity proof**: Physical proximity enforcement for pairing and DoS protection


### PR DESCRIPTION
## Motivation

v0.5.0 is shipped. The community needs visibility into what comes next: FIPS mesh integration, internet exit/tunneling, native Android, and the TollGate Review Club program. This PR adds the roadmap and Review Club documentation so contributors and users can see the direction.

## Changes

**`ROADMAP.md`** (new) — Versioned roadmap:
- v0.6.0: Mesh & FIPS Integration (peering, 802.11s backbone, Review Club begins)
- v0.7.0: Internet Exit & Tunneling (GRE, binary allow/deny → TollGate RS pricing)
- v0.8.0: Native Android (Rust + Kotlin via UniFFI, FIPS notifications)
- Future: Full FIPS-only mesh, gamification, microFIPS, TTL proximity proof

**`CONTRIBUTING.md`** — TollGate Review Club section:
- Inspired by Bitcoin Review Club
- Community alpha testing program
- Signal group link

**`README.md`** — Roadmap section at bottom pointing to FIPS integration as the next major direction.

## Related

- tollgate-rs PR: https://github.com/OpenTollGate/tollgate-rs/pull/6 (FIPS feature requests + roadmap)
- v0.5.0 release: https://github.com/OpenTollGate/tollgate-module-basic-go/releases/tag/v0.5.0