### PR TITLE
security: limit all io.ReadAll calls to 1MB to prevent DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **HTTP response body reads now limited to 1 MB.** All `io.ReadAll`
+  calls on HTTP response bodies (LNURL resolve, invoice fetch, gateway
+  probes, usage tracker) now use `io.LimitReader` with a 1 MB cap,
+  matching the existing limit on the main payment handler. Prevents
+  OOM crashes on resource-constrained routers when a malicious or
+  compromised upstream service returns an oversized response
+  ([#267](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/267)).
+
 - **Lightning quote persistence across restarts.** Lightning invoice
   quotes are now persisted to disk (`quotes.json` in the wallet
   directory) so they survive process restarts. Previously all pending

--- a/src/lightning/lightning.go
+++ b/src/lightning/lightning.go
@@ -68,7 +68,7 @@ func GetInvoiceFromLightningAddress(lightningAddr string, amountSats uint64) (st
 	defer resp.Body.Close()
 
 	// 4. Parse the LNURL response
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return "", fmt.Errorf("failed to read Lightning Address response: %w", err)
 	}
@@ -112,7 +112,7 @@ func GetInvoiceFromLightningAddress(lightningAddr string, amountSats uint64) (st
 	defer invoiceResp.Body.Close()
 
 	// 7. Parse the invoice response
-	invoiceBody, err := io.ReadAll(invoiceResp.Body)
+	invoiceBody, err := io.ReadAll(io.LimitReader(invoiceResp.Body, 1<<20))
 	if err != nil {
 		return "", fmt.Errorf("failed to read invoice response: %w", err)
 	}

--- a/src/upstream_session_manager/session.go
+++ b/src/upstream_session_manager/session.go
@@ -350,7 +350,7 @@ func (s *UpstreamSession) sendPayment(steps uint64) (uint64, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		s.recoverToken(token, err)
 		return 0, fmt.Errorf("failed to read response: %w", err)

--- a/src/upstream_session_manager/tollgate_prober.go
+++ b/src/upstream_session_manager/tollgate_prober.go
@@ -191,7 +191,7 @@ func (tp *tollGateProber) performRequestWithContext(ctx context.Context, url str
 	}
 
 	// Read response body
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -277,7 +277,7 @@ func (tp *tollGateProber) TriggerCaptivePortalSession(ctx context.Context, gatew
 	defer resp.Body.Close()
 
 	// Read and discard response body (we don't need the content)
-	_, _ = io.ReadAll(resp.Body)
+	_, _ = io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 
 	logger.WithFields(logrus.Fields{
 		"gateway_ip":   gatewayIP,

--- a/src/upstream_session_manager/upstream_usage_tracker.go
+++ b/src/upstream_session_manager/upstream_usage_tracker.go
@@ -183,7 +183,7 @@ func (u *UpstreamUsageTracker) fetchUpstreamUsage() (usage, allotment uint64, er
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return 0, 0, err
 	}


### PR DESCRIPTION
## Summary

6 of 7 `io.ReadAll` calls read HTTP response bodies without a size limit. A malicious upstream gateway or LNURL service could exhaust router memory by returning a multi-GB response.

The main HTTP handler (`main.go:413`) already limits request bodies to 1MB via `http.MaxBytesReader`. This PR applies the same limit to all response body reads.

## Changes

| File | Line | What's read | Limit |
|---|---|---|---|
| `lightning/lightning.go` | 71 | LNURL resolve response | 1MB |
| `lightning/lightning.go` | 115 | LNURL invoice response | 1MB |
| `upstream_session_manager/session.go` | 353 | Gateway payment response | 1MB |
| `upstream_session_manager/tollgate_prober.go` | 194 | Gateway probe response | 1MB |
| `upstream_session_manager/tollgate_prober.go` | 280 | Body drain (discard) | 1MB |
| `upstream_session_manager/upstream_usage_tracker.go` | 186 | Usage data response | 1MB |

All responses are small JSON (< 10KB expected). 1MB limit is generous.

## Why this matters

TollGate routers run on embedded hardware with 128-512MB RAM. An unbounded `io.ReadAll` on a malicious response could OOM-kill the process. The router connects to external services (LNURL providers, upstream TollGate gateways) that could be compromised or malicious.

## Verification

```bash
gofmt -l .     # clean
go build ./...  # OK
go test ./...   # all pass
```

Found during the codebase audit in #263.