### PR TITLE
fix: AP setup recovery on reinstall/upgrade (#103, #173)

### DIFF
--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -2,12 +2,13 @@
 # TollGate first-boot configuration. Runs once from /etc/init.d/boot before
 # services start. All UCI changes are committed in a single pass at the end;
 # no service restarts here (uci-defaults runs before procd brings services up).
+#
+# The flag file stores the setup version. On reinstall/upgrade:
+# - Same version → verify wireless APs only (belt-and-suspenders)
+# - New version or first boot → full setup
 
 SETUP_FLAG="/etc/tollgate-setup-done"
-
-if [ -f "$SETUP_FLAG" ]; then
-    exit 0
-fi
+SETUP_VERSION="v0.5.0"
 
 LOGFILE=/tmp/tollgate-setup.log
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$LOGFILE"; }
@@ -277,8 +278,36 @@ commit_all() {
 
 # -- driver -----------------------------------------------------------------
 
+# Check if full setup is needed (version mismatch or first boot)
+EXISTING_VERSION=""
+if [ -f "$SETUP_FLAG" ]; then
+    EXISTING_VERSION=$(cat "$SETUP_FLAG" 2>/dev/null)
+fi
+
+if [ "$EXISTING_VERSION" = "$SETUP_VERSION" ]; then
+    # Same version — verify wireless APs only (fixes #103/#173: APs missing
+    # after reinstall when setup-done flag persisted from a prior install).
+    : > "$LOGFILE"
+    log "Flag matches $SETUP_VERSION — verifying wireless APs only"
+
+    # Recover gateway name from existing config for AP SSID consistency
+    GATEWAY_NAME=$(uci -q get wireless.tollgate_2g_open.ssid 2>/dev/null) || \
+    GATEWAY_NAME=$(uci -q get wireless.default_radio0.ssid 2>/dev/null) || \
+    GATEWAY_NAME="TollGate-$(hexdump -n 3 -e '4/1 "%02X"' /dev/urandom | cut -c1-4)"
+    RANDOM_SUFFIX="${GATEWAY_NAME#TollGate-}"
+
+    configure_radio_ap 'default_radio0' 'tollgate_2g_open'
+    configure_radio_ap 'default_radio1' 'tollgate_5g_open'
+    uci -q get wireless.radio0 >/dev/null && uci set wireless.radio0.disabled='0'
+    uci -q get wireless.radio1 >/dev/null && uci set wireless.radio1.disabled='0'
+    uci commit wireless
+    log "Wireless AP verification completed"
+    exit 0
+fi
+
+# Full setup (first boot or version change)
 : > "$LOGFILE"
-log "Starting TollGate configuration"
+log "Running full setup (version $SETUP_VERSION, previous: ${EXISTING_VERSION:-none})"
 
 setup_firewall_include
 setup_uhttpd
@@ -293,6 +322,6 @@ enable_modems
 setup_private_network        # consumes RANDOM_SUFFIX
 commit_all
 
-log "TollGate setup completed"
-touch "$SETUP_FLAG"
+log "TollGate setup completed (version $SETUP_VERSION)"
+echo "$SETUP_VERSION" > "$SETUP_FLAG"
 exit 0


### PR DESCRIPTION
## Problem

The `99-tollgate-setup` uci-defaults script bailed entirely (`exit 0`) when `/etc/tollgate-setup-done` existed. On reinstall/upgrade, the flag persists in `/etc/`, so wireless APs were never recreated — TollGate SSIDs disappeared.

## Fix

Both approaches combined:

1. **Version-gated flag**: the flag now stores the setup version (`v0.5.0`). Upgrades that ship a new version trigger full re-setup.
2. **Always-run wireless verification**: even on same-version reinstall, the script verifies TollGate APs exist on both radios and recreates them if missing. AP SSID is recovered from existing config for consistency.

## Before (buggy)
```sh
if [ -f "$SETUP_FLAG" ]; then exit 0; fi  # bails entirely
```

## After (fixed)
```sh
if [ "$EXISTING_VERSION" = "$SETUP_VERSION" ]; then
    # Same version: verify/recreate APs only, then exit
    configure_radio_ap 'default_radio0' 'tollgate_2g_open'
    configure_radio_ap 'default_radio1' 'tollgate_5g_open'
    uci commit wireless
    exit 0
fi
# Full setup for new version or first boot
echo "$SETUP_VERSION" > "$SETUP_FLAG"
```

## Test plan

See #207 for manual reinstall test commands. Cloud-lab test: deploy → verify APs → reinstall → verify APs persist.

Fixes #103, fixes #173.