### PR TITLE
fix(ci): remove remaining firewall-tollgate references from build workflow + keep list

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -299,7 +299,6 @@ jobs:
           install -D -m 0755 packaging/files/etc/init.d/tollgate-wrt                         "$PAYLOAD/etc/init.d/tollgate-wrt"
           install -D -m 0755 packaging/files/etc/uci-defaults/90-tollgate-captive-portal-symlink "$PAYLOAD/etc/uci-defaults/90-tollgate-captive-portal-symlink"
           install -D -m 0755 packaging/files/etc/uci-defaults/99-tollgate-setup              "$PAYLOAD/etc/uci-defaults/99-tollgate-setup"
-          install -D -m 0644 packaging/files/etc/config/firewall-tollgate                    "$PAYLOAD/etc/config/firewall-tollgate"
           install -D -m 0755 packaging/files/usr/local/bin/first-login-setup                 "$PAYLOAD/usr/local/bin/first-login-setup"
           install -D -m 0755 packaging/files/usr/bin/check_package_path                      "$PAYLOAD/usr/bin/check_package_path"
           install -D -m 0644 packaging/files/lib/upgrade/keep.d/tollgate                     "$PAYLOAD/lib/upgrade/keep.d/tollgate"

--- a/packaging/files/lib/upgrade/keep.d/tollgate
+++ b/packaging/files/lib/upgrade/keep.d/tollgate
@@ -1,5 +1,4 @@
 # This file is used to preserve configuration during sysupgrade
-/etc/config/firewall-tollgate
 /etc/config/network
 /etc/config/wireless
 /etc/tollgate


### PR DESCRIPTION
PR #237 fixed the Makefile but missed two references that cause every build to fail:

1. **.github/workflows/build-package.yml:302** — inline `install` command copying the deleted file
2. **packaging/files/lib/upgrade/keep.d/tollgate:2** — sysupgrade keep list entry

Error on every architecture:
```
install: cannot stat 'packaging/files/etc/config/firewall-tollgate': No such file or directory
```

This blocks all CI artifact production, which blocks the physical-router-test-automation smoke tests.