### PR TITLE
security: validate UCI key/value against control characters

### DIFF
--- a/src/cli/network.go
+++ b/src/cli/network.go
@@ -351,6 +351,12 @@ func getUCIValue(key string) (string, error) {
 
 // setUCIValue sets a UCI configuration value
 func setUCIValue(key, value string) error {
+	if strings.ContainsAny(key, "\n\r\x00") {
+		return fmt.Errorf("invalid UCI key: contains control characters")
+	}
+	if strings.ContainsAny(value, "\n\r\x00") {
+		return fmt.Errorf("invalid UCI value: contains control characters")
+	}
 	cmd := exec.Command("uci", "set", fmt.Sprintf("%s=%s", key, value))
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to set UCI value: %v", err)

--- a/src/cli/network_test.go
+++ b/src/cli/network_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSetUCIValue_RejectsNewlineInKey(t *testing.T) {
+	err := setUCIValue("wireless\nrm -rf /", "TollGate")
+	if err == nil {
+		t.Error("setUCIValue should reject newline in key")
+	}
+}
+
+func TestSetUCIValue_RejectsNewlineInValue(t *testing.T) {
+	err := setUCIValue("wireless.ssid", "TollGate\nrm -rf /")
+	if err == nil {
+		t.Error("setUCIValue should reject newline in value")
+	}
+}
+
+func TestSetUCIValue_RejectsCarriageReturn(t *testing.T) {
+	err := setUCIValue("wireless\r.ssid", "value")
+	if err == nil {
+		t.Error("setUCIValue should reject carriage return in key")
+	}
+}
+
+func TestSetUCIValue_RejectsNullByte(t *testing.T) {
+	err := setUCIValue("wireless\x00.ssid", "value")
+	if err == nil {
+		t.Error("setUCIValue should reject null byte in key")
+	}
+}
+
+func TestSetUCIValue_AcceptsValidKey(t *testing.T) {
+	// In test env, uci binary doesn't exist, so exec.Command will fail.
+	// The test passes if the error is NOT a validation error.
+	err := setUCIValue("wireless.@wifi-iface[0].ssid", "TollGate-ABCD")
+	if err != nil {
+		errMsg := err.Error()
+		for _, substr := range []string{"control characters", "invalid UCI key", "invalid UCI value"} {
+			if strings.Contains(errMsg, substr) {
+				t.Errorf("valid key/value rejected by validation: %v", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Change

`setUCIValue` accepted arbitrary strings without validation. While `exec.Command` prevents shell injection, control characters (newlines, CR, null) could corrupt UCI config or enable argument injection.

Add validation: reject keys/values containing `\n\r\x00`.

Closes #220.