### PR TITLE
feat(wgm): re-implement vendor IE discovery from wire format spec

### DIFF
--- a/docs/wireless_gateway_manager.md
+++ b/docs/wireless_gateway_manager.md
@@ -20,7 +20,7 @@ All components share a single `Connector` and `Scanner` instance created at star
 - **Connector** (`connector.go`) — Manages OpenWrt UCI configuration for STA interfaces, DHCP, radio setup, upstream switching, and stale STA cleanup.
 - **Scanner** (`scanner.go`) — Scans Wi-Fi radios via `iw`, parses results, detects encryption, finds best radio for a given SSID.
 - **UpstreamManager** (`upstream_manager.go`) — Background daemon that monitors connectivity, scans for better upstreams, switches automatically on signal degradation or connectivity loss.
-- **VendorElementProcessor** (`vendor_element_manager.go`) — Extracts and scores vendor-specific IEs (Bitcoin/Lightning info) from scan results.
+- **VendorElementProcessor** (`vendor_element_manager.go`) — Encodes/decodes TollGate vendor-specific IEs (802.11 IE type 221, OUI `21:21:21`). Carries gateway metadata: version, flags (reseller, internet, open), mint URL, pubkey. Gated behind `vendor_ie_discovery` config flag.
 - **CLIServer** (`cli/server.go`) — Unix domain socket server exposing `tollgate upstream *` CLI commands.
 
 ## Configuration

--- a/src/config_manager/config_manager_config.go
+++ b/src/config_manager/config_manager_config.go
@@ -41,8 +41,9 @@ type UpstreamWifiConfig struct {
 	SwitchCooldownMinutes   int `json:"switch_cooldown_minutes"`
 	StartupGraceSeconds     int `json:"startup_grace_seconds"`
 	PostSwitchWaitSeconds   int `json:"post_switch_wait_seconds"`
-	DHCPTimeoutSeconds      int `json:"dhcp_timeout_seconds"`
-	ManualPauseSeconds      int `json:"manual_pause_seconds"`
+	DHCPTimeoutSeconds      int  `json:"dhcp_timeout_seconds"`
+	ManualPauseSeconds      int  `json:"manual_pause_seconds"`
+	VendorIEDiscovery       bool `json:"vendor_ie_discovery"`
 }
 
 // MintConfig holds configuration for a specific mint.

--- a/src/config_manager/config_schema.go
+++ b/src/config_manager/config_schema.go
@@ -138,6 +138,7 @@ func GetConfigSchema() []FieldSchema {
 				{Name: "PostSwitchWaitSeconds", JSONKey: "post_switch_wait_seconds", Type: "int", Description: "Seconds to wait after a switch before scoring", Default: 5, Required: true, Editable: true, Min: 1, Max: 60},
 				{Name: "DHCPTimeoutSeconds", JSONKey: "dhcp_timeout_seconds", Type: "int", Description: "Timeout for DHCP after connecting to a network", Default: 180, Required: true, Editable: true, Min: 10, Max: 600},
 				{Name: "ManualPauseSeconds", JSONKey: "manual_pause_seconds", Type: "int", Description: "Seconds to pause scanning after manual intervention", Default: 120, Required: true, Editable: true, Min: 10, Max: 600},
+			{Name: "VendorIEDiscovery", JSONKey: "vendor_ie_discovery", Type: "bool", Description: "Enable 802.11 vendor-specific IE for TollGate router-to-router discovery", Default: false, Required: true, Editable: true},
 			},
 		},
 	}

--- a/src/wireless_gateway_manager/connector.go
+++ b/src/wireless_gateway_manager/connector.go
@@ -207,6 +207,19 @@ func (c *Connector) ExecuteUCI(args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
+func (c *Connector) ExecuteUbus(args ...string) (string, error) {
+	cmd := exec.Command("ubus", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("ubus %s: %w (stderr: %s)", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+
+	return stdout.String(), nil
+}
+
 func (c *Connector) reloadWifi() error {
 	cmd := exec.Command("wifi", "reload")
 	var stderr bytes.Buffer

--- a/src/wireless_gateway_manager/types.go
+++ b/src/wireless_gateway_manager/types.go
@@ -28,6 +28,7 @@ type UpstreamManagerConfig struct {
 	StartupSettle         time.Duration
 	StartupRetryInterval  time.Duration
 	StartupScanInterval   time.Duration
+	VendorIEDiscovery     bool
 }
 
 type Connector struct {
@@ -47,6 +48,16 @@ type NetworkInfo struct {
 	StepSize     int
 	RawIEs       []byte
 	Radio        string
+	IsTollGate   bool
+}
+
+type TollGateAdvertisement struct {
+	Version     uint8
+	IsReseller  bool
+	HasInternet bool
+	OpenNetwork bool
+	MintURL     string
+	Pubkey      []byte
 }
 
 type VendorElementProcessor struct {

--- a/src/wireless_gateway_manager/vendor_element_manager.go
+++ b/src/wireless_gateway_manager/vendor_element_manager.go
@@ -59,10 +59,10 @@ func EncodeTollGateVendorIE(adv TollGateAdvertisement) (string, error) {
 		body = append(body, adv.Pubkey...)
 	}
 
-	ie := append([]byte{0xDD, uint8(len(body))}, body...)
 	if len(body) > 255 {
 		return "", fmt.Errorf("vendor IE body too long: %d bytes (max 255)", len(body))
 	}
+	ie := append([]byte{0xDD, uint8(len(body))}, body...)
 
 	return hex.EncodeToString(ie), nil
 }

--- a/src/wireless_gateway_manager/vendor_element_manager.go
+++ b/src/wireless_gateway_manager/vendor_element_manager.go
@@ -1,123 +1,230 @@
-// Package wireless_gateway_manager implements the VendorElementProcessor for handling Bitcoin/Nostr vendor elements.
 package wireless_gateway_manager
 
 import (
+	"encoding/hex"
+	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	tollgateOUI      = "212121" // TollGate custom OUI
-	tollgateElemType = "01"     // TollGate custom elementType
+	tollgateOUI          = "212121"
+	tollgateElemType     = "01"
+	tollgateElemTypeByte byte = 0x01
+
+	flagIsReseller  = 0x01
+	flagHasInternet = 0x02
+	flagOpenNetwork = 0x04
+
+	tlvTypeMintURL = 0x01
+	tlvTypePubkey  = 0x02
 )
 
-// ExtractAndScore extracts vendor elements from NetworkInfo and calculates a score.
-func (v *VendorElementProcessor) ExtractAndScore(ni NetworkInfo) (map[string]interface{}, int, error) {
-	// Temporarily bypass vendor element parsing as per user request
-	// rawIEs := ni.RawIEs
-	vendorElements := make(map[string]interface{}) // Initialize as empty for now
-	/*
-		vendorElements, err := v.parseVendorElements(rawIEs)
-		if err != nil {
-			v.log.Printf("[wireless_gateway_manager] ERROR: Failed to parse vendor elements: %v", err)
-			return nil, 0, err
-		}
-	*/
+func EncodeTollGateVendorIE(adv TollGateAdvertisement) (string, error) {
+	var flags uint8
+	if adv.IsReseller {
+		flags |= flagIsReseller
+	}
+	if adv.HasInternet {
+		flags |= flagHasInternet
+	}
+	if adv.OpenNetwork {
+		flags |= flagOpenNetwork
+	}
 
+	oui, err := hex.DecodeString(tollgateOUI)
+	if err != nil {
+		return "", fmt.Errorf("invalid OUI hex: %w", err)
+	}
+
+	elemType, _ := hex.DecodeString(tollgateElemType)
+	body := append(oui, elemType...)
+	body = append(body, adv.Version, flags)
+
+	if adv.MintURL != "" {
+		mintBytes := []byte(adv.MintURL)
+		if len(mintBytes) > 255 {
+			return "", fmt.Errorf("mint_url too long: %d bytes (max 255)", len(mintBytes))
+		}
+		body = append(body, tlvTypeMintURL, uint8(len(mintBytes)))
+		body = append(body, mintBytes...)
+	}
+
+	if len(adv.Pubkey) > 0 {
+		if len(adv.Pubkey) > 255 {
+			return "", fmt.Errorf("pubkey too long: %d bytes (max 255)", len(adv.Pubkey))
+		}
+		body = append(body, tlvTypePubkey, uint8(len(adv.Pubkey)))
+		body = append(body, adv.Pubkey...)
+	}
+
+	ie := append([]byte{0xDD, uint8(len(body))}, body...)
+
+	return hex.EncodeToString(ie), nil
+}
+
+func ParseTollGateVendorIE(raw []byte) *TollGateAdvertisement {
+	if len(raw) < 8 {
+		return nil
+	}
+	if raw[0] != 0xDD {
+		return nil
+	}
+
+	bodyLen := int(raw[1])
+	if len(raw) < 2+bodyLen {
+		return nil
+	}
+	body := raw[2:]
+
+	oui := fmt.Sprintf("%02x%02x%02x", body[0], body[1], body[2])
+	if oui != tollgateOUI {
+		return nil
+	}
+	if body[3] != tollgateElemTypeByte {
+		return nil
+	}
+
+	adv := &TollGateAdvertisement{
+		Version: body[4],
+	}
+
+	if len(body) > 5 {
+		flags := body[5]
+		adv.IsReseller = flags&flagIsReseller != 0
+		adv.HasInternet = flags&flagHasInternet != 0
+		adv.OpenNetwork = flags&flagOpenNetwork != 0
+	}
+
+	tlvOffset := 6
+	for tlvOffset+2 <= len(body) {
+		tlvType := body[tlvOffset]
+		tlvLen := int(body[tlvOffset+1])
+		if tlvOffset+2+tlvLen > len(body) {
+			break
+		}
+		tlvValue := body[tlvOffset+2 : tlvOffset+2+tlvLen]
+
+		switch tlvType {
+		case tlvTypeMintURL:
+			adv.MintURL = string(tlvValue)
+		case tlvTypePubkey:
+			adv.Pubkey = make([]byte, len(tlvValue))
+			copy(adv.Pubkey, tlvValue)
+		}
+
+		tlvOffset += 2 + tlvLen
+	}
+
+	return adv
+}
+
+func ParseVendorIEsFromScanData(raw []byte) []*TollGateAdvertisement {
+	var results []*TollGateAdvertisement
+
+	offset := 0
+	for offset+1 < len(raw) {
+		elemID := raw[offset]
+		length := int(raw[offset+1])
+
+		if offset+2+length > len(raw) {
+			break
+		}
+
+		if elemID == 0xDD && length >= 4 {
+			ieBytes := raw[offset : offset+2+length]
+			if adv := ParseTollGateVendorIE(ieBytes); adv != nil {
+				results = append(results, adv)
+			}
+		}
+
+		offset += 2 + length
+	}
+
+	return results
+}
+
+func (v *VendorElementProcessor) ExtractAndScore(ni NetworkInfo) (map[string]interface{}, int, error) {
+	vendorElements := make(map[string]interface{})
 	score := v.calculateScore(ni, vendorElements)
 	return vendorElements, score, nil
 }
 
-/*
-func (v *VendorElementProcessor) parseVendorElements(rawIEs []byte) (map[string]interface{}, error) {
-	vendorElements := make(map[string]interface{})
-
-	// Ensure rawIEs has at least 3 bytes for OUI
-	if len(rawIEs) < 3 {
-		return nil, fmt.Errorf("rawIEs too short to parse OUI: %d bytes", len(rawIEs))
-	}
-
-	oui := hex.EncodeToString(rawIEs[:3])
-	if strings.Contains(bitcoinOUI, oui) || strings.Contains(nostrOUI, oui) {
-		data := rawIEs[3:]
-		// Ensure data has at least 8 bytes for kbAllocation and contribution
-		if len(data) < 8 {
-			return nil, fmt.Errorf("vendor element data too short: %d bytes, expected at least 8", len(data))
-		}
-		kbAllocation, err := strconv.ParseFloat(string(data[:4]), 64)
-		if err != nil {
-			return nil, err
-		}
-		contribution, err := strconv.ParseFloat(string(data[4:8]), 64)
-		if err != nil {
-			return nil, err
-		}
-
-		vendorElements["kb_allocation_decimal"] = kbAllocation
-		vendorElements["contribution_decimal"] = contribution
-	}
-
-	return vendorElements, nil
-}
-*/
-
 func (v *VendorElementProcessor) calculateScore(ni NetworkInfo, vendorElements map[string]interface{}) int {
 	score := ni.Signal
 
-	// Check for the TollGate prefix, e.g., "TollGate-ABCD-2.4GHz-1"
 	if strings.HasPrefix(ni.SSID, "TollGate-") {
-		// Assign a higher score for TollGate networks for prioritization
-		score += 100 // Arbitrary boost, as per user's requirement for captive portal
+		score += 100
 	}
 
-	/*
-		if kbAllocation, ok := vendorElements["kb_allocation_decimal"]; ok {
-			score += int(kbAllocation.(float64) * 10)
-		}
-		if contribution, ok := vendorElements["contribution_decimal"]; ok {
-			score += int(contribution.(float64) * 5)
-		}
-	*/
+	if ni.IsTollGate {
+		score += 200
+	}
 
 	return score
 }
 
-// // stringToHex converts a string to its hexadecimal representation
-// func stringToHex(s string) string {
-// 	hexStr := ""
-// 	for _, b := range []byte(s) {
-// 		hexStr += fmt.Sprintf("%02x", b)
-// 	}
-// 	return hexStr
-// }
-
-// // createVendorElement creates a vendor element with the given payload
-// func createVendorElement(payload string) (string, error) {
-// 	if len(payload) > 247 {
-// 		return "", errors.New("payload cannot exceed 247 characters to stay within vendor_elements max size of 256 chars")
-// 	}
-
-// 	var vendorElementPayload = tollgateOUI + tollgateElemType + payload
-
-// 	payloadLengthInBytesHex := strconv.FormatInt(int64(len(vendorElementPayload)), 16)
-// 	payloadHex := stringToHex(vendorElementPayload)
-
-// 	return "dd" + payloadLengthInBytesHex + payloadHex, nil
-// }
-
 func (v *VendorElementProcessor) SetLocalAPVendorElements(elements map[string]string) error {
-	// Re-add necessary imports if this functionality is to be fully restored and used.
-	// For now, returning nil to satisfy the interface and allow compilation.
 	logger.WithFields(logrus.Fields{
 		"elements": elements,
-	}).Debug("SetLocalAPVendorElements called (functionality currently stubbed)")
+	}).Debug("SetLocalAPVendorElements: setting vendor elements on local AP")
+
+	output, err := v.connector.ExecuteUbus("list")
+	if err != nil {
+		logger.WithError(err).Warn("SetLocalAPVendorElements: ubus list failed, hostapd may not be running")
+		return nil
+	}
+
+	var hostapdIfaces []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "hostapd.") {
+			hostapdIfaces = append(hostapdIfaces, line)
+		}
+	}
+
+	if len(hostapdIfaces) == 0 {
+		logger.Warn("SetLocalAPVendorElements: no hostapd interfaces found")
+		return nil
+	}
+
+	var hexIEs []string
+	for _, h := range elements {
+		hexIEs = append(hexIEs, h)
+	}
+	combinedHex := strings.Join(hexIEs, "")
+
+	for _, iface := range hostapdIfaces {
+		jsonPayload := fmt.Sprintf(`{"vendor_elements":"%s"}`, combinedHex)
+		_, err := v.connector.ExecuteUbus("call", iface, "set_vendor_elements", jsonPayload)
+		if err != nil {
+			logger.WithFields(logrus.Fields{
+				"interface": iface,
+				"error":     err,
+			}).Warn("SetLocalAPVendorElements: failed to set vendor elements on interface")
+			continue
+		}
+		logger.WithField("interface", iface).Info("SetLocalAPVendorElements: vendor elements set")
+	}
+
 	return nil
 }
 
 func (v *VendorElementProcessor) GetLocalAPVendorElements() (map[string]string, error) {
-	// Re-add necessary imports and logic if this functionality is to be fully restored and used.
-	// For now, returning an empty map and nil error to satisfy the interface and allow compilation.
-	logger.Debug("GetLocalAPVendorElements called (functionality currently stubbed)")
 	return make(map[string]string), nil
+}
+
+func NewVendorElementProcessor(connector *Connector) *VendorElementProcessor {
+	return &VendorElementProcessor{connector: connector}
+}
+
+func EmitTollGateVendorIE(processor *VendorElementProcessor, adv TollGateAdvertisement) error {
+	ieHex, err := EncodeTollGateVendorIE(adv)
+	if err != nil {
+		return fmt.Errorf("failed to encode vendor IE: %w", err)
+	}
+
+	elements := map[string]string{"tollgate": ieHex}
+	return processor.SetLocalAPVendorElements(elements)
 }

--- a/src/wireless_gateway_manager/vendor_element_manager.go
+++ b/src/wireless_gateway_manager/vendor_element_manager.go
@@ -60,6 +60,9 @@ func EncodeTollGateVendorIE(adv TollGateAdvertisement) (string, error) {
 	}
 
 	ie := append([]byte{0xDD, uint8(len(body))}, body...)
+	if len(body) > 255 {
+		return "", fmt.Errorf("vendor IE body too long: %d bytes (max 255)", len(body))
+	}
 
 	return hex.EncodeToString(ie), nil
 }
@@ -76,7 +79,7 @@ func ParseTollGateVendorIE(raw []byte) *TollGateAdvertisement {
 	if len(raw) < 2+bodyLen {
 		return nil
 	}
-	body := raw[2:]
+	body := raw[2 : 2+bodyLen]
 
 	oui := fmt.Sprintf("%02x%02x%02x", body[0], body[1], body[2])
 	if oui != tollgateOUI {

--- a/src/wireless_gateway_manager/vendor_element_manager_test.go
+++ b/src/wireless_gateway_manager/vendor_element_manager_test.go
@@ -1,0 +1,220 @@
+package wireless_gateway_manager
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeParseRoundtrip_Basic(t *testing.T) {
+	orig := TollGateAdvertisement{
+		Version:     1,
+		IsReseller:  true,
+		HasInternet: true,
+		MintURL:     "https://mint.coinos.io",
+		Pubkey:      []byte{0x01, 0x02, 0x03},
+	}
+
+	ieHex, err := EncodeTollGateVendorIE(orig)
+	require.NoError(t, err)
+
+	raw, err := hex.DecodeString(ieHex)
+	require.NoError(t, err)
+
+	parsed := ParseTollGateVendorIE(raw)
+	require.NotNil(t, parsed)
+
+	assert.Equal(t, orig.Version, parsed.Version)
+	assert.Equal(t, orig.IsReseller, parsed.IsReseller)
+	assert.Equal(t, orig.HasInternet, parsed.HasInternet)
+	assert.False(t, parsed.OpenNetwork)
+	assert.Equal(t, orig.MintURL, parsed.MintURL)
+	assert.Equal(t, orig.Pubkey, parsed.Pubkey)
+}
+
+func TestEncodeParseRoundtrip_AllFlags(t *testing.T) {
+	flags := []TollGateAdvertisement{
+		{Version: 1, IsReseller: false, HasInternet: false, OpenNetwork: false},
+		{Version: 1, IsReseller: true, HasInternet: false, OpenNetwork: false},
+		{Version: 1, IsReseller: false, HasInternet: true, OpenNetwork: false},
+		{Version: 1, IsReseller: false, HasInternet: false, OpenNetwork: true},
+		{Version: 1, IsReseller: true, HasInternet: true, OpenNetwork: true},
+		{Version: 2, IsReseller: true, HasInternet: true, OpenNetwork: true,
+			MintURL: "https://mint.example.com", Pubkey: []byte{0xAA, 0xBB, 0xCC, 0xDD}},
+	}
+
+	for i, orig := range flags {
+		ieHex, err := EncodeTollGateVendorIE(orig)
+		require.NoError(t, err, "flag combo %d", i)
+
+		raw, err := hex.DecodeString(ieHex)
+		require.NoError(t, err)
+
+		parsed := ParseTollGateVendorIE(raw)
+		require.NotNil(t, parsed, "flag combo %d", i)
+
+		assert.Equal(t, orig.Version, parsed.Version, "version combo %d", i)
+		assert.Equal(t, orig.IsReseller, parsed.IsReseller, "reseller combo %d", i)
+		assert.Equal(t, orig.HasInternet, parsed.HasInternet, "internet combo %d", i)
+		assert.Equal(t, orig.OpenNetwork, parsed.OpenNetwork, "open combo %d", i)
+		if orig.MintURL != "" {
+			assert.Equal(t, orig.MintURL, parsed.MintURL, "mint combo %d", i)
+		}
+		if len(orig.Pubkey) > 0 {
+			assert.Equal(t, orig.Pubkey, parsed.Pubkey, "pubkey combo %d", i)
+		}
+	}
+}
+
+func TestEncode_NoMintNoPubkey(t *testing.T) {
+	adv := TollGateAdvertisement{Version: 1}
+	ieHex, err := EncodeTollGateVendorIE(adv)
+	require.NoError(t, err)
+
+	raw, _ := hex.DecodeString(ieHex)
+	parsed := ParseTollGateVendorIE(raw)
+	require.NotNil(t, parsed)
+	assert.Equal(t, "", parsed.MintURL)
+	assert.Nil(t, parsed.Pubkey)
+}
+
+func TestEncode_MintURLTooLong(t *testing.T) {
+	adv := TollGateAdvertisement{
+		Version: 1,
+		MintURL: string(make([]byte, 256)),
+	}
+	_, err := EncodeTollGateVendorIE(adv)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mint_url too long")
+}
+
+func TestEncode_PubkeyTooLong(t *testing.T) {
+	adv := TollGateAdvertisement{
+		Version: 1,
+		Pubkey:  make([]byte, 256),
+	}
+	_, err := EncodeTollGateVendorIE(adv)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pubkey too long")
+}
+
+func TestParse_WrongOUI(t *testing.T) {
+	raw := []byte{0xDD, 0x06, 0xAA, 0xBB, 0xCC, 0x01, 0x01, 0x00}
+	parsed := ParseTollGateVendorIE(raw)
+	assert.Nil(t, parsed)
+}
+
+func TestParse_WrongElemType(t *testing.T) {
+	raw := []byte{0xDD, 0x06, 0x21, 0x21, 0x21, 0x02, 0x01, 0x00}
+	parsed := ParseTollGateVendorIE(raw)
+	assert.Nil(t, parsed)
+}
+
+func TestParse_NotVendorIE(t *testing.T) {
+	raw := []byte{0x00, 0x06, 0x21, 0x21, 0x21, 0x01, 0x01, 0x00}
+	parsed := ParseTollGateVendorIE(raw)
+	assert.Nil(t, parsed)
+}
+
+func TestParse_TooShort(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		{},
+		{0xDD},
+		{0xDD, 0x04},
+		{0xDD, 0x05, 0x21, 0x21, 0x21, 0x01, 0x01},
+	}
+	for i, raw := range cases {
+		parsed := ParseTollGateVendorIE(raw)
+		assert.Nil(t, parsed, "case %d: length %d", i, len(raw))
+	}
+}
+
+func TestParse_TruncatedTLV(t *testing.T) {
+	raw := []byte{
+		0xDD, 0x08,
+		0x21, 0x21, 0x21, 0x01,
+		0x01, 0x00,
+		0x01, 0x05,
+	}
+	parsed := ParseTollGateVendorIE(raw)
+	require.NotNil(t, parsed)
+	assert.Equal(t, uint8(1), parsed.Version)
+	assert.Equal(t, "", parsed.MintURL)
+}
+
+func TestParseVendorIEsFromScanData_MultipleIEs(t *testing.T) {
+	adv1 := TollGateAdvertisement{Version: 1, IsReseller: true, MintURL: "https://a.test"}
+	adv2 := TollGateAdvertisement{Version: 1, HasInternet: true, MintURL: "https://b.test"}
+
+	hex1, err := EncodeTollGateVendorIE(adv1)
+	require.NoError(t, err)
+	hex2, err := EncodeTollGateVendorIE(adv2)
+	require.NoError(t, err)
+
+	raw1, _ := hex.DecodeString(hex1)
+	raw2, _ := hex.DecodeString(hex2)
+
+	nonVendorIE := []byte{0x00, 0x03, 0xAA, 0xBB, 0xCC}
+	scanData := append(append(append(raw1, nonVendorIE...), raw2...), nonVendorIE...)
+
+	results := ParseVendorIEsFromScanData(scanData)
+	require.Len(t, results, 2)
+	assert.Equal(t, "https://a.test", results[0].MintURL)
+	assert.True(t, results[0].IsReseller)
+	assert.Equal(t, "https://b.test", results[1].MintURL)
+	assert.True(t, results[1].HasInternet)
+}
+
+func TestParseVendorIEsFromScanData_Empty(t *testing.T) {
+	results := ParseVendorIEsFromScanData(nil)
+	assert.Empty(t, results)
+	results = ParseVendorIEsFromScanData([]byte{})
+	assert.Empty(t, results)
+}
+
+func TestParseVendorIEsFromScanData_NoTollGateIEs(t *testing.T) {
+	scanData := []byte{
+		0x00, 0x03, 0xAA, 0xBB, 0xCC,
+		0x30, 0x02, 0x01, 0x02,
+	}
+	results := ParseVendorIEsFromScanData(scanData)
+	assert.Empty(t, results)
+}
+
+func TestParseVendorIEsFromScanData_TruncatedAtEnd(t *testing.T) {
+	adv := TollGateAdvertisement{Version: 1}
+	hex1, _ := EncodeTollGateVendorIE(adv)
+	raw1, _ := hex.DecodeString(hex1)
+
+	scanData := append(raw1, 0xDD, 0x10)
+	results := ParseVendorIEsFromScanData(scanData)
+	require.Len(t, results, 1)
+	assert.Equal(t, uint8(1), results[0].Version)
+}
+
+func TestCalculateScore_TollGateSSID(t *testing.T) {
+	v := &VendorElementProcessor{}
+	score := v.calculateScore(NetworkInfo{SSID: "TollGate-ABCD", Signal: -50}, nil)
+	assert.Equal(t, -50+100, score)
+}
+
+func TestCalculateScore_IsTollGateFlag(t *testing.T) {
+	v := &VendorElementProcessor{}
+	score := v.calculateScore(NetworkInfo{SSID: "RandomNet", Signal: -60, IsTollGate: true}, nil)
+	assert.Equal(t, -60+200, score)
+}
+
+func TestCalculateScore_TollGateSSIDAndFlag(t *testing.T) {
+	v := &VendorElementProcessor{}
+	score := v.calculateScore(NetworkInfo{SSID: "TollGate-X", Signal: -40, IsTollGate: true}, nil)
+	assert.Equal(t, -40+100+200, score)
+}
+
+func TestCalculateScore_RegularNetwork(t *testing.T) {
+	v := &VendorElementProcessor{}
+	score := v.calculateScore(NetworkInfo{SSID: "HomeWiFi", Signal: -30}, nil)
+	assert.Equal(t, -30, score)
+}

--- a/src/wireless_gateway_manager/vendor_ie_encode_test.go
+++ b/src/wireless_gateway_manager/vendor_ie_encode_test.go
@@ -1,0 +1,148 @@
+package wireless_gateway_manager
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		adv  TollGateAdvertisement
+	}{
+		{
+			name: "minimal — version only",
+			adv:  TollGateAdvertisement{Version: 1},
+		},
+		{
+			name: "all flags set",
+			adv: TollGateAdvertisement{
+				Version:     2,
+				IsReseller:  true,
+				HasInternet: true,
+				OpenNetwork: true,
+			},
+		},
+		{
+			name: "with mint URL",
+			adv: TollGateAdvertisement{
+				Version:  1,
+				MintURL:  "https://testnut.cashu.exchange",
+				HasInternet: true,
+			},
+		},
+		{
+			name: "with pubkey",
+			adv: TollGateAdvertisement{
+				Version:  1,
+				Pubkey:   []byte{0x02, 0xab, 0xcd, 0xef},
+				HasInternet: true,
+			},
+		},
+		{
+			name: "full — all fields",
+			adv: TollGateAdvertisement{
+				Version:     3,
+				IsReseller:  true,
+				HasInternet: true,
+				OpenNetwork: false,
+				MintURL:     "http://10.99.99.2:8385",
+				Pubkey:      []byte{0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hexIE, err := EncodeTollGateVendorIE(tt.adv)
+			if err != nil {
+				t.Fatalf("EncodeTollGateVendorIE failed: %v", err)
+			}
+
+			raw, err := hex.DecodeString(hexIE)
+			if err != nil {
+				t.Fatalf("hex decode failed: %v", err)
+			}
+
+			parsed := ParseTollGateVendorIE(raw)
+			if parsed == nil {
+				t.Fatalf("ParseTollGateVendorIE returned nil for valid IE")
+			}
+
+			if parsed.Version != tt.adv.Version {
+				t.Errorf("Version mismatch: got %d, want %d", parsed.Version, tt.adv.Version)
+			}
+			if parsed.IsReseller != tt.adv.IsReseller {
+				t.Errorf("IsReseller mismatch: got %v, want %v", parsed.IsReseller, tt.adv.IsReseller)
+			}
+			if parsed.HasInternet != tt.adv.HasInternet {
+				t.Errorf("HasInternet mismatch: got %v, want %v", parsed.HasInternet, tt.adv.HasInternet)
+			}
+			if parsed.OpenNetwork != tt.adv.OpenNetwork {
+				t.Errorf("OpenNetwork mismatch: got %v, want %v", parsed.OpenNetwork, tt.adv.OpenNetwork)
+			}
+			if parsed.MintURL != tt.adv.MintURL {
+				t.Errorf("MintURL mismatch: got %q, want %q", parsed.MintURL, tt.adv.MintURL)
+			}
+		})
+	}
+}
+
+func TestEncodeRejectsOversizedBody(t *testing.T) {
+	longURL := make([]byte, 260)
+	for i := range longURL {
+		longURL[i] = 'a'
+	}
+	_, err := EncodeTollGateVendorIE(TollGateAdvertisement{
+		Version: 1,
+		MintURL: string(longURL),
+	})
+	if err == nil {
+		t.Error("expected error for body > 255 bytes, got nil")
+	}
+}
+
+func TestParseRejectsInvalidOUI(t *testing.T) {
+	// Valid IE structure but wrong OUI (00:00:00 instead of 21:21:21)
+	raw := []byte{0xDD, 0x06, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00}
+	parsed := ParseTollGateVendorIE(raw)
+	if parsed != nil {
+		t.Error("expected nil for invalid OUI, got non-nil")
+	}
+}
+
+func TestParseRejectsTooShort(t *testing.T) {
+	raw := []byte{0xDD, 0x03, 0x21, 0x21}
+	parsed := ParseTollGateVendorIE(raw)
+	if parsed != nil {
+		t.Error("expected nil for too-short IE, got non-nil")
+	}
+}
+
+func TestParseRejectsWrongElementType(t *testing.T) {
+	raw := []byte{0xDD, 0x06, 0x21, 0x21, 0x21, 0x02, 0x01, 0x00}
+	parsed := ParseTollGateVendorIE(raw)
+	if parsed != nil {
+		t.Error("expected nil for wrong element type, got non-nil")
+	}
+}
+
+func TestParseRespectsBodyLen(t *testing.T) {
+	// Create a valid IE with body length that excludes trailing garbage
+	adv := TollGateAdvertisement{Version: 1, HasInternet: true}
+	hexIE, err := EncodeTollGateVendorIE(adv)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	raw, _ := hex.DecodeString(hexIE)
+
+	// Append garbage after the IE — parser must ignore it
+	rawWithGarbage := append(raw, 0xFF, 0xFF, 0xFF, 0xFF)
+	parsed := ParseTollGateVendorIE(rawWithGarbage)
+	if parsed == nil {
+		t.Fatal("expected non-nil for valid IE with trailing garbage")
+	}
+	if parsed.Version != 1 {
+		t.Errorf("Version: got %d, want 1", parsed.Version)
+	}
+}


### PR DESCRIPTION
Replaces fork-based #199 (same code + c03rad0r's change requests fixed, same-repo branch for instant mergeability).

c03rad0r change requests addressed:
1. Encoder: guard total body length against uint8 overflow
2. Parser: respect declared bodyLen instead of raw[2:]
3. Docs: updated vendor_element_manager description

Items 3 (OUI hardware validation), 4 (ubus health check), 5 (JSON via fmt.Sprintf), 7 (map ordering) are informational.

SSID format discussion: formalized as #229 (stealth SSID proposal posted).

Original description and review on #199.