### PR TITLE
fix(tollwallet): return an error instead of panicking on nil wallet in GetMintQuoteState

### DIFF
--- a/src/tollwallet/sentinel_test.go
+++ b/src/tollwallet/sentinel_test.go
@@ -39,3 +39,11 @@ func TestShutdown_NilWallet_NoPanic(t *testing.T) {
 	err := w.Shutdown()
 	assert.NoError(t, err)
 }
+
+func TestGetMintQuoteState_NilWallet_ReturnsError(t *testing.T) {
+	w := &TollWallet{wallet: nil}
+	resp, err := w.GetMintQuoteState("quote-id")
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, ErrWalletNotInitialized,
+		"GetMintQuoteState on an uninitialized wallet must return ErrWalletNotInitialized, not panic")
+}

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -16,6 +16,11 @@ import (
 
 var ErrTokenAlreadySpent = errors.New("Token already spent")
 
+// ErrWalletNotInitialized is returned by wallet operations when the underlying
+// cashu wallet has not been initialized (for example on a bare Merchant or in
+// degraded mode), so callers get an error instead of a nil-pointer panic.
+var ErrWalletNotInitialized = errors.New("wallet not initialized")
+
 type TollWallet struct {
 	wallet                     *wallet.Wallet
 	acceptedMints              []string
@@ -264,6 +269,9 @@ func (w *TollWallet) RequestMintQuote(amount uint64, mintURL string) (*nut04.Pos
 }
 
 func (w *TollWallet) GetMintQuoteState(quoteID string) (*nut04.PostMintQuoteBolt11Response, error) {
+	if w.wallet == nil {
+		return nil, ErrWalletNotInitialized
+	}
 	return w.wallet.MintQuoteState(quoteID)
 }
 


### PR DESCRIPTION
## Summary

`TollWallet.GetMintQuoteState` dereferenced `w.wallet` unconditionally and panicked with a nil-pointer dereference when the underlying cashu wallet was not initialized. This returns a sentinel error instead so callers on a bare or degraded `Merchant` get an error rather than a crash.

## Motivation

`TollWallet` is a struct (never nil), but its `wallet *wallet.Wallet` field is nil when the wallet has not been initialized — for example on a bare `&Merchant{}` (degraded mode, or in tests). `Merchant.getLightningQuoteState` calls `GetMintQuoteState`, which called `w.wallet.MintQuoteState(...)` directly, so a nil `w.wallet` panicked:

```
panic: runtime error: invalid memory address or nil pointer dereference
  ...wallet.(*Wallet).MintQuoteState(0x0, ...)
  ...tollwallet.(*TollWallet).GetMintQuoteState(...)
  ...merchant.(*Merchant).getLightningQuoteState(...)
```

Fixes #255.

## Fix

- Adds an `ErrWalletNotInitialized` sentinel error (alongside the existing `ErrTokenAlreadySpent`).
- `GetMintQuoteState` returns `ErrWalletNotInitialized` when `w.wallet == nil` instead of dereferencing it.

This is the "add a nil check in `GetMintQuoteState`" option the issue recommends as simplest, and it mirrors the existing nil-tolerant `Shutdown()`. The sibling wallet methods (`Receive`, `Send`, `RequestMintQuote`, `MintQuoteTokens`, `GetBalance`, ...) share the same latent nil-`w.wallet` assumption; hardening those is left out of scope here to keep the change focused on the reported crash path, but the new sentinel is available for reuse.

## Testing

Added `TestGetMintQuoteState_NilWallet_ReturnsError` (mirroring the existing `TestShutdown_NilWallet_NoPanic`): calling `GetMintQuoteState` on `&TollWallet{wallet: nil}` returns `ErrWalletNotInitialized` (via `errors.Is`) and a nil response instead of panicking.

- `go build ./...`, `go vet ./...`, `go test ./...` (in `src/tollwallet`) — pass.
- `gofmt -l` — clean.


---

AI was used for assistance.
