### PR TITLE
fix(ci): publish NIP-94 1063 events directly during build step

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -637,6 +637,7 @@ jobs:
               --tag n="$PACKAGE_NAME" \
               --tag compression="$compression" \
               --tag format="$fmt" \
+              $RELAYS \
               < /dev/null \
               | jq -c . >> events.jsonl
           done < build-results.jsonl
@@ -648,10 +649,11 @@ jobs:
             exit 1
           fi
 
-      - name: Publish events (one connection per relay)
+      - name: Verify NIP-94 events published
         run: |
           set -euo pipefail
-          cat events.jsonl | nak event $RELAYS
+          echo "Events were published directly during the build step."
+          echo "Event count: $(wc -l < events.jsonl)"
 
       - name: Cleanup coordination events
         env:


### PR DESCRIPTION
## Bug

NIP-94 file-metadata events (kind 1063) were **never published to relays**. The CI built them correctly but the publishing step was broken.

### Root cause

The "Publish events" step used:
```bash
cat events.jsonl | nak event $RELAYS
```

`nak event` without `--sec` creates **new kind-1 text notes** from the piped JSON — it does not publish pre-signed 1063 events. The actual 1063 events (built and signed in the previous step) were saved to `events.jsonl` but the garbage text notes were published instead.

### Fix

Add `$RELAYS` as positional args to the `nak event --sec "$NSEC_HEX" -k 1063 ...` call in the "Build NIP-94 events" step. This publishes each 1063 event directly to relays when it's created. The broken "Publish events" step is replaced with a verification message.

### Impact

After this fix, ALL branch builds (main, feature branches, PRs from the same repo) will publish kind 1063 events to the coordination relays. The artifact resolver in physical-router-test-automation can then find them automatically, enabling router-level testing of any branch via `cloud-lab.py submit --branch <branch>`.

Before this fix, only kind 30078 (transient coordination) events were published — and they were cleaned up (kind 5 deletion) after the build completed, leaving no persistent artifact index.