### PR TITLE
fix(packaging): remove dangling firewall-tollgate references from Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and [Semantic Versioning](https://semver.org/).
   was silently rejected by fw4 (nftables); rules now created directly via
   UCI named sections with idempotent guards
   ([#196](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/196)).
+- **Makefile references to deleted firewall-tollgate.** PR #196 removed
+  `files/etc/config/firewall-tollgate` but two Makefile references (install
+  rule + conffiles list) were left behind, breaking all package builds
+  ([#235](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/235)).
 - **Upstream gateway IP validation.** Loopback, unspecified, and
   link-local addresses are now rejected in the TollGate prober to prevent
   SSRF

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -160,8 +160,6 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_BIN) $(PKG_MAKEFILE_DIR)files/etc/uci-defaults/90-tollgate-captive-portal-symlink $(1)/etc/uci-defaults/
 	$(INSTALL_BIN) $(PKG_MAKEFILE_DIR)files/etc/uci-defaults/99-tollgate-setup $(1)/etc/uci-defaults/
 
-	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DATA) $(PKG_MAKEFILE_DIR)files/etc/config/firewall-tollgate $(1)/etc/config/
 
 	$(INSTALL_DIR) $(1)/usr/local/bin
 	$(INSTALL_BIN) $(PKG_MAKEFILE_DIR)files/usr/local/bin/first-login-setup $(1)/usr/local/bin/
@@ -191,7 +189,6 @@ FILES_$(PKG_NAME) += \
 	/usr/bin/tollgate-apply-ssl \
 	/usr/bin/tollgate-remove-ssl \
 	/etc/init.d/tollgate-wrt \
-	/etc/config/firewall-tollgate \
 	/usr/local/bin/first-login-setup \
 	/etc/uci-defaults/90-tollgate-captive-portal-symlink \
 	/etc/uci-defaults/99-tollgate-setup \


### PR DESCRIPTION
## Bug

PR #196 deleted `files/etc/config/firewall-tollgate` (it was a dead iptables-syntax include that fw4 silently rejected), but two Makefile references were left behind:

1. **Install rule** (line ~164): `$(INSTALL_DATA) .../firewall-tollgate $(1)/etc/config/`
2. **Conffiles list** (line ~194): `/etc/config/firewall-tollgate`

This breaks **every** package build job on every architecture:

```
install: cannot stat '/builder/package/tollgate-wrt/files/etc/config/firewall-tollgate': No such file or directory
make[2]: *** [Makefile:215: ...tollgate-wrt.installed] Error 1
ERROR: package/tollgate-wrt failed to build.
```

## Fix

Remove both references. The firewall rules that #196 replaced them with are created directly via UCI named sections in `99-tollgate-setup`, so the install step and conffiles entry are no longer needed.

## Testing

CI on this PR should go fully green — all 6 architectures x ipk/apk variants.

## Files changed

- `packaging/Makefile` — 2 lines removed (install rule + conffiles entry)
- `CHANGELOG.md` — entry added under Fixed
