### PR TITLE
fix: align sub-module gonuts replace directives with main module

### DIFF
--- a/src/merchant/go.mod
+++ b/src/merchant/go.mod
@@ -64,7 +64,7 @@ replace (
 	github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet => ../tollwallet
 	github.com/OpenTollGate/tollgate-module-basic-go/src/utils => ../utils
 	github.com/OpenTollGate/tollgate-module-basic-go/src/valve => ../valve
-	github.com/Origami74/gonuts-tollgate => github.com/Amperstrand/gonuts-tollgate v0.7.0
+	github.com/Origami74/gonuts-tollgate => github.com/OpenTollGate/gonuts-tollgate v0.7.1
 )
 
 require (

--- a/src/merchant/go.sum
+++ b/src/merchant/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Amperstrand/gonuts-tollgate v0.7.0 h1:pp7Cqt3TFH3h7c8tFhNM9aSHJ89D5dUmJ5WqBo3oiF8=
-github.com/Amperstrand/gonuts-tollgate v0.7.0/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
+github.com/OpenTollGate/gonuts-tollgate v0.7.1 h1:1D7GRpu1SwyQCbx70wVomOpzMVi6W7E3yGfc/gCxAvM=
+github.com/OpenTollGate/gonuts-tollgate v0.7.1/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3 h1:ClzzXMDDuUbWfNNZqGeYq4PnYOlwlOVIvSyNaIy0ykg=

--- a/src/tollwallet/go.mod
+++ b/src/tollwallet/go.mod
@@ -10,7 +10,7 @@ require (
 
 replace (
 	github.com/OpenTollGate/tollgate-module-basic-go/src/lightning => ../lightning
-	github.com/Origami74/gonuts-tollgate => github.com/Amperstrand/gonuts-tollgate v0.7.0
+	github.com/Origami74/gonuts-tollgate => github.com/OpenTollGate/gonuts-tollgate v0.7.1
 )
 
 require (

--- a/src/tollwallet/go.sum
+++ b/src/tollwallet/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Amperstrand/gonuts-tollgate v0.7.0 h1:pp7Cqt3TFH3h7c8tFhNM9aSHJ89D5dUmJ5WqBo3oiF8=
-github.com/Amperstrand/gonuts-tollgate v0.7.0/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
+github.com/OpenTollGate/gonuts-tollgate v0.7.1 h1:1D7GRpu1SwyQCbx70wVomOpzMVi6W7E3yGfc/gCxAvM=
+github.com/OpenTollGate/gonuts-tollgate v0.7.1/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
Sub-modules `src/merchant` and `src/tollwallet` still pointed to `Amperstrand/gonuts-tollgate v0.7.0` while the main module (`src/go.mod`) uses `OpenTollGate/gonuts-tollgate v0.7.1`.

Updated both sub-modules for consistency. Functionally equivalent (main module replace overrides at build time) but eliminates the version mismatch that causes `go.sum` churn across sub-module builds.

## Changes
- `src/merchant/go.mod`: replace directive `Amperstrand/gonuts-tollgate v0.7.0` → `OpenTollGate/gonuts-tollgate v0.7.1`
- `src/tollwallet/go.mod`: same
- `src/merchant/go.sum`, `src/tollwallet/go.sum`: updated hash entries

## Verification
- `cd src/merchant && go build ./...` — clean (exit 0)
- `cd src/tollwallet && go build ./...` — clean (exit 0)

Closes #134.