### PR TITLE
security: tighten config file permissions (0644 → 0600)

### DIFF
--- a/src/config_manager/config_manager_config.go
+++ b/src/config_manager/config_manager_config.go
@@ -161,7 +161,7 @@ func SaveConfig(filePath string, config *Config) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filePath, data, 0644)
+	return os.WriteFile(filePath, data, 0600)
 }
 
 func defaultProductionMints() []MintConfig {

--- a/src/config_manager/config_manager_install.go
+++ b/src/config_manager/config_manager_install.go
@@ -59,7 +59,7 @@ func SaveInstallConfig(filePath string, installConfig *InstallConfig) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filePath, data, 0644)
+	return os.WriteFile(filePath, data, 0600)
 }
 
 // EnsureDefaultInstall ensures a default install.json exists, loading from file if present.


### PR DESCRIPTION
## Change

Two config files written with world-readable 0644 → root-only 0600.

- `config_manager_config.go:164` — SaveConfig (writes /etc/tollgate/config.json)
- `config_manager_install.go:62` — SaveInstallConfig

Trivial 2-line fix. identities.json already uses 0600 (PR #104).

Closes #219.