### PR TITLE
fix: add CORS to /usage endpoint + test kind=21000 wrapper parsing

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -372,6 +372,20 @@ func handleDetails(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleRootPost handles POST requests to the root endpoint
+func extractCashuToken(body []byte) (token string, event *nostr.Event) {
+	var ev nostr.Event
+	err := json.Unmarshal(body, &ev)
+	if err == nil && ev.Kind == 21000 {
+		for _, tag := range ev.Tags {
+			if len(tag) >= 2 && tag[0] == "payment" {
+				return tag[1], &ev
+			}
+		}
+		return "", &ev
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
 func HandleRootPost(w http.ResponseWriter, r *http.Request) {
 	// Log the request details
 	mainLogger.WithFields(logrus.Fields{
@@ -408,42 +422,24 @@ func HandleRootPost(w http.ResponseWriter, r *http.Request) {
 	bodyStr := string(body)
 	mainLogger.WithField("body", bodyStr).Debug("Received POST request")
 
-	var cashuToken string
+	cashuToken, nostrEvent := extractCashuToken(body)
 
-	// Try to parse as JSON (Nostr event format)
-	var event nostr.Event
-	err = json.Unmarshal(body, &event)
-
-	if err == nil && event.Kind == 21000 {
-		// It's a valid Nostr event (signature validation is now optional)
+	if nostrEvent != nil {
 		mainLogger.WithFields(logrus.Fields{
-			"event_id":   event.ID,
-			"created_at": event.CreatedAt,
-			"kind":       event.Kind,
-			"pubkey":     event.PubKey,
+			"event_id":   nostrEvent.ID,
+			"created_at": nostrEvent.CreatedAt,
+			"kind":       nostrEvent.Kind,
+			"pubkey":     nostrEvent.PubKey,
 		}).Info("Parsed nostr event (signature not validated)")
 
-		// Extract payment token from event
-		var paymentToken string
-		for _, tag := range event.Tags {
-			if len(tag) >= 2 && tag[0] == "payment" {
-				paymentToken = tag[1]
-				break
-			}
-		}
-
-		if paymentToken == "" {
+		if cashuToken == "" {
 			mainLogger.Error("No payment tag found in event")
 			sendNoticeResponse(w, merchantProvider.inner.GetMerchant(), http.StatusBadRequest, "error", "invalid-event",
 				"No payment tag found in event", macAddress)
 			return
 		}
-
-		cashuToken = paymentToken
 	} else {
-		// Treat as plain Cashu token string
 		mainLogger.Info("Treating request as plain Cashu token string")
-		cashuToken = strings.TrimSpace(bodyStr)
 	}
 
 	// Process payment with cashu token and MAC address
@@ -492,6 +488,29 @@ func sendNoticeResponse(w http.ResponseWriter, m merchant.MerchantInterface, sta
 }
 
 // handleRoot routes requests based on method
+func HandleUsage(w http.ResponseWriter, r *http.Request) {
+	ip := getIP(r)
+	macAddress, err := getMacAddress(ip)
+	if err != nil {
+		mainLogger.WithError(err).Error("Error getting MAC address for /usage")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "-1/-1")
+		return
+	}
+	usageStr, err := merchantProvider.inner.GetMerchant().GetUsage(macAddress)
+	if err != nil {
+		mainLogger.WithFields(logrus.Fields{
+			"mac":   macAddress,
+			"error": err,
+		}).Error("Error getting usage")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "-1/-1")
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, usageStr)
+}
+
 func HandleRoot(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		HandleRootPost(w, r)
@@ -762,31 +781,7 @@ func main() {
 
 	http.HandleFunc("/usage", func(w http.ResponseWriter, r *http.Request) {
 		mainLogger.WithField("remote_addr", r.RemoteAddr).Debug("Hit /usage endpoint")
-
-		// Get MAC address from request
-		ip := getIP(r)
-		macAddress, err := getMacAddress(ip)
-		if err != nil {
-			mainLogger.WithError(err).Error("Error getting MAC address for /usage")
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprint(w, "-1/-1")
-			return
-		}
-
-		// Get usage from merchant
-		usageStr, err := merchantProvider.inner.GetMerchant().GetUsage(macAddress)
-		if err != nil {
-			mainLogger.WithFields(logrus.Fields{
-				"mac":   macAddress,
-				"error": err,
-			}).Error("Error getting usage")
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprint(w, "-1/-1")
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, usageStr)
+		CorsMiddleware(HandleUsage)(w, r)
 	})
 
 	mainLogger.Info("Starting HTTP server on all interfaces...")

--- a/src/payment_cors_test.go
+++ b/src/payment_cors_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractCashuToken_RawToken(t *testing.T) {
+	token, event := extractCashuToken([]byte("cashuB1234567890"))
+	assert.Equal(t, "cashuB1234567890", token)
+	assert.Nil(t, event)
+}
+
+func TestExtractCashuToken_RawToken_TrimsWhitespace(t *testing.T) {
+	token, event := extractCashuToken([]byte("  cashuBxyz  \n"))
+	assert.Equal(t, "cashuBxyz", token)
+	assert.Nil(t, event)
+}
+
+func TestExtractCashuToken_Kind21000Wrapper(t *testing.T) {
+	ev := nostr.Event{Kind: 21000, Tags: nostr.Tags{{"payment", "cashuBwrapped"}}}
+	body, _ := json.Marshal(ev)
+
+	token, parsedEvent := extractCashuToken(body)
+	assert.Equal(t, "cashuBwrapped", token)
+	assert.NotNil(t, parsedEvent)
+	assert.Equal(t, 21000, parsedEvent.Kind)
+}
+
+func TestExtractCashuToken_Kind21000Wrapper_NoPaymentTag(t *testing.T) {
+	ev := nostr.Event{Kind: 21000, Tags: nostr.Tags{{"other", "value"}}}
+	body, _ := json.Marshal(ev)
+
+	token, parsedEvent := extractCashuToken(body)
+	assert.Equal(t, "", token)
+	assert.NotNil(t, parsedEvent)
+}
+
+func TestExtractCashuToken_Non21000JSON(t *testing.T) {
+	body, _ := json.Marshal(nostr.Event{Kind: 1})
+	token, event := extractCashuToken(body)
+	assert.NotNil(t, token)
+	assert.Nil(t, event)
+}
+
+func TestCorsMiddleware_SetsCORSHeaders(t *testing.T) {
+	handler := CorsMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/usage", nil)
+	req.Header.Set("Origin", "http://192.168.1.1:8080")
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "http://192.168.1.1:8080", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET, POST, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Content-Type, Authorization", rec.Header().Get("Access-Control-Allow-Headers"))
+}
+
+func TestCorsMiddleware_PassesThroughNonOptions(t *testing.T) {
+	called := false
+	handler := CorsMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler(rec, req)
+
+	assert.True(t, called)
+	assert.Equal(t, "GET, POST, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+}


### PR DESCRIPTION
## Changes

### #41 fix: /usage CORS

`/usage` was the only HTTP endpoint without `CorsMiddleware`. Every other route (`/`, `/whoami`, `/ln-invoice`, `/balance`) was already wrapped. Extracted the inline handler to `HandleUsage` and wrapped it with `CorsMiddleware`.

### #36 test: kind=21000 wrapper

Extracted the token-parsing logic from `HandleRootPost` into `extractCashuToken()` so the kind=21000 Nostr wrapper acceptance can be unit-tested. The wrapper acceptance itself is **unchanged** — this commit documents the current behavior. Whether to remove the wrapper (HTTP-01 spec says raw body only, README says "March 2026 — Payment accepts pure bearer asset tokens instead of kind=21000") is a separate decision tracked in Amperstrand/tollgate-module-basic-go#36.

## Test coverage
- `TestExtractCashuToken_RawToken` — raw Cashu token string
- `TestExtractCashuToken_RawToken_TrimsWhitespace` — whitespace trimmed
- `TestExtractCashuToken_Kind21000Wrapper` — kind=21000 event with `payment` tag
- `TestExtractCashuToken_Kind21000Wrapper_NoPaymentTag` — wrapper without payment tag
- `TestExtractCashuToken_Non21000JSON` — non-21000 JSON treated as raw token
- `TestCorsMiddleware_SetsCORSHeaders` — OPTIONS preflight returns correct headers
- `TestCorsMiddleware_PassesThroughNonOptions` — non-OPTIONS passes through to handler

## Verification
- `go build -tags testenv ./...` — clean
- `go test -tags testenv -count=1 ./...` — all pass (7 new + existing suite)