### PR TITLE
security: RFC 1918 isolation — block public WiFi from upstream private networks

### DIFF
--- a/src/lightning/lightning.go
+++ b/src/lightning/lightning.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -98,4 +99,19 @@ func GetInvoiceFromLightningAddress(lightningAddr string, amountSats uint64) (st
 	}
 
 	return invoice.PR, nil
+}
+
+func validateCallbackURL(callbackURL *url.URL) error {
+	host := callbackURL.Hostname()
+	if host == "" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("callback URL points to blocked address: %s", host)
+	}
+	return nil
 }

--- a/src/lightning/ssrf_validation_test.go
+++ b/src/lightning/ssrf_validation_test.go
@@ -1,0 +1,72 @@
+package lightning
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestValidateCallbackURL_PublicDomain(t *testing.T) {
+	u, _ := url.Parse("https://ln.example.com/callback")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("public domain should pass: %v", err)
+	}
+}
+
+func TestValidateCallbackURL_PublicIP(t *testing.T) {
+	u, _ := url.Parse("https://203.0.113.1/callback")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("public IP should pass: %v", err)
+	}
+}
+
+func TestValidateCallbackURL_Loopback(t *testing.T) {
+	u, _ := url.Parse("http://127.0.0.1:8080/steal")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("loopback should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_LoopbackIPv6(t *testing.T) {
+	u, _ := url.Parse("http://[::1]:8080/steal")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("IPv6 loopback should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_PrivateRFC1918(t *testing.T) {
+	ips := []string{"10.0.0.1", "172.16.0.1", "192.168.1.1"}
+	for _, ip := range ips {
+		u, _ := url.Parse("http://" + ip + "/steal")
+		if err := validateCallbackURL(u); err == nil {
+			t.Errorf("RFC1918 %s should be rejected", ip)
+		}
+	}
+}
+
+func TestValidateCallbackURL_LinkLocal(t *testing.T) {
+	u, _ := url.Parse("http://169.254.169.254/latest/meta-data/")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("link-local (cloud metadata) should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_Unspecified(t *testing.T) {
+	u, _ := url.Parse("http://0.0.0.0/callback")
+	if err := validateCallbackURL(u); err == nil {
+		t.Error("unspecified 0.0.0.0 should be rejected")
+	}
+}
+
+func TestValidateCallbackURL_EmptyHost(t *testing.T) {
+	u, _ := url.Parse("/relative-path")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("empty host should pass: %v", err)
+	}
+}
+
+func TestValidateCallbackURL_CGNAT_PassesThrough(t *testing.T) {
+	u, _ := url.Parse("http://100.64.0.1/callback")
+	if err := validateCallbackURL(u); err != nil {
+		t.Errorf("CGNAT 100.64.x passes through Go IsPrivate() — acceptable for SSRF prevention since CGNAT is ISP-level: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Without this fix, an authenticated public WiFi customer (someone who paid via the captive portal) can directly access devices on the operator's upstream network — PCs, printers, NAS, the ISP router's admin interface, and anything else on 192.168.x.x (or 10.x / 172.16.x).

This is because the `lan → wan` firewall forwarding rule accepts ALL forwarded traffic, including traffic destined for RFC 1918 private addresses on the upstream side.

## Fix

Add 4 DROP rules that block forwarded traffic from the `lan` zone to RFC 1918 ranges on the `wan` zone:

| Rule | Dest IP | Blocks |
|---|---|---|
| `block_rfc1918_10` | 10.0.0.0/8 | Corporate VPNs, some ISP CPEs |
| `block_rfc1918_172` | 172.16.0.0/12 | Enterprise networks |
| `block_rfc1918_192` | 192.168.0.0/16 | Home routers (most common) |
| `block_linklocal` | 169.254.0.0/16 | Link-local autoconfig |

In OpenWrt firewall4 (nftables), explicit `rule` sections are evaluated **before** `forwarding` sections, so these DROPs take precedence over the general `lan → wan` ACCEPT.

## Files

- `packaging/files/etc/uci-defaults/99-tollgate-setup` — new `setup_rfc1918_isolation()` function, idempotent
- `SECURITY.md` (new) — full threat model, traffic flow diagrams, RFC references

## Ported from

Amperstrand PR #58, rebased onto upstream `packaging/` path structure. The SECURITY.md is the full analysis from the original PR.

## Verification

- `shellcheck -s sh` on the modified script: clean (the `local` warning on line 54 is pre-existing, not from this change)
- Idempotent: `uci -q get firewall.block_rfc1918_10` guards prevent duplicate rules on re-run
- Needs physical router testing: verify that paying WiFi customers can reach the internet but NOT the operator's LAN devices