### PR TITLE
fix: use fuzzy mint URL matching in calculateAllotment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ reference/
 
 # Planning docs — internal, not for release
 docs/tmp/
+handover-mint-url-bug.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and [Semantic Versioning](https://semver.org/).
   `swapWithRetry` path that regenerates fresh blinded messages on
   retry.
 
+- **Mint URL fuzzy matching in `calculateAllotment()`.** The mint URL
+  from Cashu tokens was compared against configured accepted mints
+  using exact string equality (`==`), causing payments to fail when
+  the URL differed by a trailing slash, uppercase host, or path
+  normalization. `calculateAllotment()` now uses the existing
+  `tollwallet.MintURLMatches()` function which tolerates these
+  differences — the same function already used by the wallet layer
+  during `Receive()`
+  ([#250](https://github.com/OpenTollGate/tollgate-module-basic-go/issues/250),
+  [#251](https://github.com/OpenTollGate/tollgate-module-basic-go/issues/251)).
+
 - **Lightning quote persistence across restarts.** Lightning invoice
   quotes are now persisted to disk (`quotes.json` in the wallet
   directory) so they survive process restarts. Previously all pending

--- a/src/merchant/go.mod
+++ b/src/merchant/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/OpenTollGate/tollgate-module-basic-go/src/lightning v0.0.0-00010101000000-000000000000 // indirect
+	github.com/OpenTollGate/tollgate-module-basic-go/src/lightning v0.0.0-00010101000000-000000000000
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect

--- a/src/merchant/go.sum
+++ b/src/merchant/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/OpenTollGate/gonuts-tollgate v0.7.1 h1:1D7GRpu1SwyQCbx70wVomOpzMVi6W7E3yGfc/gCxAvM=
-github.com/OpenTollGate/gonuts-tollgate v0.7.1/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3 h1:ClzzXMDDuUbWfNNZqGeYq4PnYOlwlOVIvSyNaIy0ykg=
@@ -10,6 +8,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/OpenTollGate/gonuts-tollgate v0.7.4 h1:dMA6BCcstKhrLSfFWhr45H5U0aMMkRm66Efn/NHp3aw=
+github.com/OpenTollGate/gonuts-tollgate v0.7.4/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -625,7 +625,7 @@ func (m *Merchant) calculateAllotment(amountSats uint64, mintURL string) (uint64
 	// Find the mint configuration for this mint
 	var mintConfig *config_manager.MintConfig
 	for _, mint := range m.config.AcceptedMints {
-		if mint.URL == mintURL {
+		if tollwallet.MintURLMatches(mint.URL, mintURL) {
 			mintConfig = &mint
 			break
 		}

--- a/src/merchant/merchant_test.go
+++ b/src/merchant/merchant_test.go
@@ -192,3 +192,63 @@ func TestProcessPayout_UnderflowGuard(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateAllotment_TrailingSlashMintURL(t *testing.T) {
+	m := &Merchant{
+		config: &config_manager.Config{
+			Metric:   "milliseconds",
+			StepSize: 1000,
+			AcceptedMints: []config_manager.MintConfig{
+				{URL: "https://mint.example.com/Bitcoin", PricePerStep: 1, MinPurchaseSteps: 1},
+			},
+		},
+	}
+
+	allotment, err := m.calculateAllotment(10, "https://mint.example.com/Bitcoin/")
+	if err != nil {
+		t.Fatalf("trailing slash should match, got error: %v", err)
+	}
+	if allotment != 10000 {
+		t.Errorf("expected allotment 10000, got %d", allotment)
+	}
+}
+
+func TestCalculateAllotment_CaseInsensitiveMintURL(t *testing.T) {
+	m := &Merchant{
+		config: &config_manager.Config{
+			Metric:   "milliseconds",
+			StepSize: 1000,
+			AcceptedMints: []config_manager.MintConfig{
+				{URL: "https://mint.example.com/Bitcoin", PricePerStep: 1, MinPurchaseSteps: 1},
+			},
+		},
+	}
+
+	allotment, err := m.calculateAllotment(10, "https://MINT.EXAMPLE.COM/Bitcoin")
+	if err != nil {
+		t.Fatalf("uppercase host should match, got error: %v", err)
+	}
+	if allotment != 10000 {
+		t.Errorf("expected allotment 10000, got %d", allotment)
+	}
+}
+
+func TestCalculateAllotment_NoPathMintURL(t *testing.T) {
+	m := &Merchant{
+		config: &config_manager.Config{
+			Metric:   "milliseconds",
+			StepSize: 1000,
+			AcceptedMints: []config_manager.MintConfig{
+				{URL: "https://mint.example.com", PricePerStep: 1, MinPurchaseSteps: 1},
+			},
+		},
+	}
+
+	allotment, err := m.calculateAllotment(10, "https://mint.example.com/")
+	if err != nil {
+		t.Fatalf("root path should match no-path config, got error: %v", err)
+	}
+	if allotment != 10000 {
+		t.Errorf("expected allotment 10000, got %d", allotment)
+	}
+}

--- a/src/merchant/mint_url_match_test.go
+++ b/src/merchant/mint_url_match_test.go
@@ -1,0 +1,100 @@
+package merchant
+
+import (
+	"testing"
+
+	"github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager"
+	"github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet"
+)
+
+func TestMintURLMatchesTrailingSlash(t *testing.T) {
+	if !tollwallet.MintURLMatches("https://mint.example.com/Bitcoin", "https://mint.example.com/Bitcoin/") {
+		t.Error("trailing slash difference should match")
+	}
+	if !tollwallet.MintURLMatches("https://mint.example.com/Bitcoin/", "https://mint.example.com/Bitcoin") {
+		t.Error("trailing slash difference should match (reversed)")
+	}
+}
+
+func TestMintURLMatchesCaseInsensitiveHost(t *testing.T) {
+	if !tollwallet.MintURLMatches("https://Mint.Example.COM/Bitcoin", "https://mint.example.com/Bitcoin") {
+		t.Error("host case difference should match")
+	}
+}
+
+func TestMintURLMatchesNoPath(t *testing.T) {
+	if !tollwallet.MintURLMatches("https://mint.example.com", "https://mint.example.com/") {
+		t.Error("missing path vs root path should match")
+	}
+}
+
+func TestMintURLMatchesDifferentSchemesDiffer(t *testing.T) {
+	if tollwallet.MintURLMatches("http://mint.example.com/Bitcoin", "https://mint.example.com/Bitcoin") {
+		t.Error("different schemes should not match")
+	}
+}
+
+func TestMintURLMatchesDifferentHostsDiffer(t *testing.T) {
+	if tollwallet.MintURLMatches("https://mint.example.com/Bitcoin", "https://mint.other.com/Bitcoin") {
+		t.Error("different hosts should not match")
+	}
+}
+
+func TestCalculateAllotmentFuzzyMintURLMatch(t *testing.T) {
+	m := &Merchant{
+		config: &config_manager.Config{
+			Metric:   "milliseconds",
+			StepSize: 1000,
+			AcceptedMints: []config_manager.MintConfig{
+				{URL: "https://mint.example.com/Bitcoin", PricePerStep: 1, MinPurchaseSteps: 1},
+			},
+		},
+	}
+
+	// Token mint URL has trailing slash — should still match
+	allotment, err := m.calculateAllotment(5, "https://mint.example.com/Bitcoin/")
+	if err != nil {
+		t.Fatalf("expected fuzzy match to succeed, got error: %v", err)
+	}
+	expected := uint64(5 * 1000) // 5 steps * 1000ms step size
+	if allotment != expected {
+		t.Errorf("expected allotment %d, got %d", expected, allotment)
+	}
+}
+
+func TestCalculateAllotmentFuzzyMintURLCaseInsensitive(t *testing.T) {
+	m := &Merchant{
+		config: &config_manager.Config{
+			Metric:   "milliseconds",
+			StepSize: 1000,
+			AcceptedMints: []config_manager.MintConfig{
+				{URL: "https://mint.example.com/Bitcoin", PricePerStep: 2, MinPurchaseSteps: 1},
+			},
+		},
+	}
+
+	// Token mint URL has uppercase host — should still match
+	allotment, err := m.calculateAllotment(10, "https://MINT.EXAMPLE.COM/Bitcoin")
+	if err != nil {
+		t.Fatalf("expected case-insensitive match to succeed, got error: %v", err)
+	}
+	expected := uint64(5 * 1000) // 10 sats / 2 pricePerStep = 5 steps * 1000ms
+	if allotment != expected {
+		t.Errorf("expected allotment %d, got %d", expected, allotment)
+	}
+}
+
+func TestCalculateAllotmentRejectsUnknownMint(t *testing.T) {
+	m := &Merchant{
+		config: &config_manager.Config{
+			AcceptedMints: []config_manager.MintConfig{
+				{URL: "https://mint.example.com/Bitcoin", PricePerStep: 1, MinPurchaseSteps: 1},
+			},
+		},
+	}
+
+	_, err := m.calculateAllotment(5, "https://mint.unknown.com/Bitcoin")
+	if err == nil {
+		t.Fatal("expected error for unknown mint URL")
+	}
+}

--- a/src/tollwallet/go.sum
+++ b/src/tollwallet/go.sum
@@ -1,13 +1,13 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/OpenTollGate/gonuts-tollgate v0.7.1 h1:1D7GRpu1SwyQCbx70wVomOpzMVi6W7E3yGfc/gCxAvM=
-github.com/OpenTollGate/gonuts-tollgate v0.7.1/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/OpenTollGate/gonuts-tollgate v0.7.4 h1:dMA6BCcstKhrLSfFWhr45H5U0aMMkRm66Efn/NHp3aw=
+github.com/OpenTollGate/gonuts-tollgate v0.7.4/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -283,7 +283,11 @@ func ParseToken(token string) (cashu.Token, error) {
 	return cashu.DecodeToken(token)
 }
 
-func mintURLMatches(a, b string) bool {
+// MintURLMatches compares two mint URLs for equality, tolerating
+// differences in case (host), trailing slashes, and path normalization.
+// Both URLs must parse successfully; if either fails to parse, a plain
+// string comparison is used as fallback.
+func MintURLMatches(a, b string) bool {
 	ua, err := url.Parse(a)
 	if err != nil {
 		return a == b
@@ -294,12 +298,31 @@ func mintURLMatches(a, b string) bool {
 	}
 	return strings.EqualFold(ua.Host, ub.Host) &&
 		ua.Scheme == ub.Scheme &&
-		ua.Path == ub.Path
+		normalizePath(ua.Path) == normalizePath(ub.Path)
+}
+
+// normalizePath strips a single trailing slash from the path so that
+// "/Bitcoin" and "/Bitcoin/" compare as equal, and treats empty path
+// the same as "/" (root).
+func normalizePath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if len(p) > 1 && p[len(p)-1] == '/' {
+		return p[:len(p)-1]
+	}
+	return p
+}
+
+// mintURLMatches is kept for internal backwards compatibility within
+// the tollwallet package.
+func mintURLMatches(a, b string) bool {
+	return MintURLMatches(a, b)
 }
 
 func contains(slice []string, str string) bool {
 	for _, item := range slice {
-		if mintURLMatches(item, str) {
+		if MintURLMatches(item, str) {
 			return true
 		}
 	}

--- a/src/tollwallet/tollwallet_test.go
+++ b/src/tollwallet/tollwallet_test.go
@@ -178,10 +178,10 @@ func TestContains(t *testing.T) {
 			"fallback is exact match, not EqualFold")
 	})
 
-	t.Run("Empty path differs from trailing slash", func(t *testing.T) {
+	t.Run("Empty path matches trailing slash (RFC 3986)", func(t *testing.T) {
 		mints := []string{"https://testnut.cashu.exchange"}
 		assert.True(t, contains(mints, "https://TESTNUT.CASHU.EXCHANGE"))
-		assert.False(t, contains(mints, "https://testnut.cashu.exchange/"),
-			"empty path != slash path")
+		assert.True(t, contains(mints, "https://testnut.cashu.exchange/"),
+			"empty path == slash path per RFC 3986")
 	})
 }


### PR DESCRIPTION
Closes #250, #251

## Problem

`calculateAllotment()` in `src/merchant/merchant.go` used exact string comparison (`mint.URL == mintURL`) to match the mint URL from a Cashu token against configured accepted mints. This rejected valid tokens when the URL differed by:
- Trailing slash (`https://mint.minibits.cash/Bitcoin/` vs `https://mint.minibits.cash/Bitcoin`)
- Host casing (`https://Mint.Minibits.Cash/Bitcoin` vs `https://mint.minibits.cash/Bitcoin`)
- Empty path vs root (`https://mint.example.com` vs `https://mint.example.com/`)

The wallet layer (`tollwallet.Receive()`) already used `mintURLMatches()` and accepted the token. But `calculateAllotment()` failed with `mint configuration not found for URL: ...`, consuming the user's sats without granting access.

## Fix

- Export `mintURLMatches` as `MintURLMatches` from the tollwallet package
- Add `normalizePath` helper to handle trailing slash and empty path normalization that `url.Parse` does not handle automatically
- Replace `mint.URL == mintURL` with `tollwallet.MintURLMatches(mint.URL, mintURL)` in `calculateAllotment()`

## Tests

11 new tests across `mint_url_match_test.go` and `merchant_test.go`:
- Trailing slash matching (both directions)
- Case-insensitive host matching
- Empty path vs root path matching
- Different schemes correctly rejected
- Different hosts correctly rejected
- `calculateAllotment` with trailing slash mint URL succeeds
- `calculateAllotment` with uppercase host succeeds
- `calculateAllotment` with no path succeeds
- Unknown mint URL still rejected

All pass with `go test -race -count=1 -tags testenv`.

## Notes

- Pre-existing gofmt issues on several repo files and a pre-existing go vet warning (sync.Mutex copy in merchant.go:147) exist on main and are not addressed here (one logical change per PR).