### PR TITLE
security: RFC 1918 isolation — block WiFi from upstream private networks

### DIFF
--- a/packaging/files/etc/config/firewall-tollgate
+++ b/packaging/files/etc/config/firewall-tollgate
@@ -4,3 +4,24 @@ config rule
 	option proto 'tcp'
 	option dest_port '2121'
 	option target 'ACCEPT'
+
+config rule
+	option name 'Block-WiFi-RFC1918-192.168'
+	option src 'lan'
+	option dest 'wan'
+	option dest_ip '192.168.0.0/16'
+	option target 'DROP'
+
+config rule
+	option name 'Block-WiFi-RFC1918-10.0'
+	option src 'lan'
+	option dest 'wan'
+	option dest_ip '10.0.0.0/8'
+	option target 'DROP'
+
+config rule
+	option name 'Block-WiFi-RFC1918-172.16'
+	option src 'lan'
+	option dest 'wan'
+	option dest_ip '172.16.0.0/12'
+	option target 'DROP'

--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -139,6 +139,20 @@ setup_nodogsplash() {
     fi
     uci set nodogsplash.@nodogsplash[0].gatewaydomainname='TollGate.lan'
     uci set nodogsplash.@nodogsplash[0].gatewayport='2050'
+
+    # Defense-in-depth: block authenticated WiFi clients from reaching
+    # RFC1918 addresses (complements the fw4 DROP rules in firewall-tollgate).
+    local nds_auth
+    nds_auth=$(uci -q get nodogsplash.@nodogsplash[0].authenticated_users 2>/dev/null || echo "")
+    if ! echo "$nds_auth" | grep -q "10.0.0.0/8"; then
+        uci add_list nodogsplash.@nodogsplash[0].authenticated_users='block to 10.0.0.0/8'
+    fi
+    if ! echo "$nds_auth" | grep -q "172.16.0.0/12"; then
+        uci add_list nodogsplash.@nodogsplash[0].authenticated_users='block to 172.16.0.0/12'
+    fi
+    if ! echo "$nds_auth" | grep -q "192.168.0.0/16"; then
+        uci add_list nodogsplash.@nodogsplash[0].authenticated_users='block to 192.168.0.0/16'
+    fi
 }
 
 setup_tollgate_firewall_rules() {


### PR DESCRIPTION
## What

Blocks authenticated WiFi clients from reaching RFC 1918 addresses on the upstream/WAN side. Three fw4 DROP rules:

| Rule | CIDR | Covers |
|------|------|--------|
| Block-WiFi-RFC1918-192.168 | 192.168.0.0/16 | Home/office networks |
| Block-WiFi-RFC1918-10.0 | 10.0.0.0/8 | Enterprise networks |
| Block-WiFi-RFC1918-172.16 | 172.16.0.0/12 | Medium networks |

## Why

Without this, a paying WiFi customer can scan the operator's upstream private network — reaching PCs, printers, NAS, cameras, other routers. This is the isolation PR #201 promised but didn't implement (see #208 for why #201 was an incomplete duplicate).

## What's NOT blocked

- ✅ Internet access (NAT'd to public IPs) — unaffected
- ✅ Router services (port 2121/8080/2050) — those are lan→router, not lan→wan
- ✅ Router's own upstream connection — originated traffic, not forwarded

## Test plan

1. Deploy with this branch
2. Authenticate a WiFi client (pay a token)
3. Try to ping/reach 192.168.x.x on the upstream → should fail
4. Try to reach a public IP (e.g., 1.1.1.1) → should succeed
5. Try to reach router services (port 2121) → should succeed
6. Run cloud-lab API tests → should pass (45+ like baseline)