### PR TITLE
fix: sanitize error responses to avoid leaking internal details

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -556,7 +556,7 @@ func HandleBalance(w http.ResponseWriter, r *http.Request) {
 		mainLogger.WithFields(logrus.Fields{"mac": macAddress, "error": err}).Error("Error getting balance usage")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(balanceResponse{Status: 0, Error: err.Error()})
+		json.NewEncoder(w).Encode(balanceResponse{Status: 0, Error: "failed to retrieve usage data"})
 		return
 	}
 	if usage == "-1/-1" {
@@ -571,7 +571,7 @@ func HandleBalance(w http.ResponseWriter, r *http.Request) {
 		mainLogger.WithFields(logrus.Fields{"mac": macAddress, "usage": usage, "error": err}).Error("Error parsing usage string")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(balanceResponse{Status: 0, Error: err.Error()})
+		json.NewEncoder(w).Encode(balanceResponse{Status: 0, Error: "failed to process usage data"})
 		return
 	}
 
@@ -647,7 +647,7 @@ func handleLightningInvoicePost(w http.ResponseWriter, r *http.Request) {
 		mainLogger.WithError(err).Warn("Failed to create lightning invoice")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(lightningInvoiceResponse{Status: 0, Error: err.Error()})
+		json.NewEncoder(w).Encode(lightningInvoiceResponse{Status: 0, Error: "failed to create lightning invoice"})
 		return
 	}
 
@@ -695,7 +695,7 @@ func handleLightningInvoiceGet(w http.ResponseWriter, r *http.Request) {
 		mainLogger.WithError(err).Warn("Failed to fetch lightning invoice status")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
-		json.NewEncoder(w).Encode(lightningInvoiceResponse{Status: 0, Error: err.Error()})
+		json.NewEncoder(w).Encode(lightningInvoiceResponse{Status: 0, Error: "failed to fetch invoice status"})
 		return
 	}
 


### PR DESCRIPTION
## Change

Replace `err.Error()` with generic client-safe messages in 4 JSON response paths (balance ×2, lightning invoice ×2). Internal errors are still logged server-side via `mainLogger` — only the client-facing response is sanitized.

## Why

Audit finding S3 from #177: balance and lightning-invoice endpoints return `err.Error()` directly in JSON responses (lines 559, 574, 650, 698 of main.go). Could leak internal error details (library paths, connection strings, stack fragments) to attackers.

## Testing

- [ ] API tests pass on cloud lab
- [ ] Error responses contain generic messages, not internal details
- [ ] Server-side logs still contain full error details

Closes audit finding S3 from #177.