### PR TITLE
fix(lightning): validate LNURL callback URL to prevent SSRF

### DIFF
--- a/src/lightning/lightning.go
+++ b/src/lightning/lightning.go
@@ -108,3 +108,18 @@ func GetInvoiceFromLightningAddress(lightningAddr string, amountSats uint64) (st
 
 	return invoice.PR, nil
 }
+
+func validateCallbackURL(callbackURL *url.URL) error {
+	host := callbackURL.Hostname()
+	if host == "" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("callback URL points to blocked address: %s", host)
+	}
+	return nil
+}

--- a/src/lightning/lightning.go
+++ b/src/lightning/lightning.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -67,6 +68,14 @@ func GetInvoiceFromLightningAddress(lightningAddr string, amountSats uint64) (st
 	callbackURL, err := url.Parse(lnurlPayResp.Callback)
 	if err != nil {
 		return "", fmt.Errorf("invalid callback URL: %w", err)
+	}
+
+	if host := callbackURL.Hostname(); host != "" {
+		if ip := net.ParseIP(host); ip != nil {
+			if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+				return "", fmt.Errorf("callback URL points to blocked address: %s", host)
+			}
+		}
 	}
 
 	// Add amount parameter

--- a/src/lightning/ssrf_validation_test.go
+++ b/src/lightning/ssrf_validation_test.go
@@ -1,0 +1,72 @@
+package lightning
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestValidateCallbackURL_PublicDomain(t *testing.T) {
+	u, _ := url.Parse("https://ln.example.com/callback")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("public domain should pass: %v", err)
+	}
+}
+
+func TestValidateCallbackURL_PublicIP(t *testing.T) {
+	u, _ := url.Parse("https://203.0.113.1/callback")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("public IP should pass: %v", err)
+	}
+}
+
+func TestValidateCallbackURL_Loopback(t *testing.T) {
+	u, _ := url.Parse("http://127.0.0.1:8080/steal")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("loopback should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_LoopbackIPv6(t *testing.T) {
+	u, _ := url.Parse("http://[::1]:8080/steal")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("IPv6 loopback should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_PrivateRFC1918(t *testing.T) {
+	ips := []string{"10.0.0.1", "172.16.0.1", "192.168.1.1"}
+	for _, ip := range ips {
+		u, _ := url.Parse("http://" + ip + "/steal")
+		if err := validateCallbackURL(u); err == nil {
+			t.Errorf("RFC1918 %s should be rejected", ip)
+		}
+	}
+}
+
+func TestValidateCallbackURL_LinkLocal(t *testing.T) {
+	u, _ := url.Parse("http://169.254.169.254/latest/meta-data/")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("link-local (cloud metadata) should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_Unspecified(t *testing.T) {
+	u, _ := url.Parse("http://0.0.0.0/callback")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("unspecified 0.0.0.0 should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_EmptyHost(t *testing.T) {
+	u, _ := url.Parse("/relative-path")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("empty host should pass: %v", err)
+	}
+}
+
+func TestValidateCallbackURL_CGNAT_PassesThrough(t *testing.T) {
+	u, _ := url.Parse("http://100.64.0.1/callback")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("CGNAT 100.64.x passes through Go IsPrivate() — acceptable for SSRF prevention since CGNAT is ISP-level: %v", err)
+	}
+}


### PR DESCRIPTION
## Change

Added IP validation in `src/lightning/lightning.go` between parsing the LNURL callback URL and fetching it. Callbacks that resolve to loopback, private (RFC 1918), unspecified, or link-local addresses are rejected.

## Attack vector

A malicious Lightning Address provider returns a callback URL pointing to an internal service (e.g., `http://169.254.169.254/latest/meta-data/` for cloud metadata exfiltration). The router dutifully fetches it, exposing internal endpoints.

## Fix

```go
if host := callbackURL.Hostname(); host != "" {
    if ip := net.ParseIP(host); ip != nil {
        if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
            return "", fmt.Errorf("callback URL points to blocked address: %s", host)
        }
    }
}
```

Domain names are allowed through (DNS resolution happens later). Only literal IP addresses in the callback URL are checked.

## Verification
- `go build -tags testenv .` — clean (exit 0)

Fixes Amperstrand/tollgate-module-basic-go#12.