### PR TITLE
fix: bump gonuts-tollgate to v0.7.3 for DLEQ keyset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **DLEQ proofs now verified against correct keyset via gonuts-tollgate
+  v0.7.3.** gonuts-tollgate v0.6.1 verified DLEQ proofs against the
+  mint's current active keyset, ignoring `proof.Id` which identifies
+  the keyset that actually signed the proof. When a mint rotates
+  keysets, tokens minted under the old keyset failed with "invalid DLEQ
+  proof". gonuts-tollgate v0.7.3 adds `VerifyProofsDLEQWithKeysets()`
+  which groups proofs by keyset ID and fetches the correct keyset per
+  group. Bump replace directive from v0.7.1 to v0.7.3
+  ([Amperstrand/gonuts-tollgate#5](https://github.com/Amperstrand/gonuts-tollgate/pull/5)).
+
 - **Protocol compliance: notice event codes and tips tag.** Map
   implementation-specific notice event codes to spec-defined codes from
   TIP-01 (`session-management-failed`, `gate-open-failed`, and

--- a/src/tollwallet/go.mod
+++ b/src/tollwallet/go.mod
@@ -10,7 +10,7 @@ require (
 
 replace (
 	github.com/OpenTollGate/tollgate-module-basic-go/src/lightning => ../lightning
-	github.com/Origami74/gonuts-tollgate => github.com/OpenTollGate/gonuts-tollgate v0.7.1
+	github.com/Origami74/gonuts-tollgate => github.com/OpenTollGate/gonuts-tollgate v0.7.3
 )
 
 require (

--- a/src/tollwallet/go.sum
+++ b/src/tollwallet/go.sum
@@ -1,13 +1,13 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/OpenTollGate/gonuts-tollgate v0.7.1 h1:1D7GRpu1SwyQCbx70wVomOpzMVi6W7E3yGfc/gCxAvM=
-github.com/OpenTollGate/gonuts-tollgate v0.7.1/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/OpenTollGate/gonuts-tollgate v0.7.3 h1:ZQHqST+qDelERn99+baKJR/xTM5buMJU+hr/SnMIkkk=
+github.com/OpenTollGate/gonuts-tollgate v0.7.3/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=


### PR DESCRIPTION
## Summary

Bump gonuts-tollgate replace directive from v0.7.1 to v0.7.3.

## Problem

gonuts-tollgate v0.6.1/v0.7.1 verified DLEQ proofs (NUT-12) against the mint's current active keyset, ignoring `proof.Id` which identifies the keyset that actually signed the proof. When a mint rotates keysets, tokens minted under the old keyset fail DLEQ verification with "invalid DLEQ proof".

## Fix

gonuts-tollgate v0.7.3 adds `VerifyProofsDLEQWithKeysets()` which groups proofs by keyset ID and fetches the correct keyset for each group via `GetKeysetKeys(mintURL, id)`.

Upstream PR: https://github.com/Amperstrand/gonuts-tollgate/pull/5

## Testing

- `gofmt -l .` clean (pre-existing issues in other files unchanged)
- `go vet ./...` clean
- `go build ./...` clean
- `go test -race -count=1 -tags testenv ./...` — all pass

cc @Amperstrand @Origami79