### PR TITLE
fix: protocol compliance — map notice codes to TIP-01 spec, fix tips tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Protocol compliance: notice event codes and tips tag.** Map
+  implementation-specific notice event codes to spec-defined codes from
+  TIP-01 (`session-management-failed`, `gate-open-failed`, and
+  `allotment-calculation-failed` → `session-error`;
+  `payment-error-token-spent` already matched). Codes with no spec
+  equivalent (`payment-error-invalid-token`, `invalid-mac-address`,
+  `payment-processing-timeout`, `payment-processing-failed`) are kept
+  as-is with precision in the content string. Also remove non-existent
+  TIP-03 and TIP-04 from the advertisement `tips` tag — only TIP-01 and
+  TIP-02 are defined.
+
 - **Wireless config missing-file guard.** `scanner.GetRadios()` and
   `connector.getRadiosFromConfig()` now return gracefully when
   `/etc/config/wireless` does not exist instead of erroring every scan

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -438,7 +438,7 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 	mintURL := paymentCashuToken.Mint()
 	allotment, err := m.calculateAllotment(amountAfterSwap, mintURL)
 	if err != nil {
-		noticeEvent, noticeErr := m.CreateNoticeEvent("error", "allotment-calculation-failed",
+		noticeEvent, noticeErr := m.CreateNoticeEvent("error", "session-error",
 			fmt.Sprintf("Failed to calculate allotment: %v", err), macAddress)
 		if noticeErr != nil {
 			return nil, fmt.Errorf("failed to calculate allotment and failed to create notice: %w", noticeErr)
@@ -449,10 +449,10 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 	// Add allotment to the session and only persist the update if gate access opens.
 	session, err := m.grantSessionAccess(macAddress, allotment)
 	if err != nil {
-		errorCode := "session-management-failed"
+		errorCode := "session-error"
 		errorMessage := fmt.Sprintf("Failed to manage session: %v", err)
 		if strings.Contains(err.Error(), "failed to open gate:") {
-			errorCode = "gate-open-failed"
+			errorCode = "session-error"
 			errorMessage = err.Error()
 		}
 		noticeEvent, noticeErr := m.CreateNoticeEvent("error", errorCode,
@@ -493,7 +493,7 @@ func CreateAdvertisement(configManager *config_manager.ConfigManager, tracker *M
 		Tags: nostr.Tags{
 			{"metric", config.Metric},
 			{"step_size", fmt.Sprintf("%d", config.StepSize)},
-			{"tips", "1", "2", "3", "4"},
+			{"tips", "1", "2"},
 		},
 		Content: "",
 	}


### PR DESCRIPTION
## Summary

Two protocol-compliance fixes bundled per maintainer request.

### 1. Notice event codes mapped to TIP-01 spec

The spec (TIP-01) defines four error codes for kind 21023 notice events:
- `session-error`
- `upstream-error-not-connected`
- `payment-error-mint-not-accepted`
- `payment-error-token-spent`

The implementation used its own non-spec codes. This PR maps them:

| Before | After | Rationale |
|--------|-------|-----------|
| `session-management-failed` | `session-error` | Spec code, detail in content |
| `gate-open-failed` | `session-error` | Gate failure is session management |
| `allotment-calculation-failed` | `session-error` | Part of session creation |
| `payment-error-token-spent` | (unchanged) | Already matches spec ✓ |
| `payment-error-invalid-token` | (unchanged) | No spec equivalent — kept |
| `invalid-mac-address` | (unchanged) | Pre-payment validation |
| `payment-processing-timeout` | (unchanged) | No spec equivalent |
| `payment-processing-failed` | (unchanged) | No spec equivalent |

Codes with no spec equivalent are kept as-is — the precision goes in the human-readable content string, following how general-purpose protocols work (e.g., HTTP status codes are general, error messages are specific).

### 2. Tips tag fixed

Advertisement event claimed `["tips", "1", "2", "3", "4"]` but only TIP-01 and TIP-02 exist. Changed to `["tips", "1", "2"]`.

## Testing

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race -count=1 -tags testenv ./...` ✓ (all pass)
- `gofmt` clean on changed files

## Related

- Spec PR: OpenTollGate/tollgate#8 (TIP-01 harmonization)
- Issue: #239 (reseller bootstrap plan)