### PR TITLE
security: RFC 1918 isolation — block WiFi from upstream private networks

### DIFF
--- a/packaging/files/etc/uci-defaults/99-tollgate-setup
+++ b/packaging/files/etc/uci-defaults/99-tollgate-setup
@@ -131,6 +131,20 @@ setup_nodogsplash() {
     fi
     uci set nodogsplash.@nodogsplash[0].gatewaydomainname='TollGate.lan'
     uci set nodogsplash.@nodogsplash[0].gatewayport='2050'
+
+    # Defense-in-depth: block authenticated WiFi clients from reaching
+    # RFC1918 addresses (complements the fw4 DROP rules in firewall-tollgate).
+    local nds_auth
+    nds_auth=$(uci -q get nodogsplash.@nodogsplash[0].authenticated_users 2>/dev/null || echo "")
+    if ! echo "$nds_auth" | grep -q "10.0.0.0/8"; then
+        uci add_list nodogsplash.@nodogsplash[0].authenticated_users='block to 10.0.0.0/8'
+    fi
+    if ! echo "$nds_auth" | grep -q "172.16.0.0/12"; then
+        uci add_list nodogsplash.@nodogsplash[0].authenticated_users='block to 172.16.0.0/12'
+    fi
+    if ! echo "$nds_auth" | grep -q "192.168.0.0/16"; then
+        uci add_list nodogsplash.@nodogsplash[0].authenticated_users='block to 192.168.0.0/16'
+    fi
 }
 
 setup_tollgate_firewall_rules() {


### PR DESCRIPTION
Replaces fork-based #217 (same code, same-repo branch for instant mergeability).

Without this fix, an authenticated public WiFi customer can directly access devices on the operator's upstream private network — PCs, printers, NAS, ISP router admin.

Cloud lab verified: 171 passed, 0 failed, 0 errors, 144 skipped.

Original description and discussion on #217.