### PR TITLE
fix(merchant): credit token face value instead of post-fee amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **Allotment based on token face value.** Payments now credit the token'"'"'s
+  face value (sum of proof amounts) rather than the post-fee wallet balance,
+  aligning with the Rust reference implementation. Users receive the full
+  amount they paid for; the mint fee is absorbed as an operator cost
+  ([#197](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/197)).
 
 ## [v0.5.0] - 2026-07-03
 

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -432,11 +432,10 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 		return noticeEvent, nil
 	}
 
-	log.Printf("Amount after swap: %d", amountAfterSwap)
+	log.Printf("Amount after swap: %d, face value: %d", amountAfterSwap, paymentCashuToken.Amount())
 
-	// Calculate allotment using the configured metric and mint-specific pricing
 	mintURL := paymentCashuToken.Mint()
-	allotment, err := m.calculateAllotment(amountAfterSwap, mintURL)
+	allotment, err := m.calculateAllotment(paymentCashuToken.Amount(), mintURL)
 	if err != nil {
 		noticeEvent, noticeErr := m.CreateNoticeEvent("error", "allotment-calculation-failed",
 			fmt.Sprintf("Failed to calculate allotment: %v", err), macAddress)


### PR DESCRIPTION
## Change

`merchant.go:439` now passes `paymentCashuToken.Amount()` (face value) to `calculateAllotment()` instead of `amountAfterSwap` (post-fee wallet balance).

## Why

The mint fee (`fee_ppk`) was silently passed to the customer — a 1-sat token on a `fee_ppk=10` keyset yielded **zero access**. The fee is an operator cost, not a customer cost.

## Alignment with Rust reference

tollgate-rs (maintained by @Origami74, 43/44 commits) already uses face value: `calculate_allotment(amount_sat, &state.config)`.

## Verification
- `go build -tags testenv ./...` — clean
- `go test -tags testenv -count=1 ./...` — all pass

Fixes Amperstrand/tollgate-module-basic-go#20.