### PR TITLE
test: characterize post-swap-fee crediting (#63)

### DIFF
--- a/src/merchant/merchant_test.go
+++ b/src/merchant/merchant_test.go
@@ -193,6 +193,7 @@ func TestProcessPayout_UnderflowGuard(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 func TestCalculateAllotment_TrailingSlashMintURL(t *testing.T) {
 	m := &Merchant{
 		config: &config_manager.Config{
@@ -200,10 +201,20 @@ func TestCalculateAllotment_TrailingSlashMintURL(t *testing.T) {
 			StepSize: 1000,
 			AcceptedMints: []config_manager.MintConfig{
 				{URL: "https://mint.example.com/Bitcoin", PricePerStep: 1, MinPurchaseSteps: 1},
+=======
+func TestCalculateAllotment_CreditsPostSwapFeeAmount_Issue63(t *testing.T) {
+	m := &Merchant{
+		config: &config_manager.Config{
+			Metric:   "bytes",
+			StepSize: 10485760,
+			AcceptedMints: []config_manager.MintConfig{
+				{URL: "https://mint.example.com", PricePerStep: 1},
+>>>>>>> e03936d (test: characterize post-swap-fee crediting for #63)
 			},
 		},
 	}
 
+<<<<<<< HEAD
 	allotment, err := m.calculateAllotment(10, "https://mint.example.com/Bitcoin/")
 	if err != nil {
 		t.Fatalf("trailing slash should match, got error: %v", err)
@@ -250,5 +261,15 @@ func TestCalculateAllotment_NoPathMintURL(t *testing.T) {
 	}
 	if allotment != 10000 {
 		t.Errorf("expected allotment 10000, got %d", allotment)
+=======
+	allotment, err := m.calculateAllotment(4, "https://mint.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := uint64(4 * 10485760)
+	if allotment != expected {
+		t.Errorf("Issue #63: post-swap amount of 4 sats should credit 4 steps (%d bytes), got %d", expected, allotment)
+>>>>>>> e03936d (test: characterize post-swap-fee crediting for #63)
 	}
 }


### PR DESCRIPTION
Adds a characterization test pinning the intentional post-swap-fee crediting behavior documented in Amperstrand#63.

## Context

Issue #63 reported "5-sat Cashu token receives as 4 sats." Investigation traced the complete fee path: the 1-sat reduction happens **inside `gonuts-tollgate`** (the Cashu library), not in tollgate's pricing code. When a customer sends a token from an untrusted mint, gonuts' `swapProofs()` deducts a per-proof fee (`InputFeePpk`) to swap it to the trusted mint. The post-fee amount (4 sats) is what reaches `calculateAllotment`. This is **intentional** — the tollgate credits exactly what it receives after the swap fee.

The integer division at `merchant.go:574` (`steps := amountSats / PricePerStep`) operates on the already-post-fee amount. With `PricePerStep=1` (the default), there's no truncation — `4/1=4`. Fixing it to ceiling division would not change the 5→4 behavior because the reduction happens upstream in gonuts.

## What this PR does

Adds `TestCalculateAllotment_CreditsPostSwapFeeAmount_Issue63` — a characterization test that pins the behavior: when `calculateAllotment` receives 4 sats (the post-swap-fee amount), it credits 4 steps. This prevents anyone from accidentally "fixing" #63 by changing `calculateAllotment` to credit 5 instead of 4 (which would credit more than the tollgate actually received).

No production code changes. Pure test addition.
