### PR TITLE
test: cdk-go evaluation spike (research for #271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,21 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Changed / Internal
 
+- **cdk-go evaluation spike.** Standalone Go module under
+  `tests/cdk-go-spike/` that exercises cdk-go (FFI bindings to the
+  Rust Cashu Development Kit) as a possible replacement for
+  `gonuts-tollgate` on the architectures it supports (linux
+  amd64/arm64). The spike is a separate module so cdk-go's CGO
+  dependencies cannot leak into `src/go.mod` and regress MIPS or
+  armv7 builds of the main project. Findings: token API is
+  ergonomic (roundtrip passes with no glue code), but cdk-go's FFI
+  does not propagate network errors as Go errors (unreachable mints
+  panic with EOF), and `Wallet.Destroy()` is manually managed.
+  Primary conclusion: cdk-go cannot replace gonuts across TollGate's
+  full build matrix (3 of 6 arches unsupported). Tracking issue #271
+  captures the full evaluation
+  ([#272](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/272)).
+
 - **Operator guide.** New `docs/operator-guide.md` covering every `tollgate`
   CLI subcommand (service, wallet, private network, upstream Wi-Fi, config,
   health) with example output, flags, and a troubleshooting section; README

--- a/tests/cdk-go-spike/Makefile
+++ b/tests/cdk-go-spike/Makefile
@@ -1,0 +1,13 @@
+.PHONY: build test test-network tidy
+
+build:
+	go build -tags cgo .
+
+test:
+	go test -v -count=1 ./...
+
+test-network:
+	CDK_SPIKE_NETWORK=1 go test -v -count=1 -run TestCdkGoTestmint ./...
+
+tidy:
+	go mod tidy

--- a/tests/cdk-go-spike/README.md
+++ b/tests/cdk-go-spike/README.md
@@ -1,0 +1,22 @@
+# cdk-go Evaluation Spike
+
+Spike for evaluating cdk-go (FFI bindings to Rust CDK) as a gonuts replacement on the architectures it supports.
+
+## Build constraints
+
+This spike requires `CGO_ENABLED=1` and only works on Linux amd64 and arm64 because cdk-go ships prebuilt libcdk_ffi.so only for those architectures. MIPS and armv7 are not supported (see issue #176 for prior rejection of CGo/FFI for embedded builds).
+
+## Targets
+
+- `make build`: Build the spike with CGO
+- `make test`: Run offline tests
+- `make test-network`: Run network-gated tests (requires CDK_SPIKE_NETWORK=1)
+- `make tidy`: Clean up dependencies
+
+## Why a separate module
+
+- Keeps cdk-go dependencies out of `src/go.mod` so MIPS and armv7 builds of the main project cannot regress
+
+## Findings
+
+See tracking issue #XXX

--- a/tests/cdk-go-spike/README.md
+++ b/tests/cdk-go-spike/README.md
@@ -19,4 +19,4 @@ This spike requires `CGO_ENABLED=1` and only works on Linux amd64 and arm64 beca
 
 ## Findings
 
-See tracking issue #XXX
+See tracking issue [#271](https://github.com/OpenTollGate/tollgate-module-basic-go/issues/271) for the full evaluation, including the MIPS/armv7 blocker, POC results, options compared, and recommendation.

--- a/tests/cdk-go-spike/go.mod
+++ b/tests/cdk-go-spike/go.mod
@@ -1,0 +1,3 @@
+module github.com/OpenTollGate/tollgate-module-basic-go/tests/cdk-go-spike
+
+go 1.25.0

--- a/tests/cdk-go-spike/go.mod
+++ b/tests/cdk-go-spike/go.mod
@@ -1,3 +1,5 @@
 module github.com/OpenTollGate/tollgate-module-basic-go/tests/cdk-go-spike
 
 go 1.25.0
+
+require github.com/cashubtc/cdk-go v0.17.3

--- a/tests/cdk-go-spike/go.sum
+++ b/tests/cdk-go-spike/go.sum
@@ -1,0 +1,2 @@
+github.com/cashubtc/cdk-go v0.17.3 h1:ncU2UbKCZ8OalMc9RQA2Fbh5rbuDYz4ULbF+aZSE7nw=
+github.com/cashubtc/cdk-go v0.17.3/go.mod h1:LkFjdm+QOW+35OIgA8cwPiElZDBDd5qlONTIs492PDE=

--- a/tests/cdk-go-spike/main.go
+++ b/tests/cdk-go-spike/main.go
@@ -1,0 +1,7 @@
+//go:build cgo && linux && (amd64 || arm64)
+
+package main
+
+func main() {
+	println("cdk-go spike — see Makefile test targets")
+}

--- a/tests/cdk-go-spike/token_test.go
+++ b/tests/cdk-go-spike/token_test.go
@@ -1,0 +1,134 @@
+//go:build cgo && linux && (amd64 || arm64)
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	cdk_ffi "github.com/cashubtc/cdk-go/bindings/cdkffi"
+)
+
+const knownGoodV3Token = "cashuAeyJ0b2tlbiI6IFt7Im1pbnQiOiAiaHR0cHM6Ly90ZXN0bnV0LmNhc2h1LnNwYWNlIiwgInByb29mcyI6IFt7ImlkIjogIjAwOWExZjI5MzI1M2U0MWUiLCAiYW1vdW50IjogMiwgInNlY3JldCI6ICI0MDc5MTViYzIxMmJlNjFhNzdlM2U2ZDJhZWI0YzcyNzk4MGJkYTUxY2QwNmE2YWZjMjllMjg2MTc2OGE3ODM3IiwgIkMiOiAiMDJiYzkwOTc5OTdkODFhZmIyY2M3MzQ2YjVlNDM0NWE5MzQ2YmQyYTUwNmViNzk1ODU5OGE3MmYwY2Y4NTE2M2VhIn1dfV0sICJ1bml0IjogInNhdCJ9"
+
+func TestCdkGoTokenRoundtrip(t *testing.T) {
+	t.Run("decode_succeeds", func(t *testing.T) {
+		decoded, err := cdk_ffi.TokenDecode(knownGoodV3Token)
+		if err != nil {
+			t.Fatalf("TokenDecode failed: %v", err)
+		}
+		if decoded == nil {
+			t.Fatal("TokenDecode returned nil Token")
+		}
+		defer decoded.Destroy()
+	})
+
+	t.Run("reencode_roundtrips", func(t *testing.T) {
+		decoded, err := cdk_ffi.TokenDecode(knownGoodV3Token)
+		if err != nil {
+			t.Fatalf("TokenDecode failed: %v", err)
+		}
+		if decoded == nil {
+			t.Fatal("TokenDecode returned nil Token")
+		}
+		defer decoded.Destroy()
+
+		reencoded := decoded.Encode()
+		if reencoded == "" {
+			t.Fatal("Encode returned empty string")
+		}
+
+		// Note: byte-equal may fail due to canonicalization; compare structural equality
+		// by decoding both and comparing proof counts and total value
+		originalProofs, _ := decoded.ProofsSimple()
+		decodedAgain, _ := cdk_ffi.TokenDecode(reencoded)
+		defer decodedAgain.Destroy()
+		reencodedProofs, _ := decodedAgain.ProofsSimple()
+
+		if len(originalProofs) != len(reencodedProofs) {
+			t.Fatalf("Proof count mismatch: original %d, reencoded %d", len(originalProofs), len(reencodedProofs))
+		}
+
+		originalValue, _ := decoded.Value()
+		reencodedValue, _ := decodedAgain.Value()
+		if originalValue.Value != reencodedValue.Value {
+			t.Fatalf("Value mismatch: original %d, reencoded %d", originalValue.Value, reencodedValue.Value)
+		}
+	})
+
+	t.Run("extracts_value", func(t *testing.T) {
+		decoded, err := cdk_ffi.TokenDecode(knownGoodV3Token)
+		if err != nil {
+			t.Fatalf("TokenDecode failed: %v", err)
+		}
+		if decoded == nil {
+			t.Fatal("TokenDecode returned nil Token")
+		}
+		defer decoded.Destroy()
+
+		value, err := decoded.Value()
+		if err != nil {
+			t.Fatalf("Value failed: %v", err)
+		}
+		if value.Value <= 0 {
+			t.Fatalf("Expected value > 0, got %d", value.Value)
+		}
+	})
+
+	t.Run("extracts_mint_url", func(t *testing.T) {
+		decoded, err := cdk_ffi.TokenDecode(knownGoodV3Token)
+		if err != nil {
+			t.Fatalf("TokenDecode failed: %v", err)
+		}
+		if decoded == nil {
+			t.Fatal("TokenDecode returned nil Token")
+		}
+		defer decoded.Destroy()
+
+		mintUrl, err := decoded.MintUrl()
+		if err != nil {
+			t.Fatalf("MintUrl failed: %v", err)
+		}
+		if !strings.Contains(mintUrl.Url, "testnut.cashu.space") {
+			t.Fatalf("Expected mint URL to contain 'testnut.cashu.space', got %s", mintUrl.Url)
+		}
+	})
+}
+
+func TestCdkGoMalformedToken(t *testing.T) {
+	t.Run("empty_string_returns_error", func(t *testing.T) {
+		decoded, err := cdk_ffi.TokenDecode("")
+		if err == nil {
+			t.Fatal("Expected error for empty token, got nil")
+			decoded.Destroy() // cleanup if somehow created
+		}
+		if decoded != nil {
+			t.Fatal("Expected nil Token for empty input, got non-nil")
+			decoded.Destroy()
+		}
+	})
+
+	t.Run("garbage_returns_error", func(t *testing.T) {
+		decoded, err := cdk_ffi.TokenDecode("not-a-cashu-token")
+		if err == nil {
+			t.Fatal("Expected error for garbage token, got nil")
+			decoded.Destroy() // cleanup if somehow created
+		}
+		if decoded != nil {
+			t.Fatal("Expected nil Token for garbage input, got non-nil")
+			decoded.Destroy()
+		}
+	})
+
+	t.Run("missing_prefix_returns_error", func(t *testing.T) {
+		decoded, err := cdk_ffi.TokenDecode("eyJ0b2tlbiI6W3si...") // valid base64 JSON but missing cashuA@/cashuB prefix
+		if err == nil {
+			t.Fatal("Expected error for missing prefix, got nil")
+			decoded.Destroy() // cleanup if somehow created
+		}
+		if decoded != nil {
+			t.Fatal("Expected nil Token for missing prefix, got non-nil")
+			decoded.Destroy()
+		}
+	})
+}

--- a/tests/cdk-go-spike/wallet_test.go
+++ b/tests/cdk-go-spike/wallet_test.go
@@ -1,0 +1,213 @@
+//go:build cgo && linux && (amd64 || arm64)
+
+package main
+
+import (
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	cdk_ffi "github.com/cashubtc/cdk-go/bindings/cdkffi"
+)
+
+// testMintUrl is the cdk-go project's canonical testmint. It auto-pays the
+// bolt11 invoices it issues, so a mint quote reaches QuoteStatePaid shortly
+// after being requested. See cdk-go's own cdk_test.go for the same URL.
+const testMintUrl = "https://testnut.cashudevkit.org"
+
+// TestCdkGoTestmintWallet exercises the REAL cdk-go wallet path end-to-end
+// against a live Cashu testmint: mnemonic → wallet → mint info → mint quote
+// (bolt11) → poll until paid → mint tokens → balance reflects the mint.
+//
+// It is gated behind CDK_SPIKE_NETWORK=1 so CI stays green by default; the
+// test SKIPS (not fails) when the env var is unset. The captured -v output
+// is the real-surface artifact proving cdk-go's Wallet API works against a
+// live mint.
+func TestCdkGoTestmintWallet(t *testing.T) {
+	if os.Getenv("CDK_SPIKE_NETWORK") != "1" {
+		t.Skip("skipping network test; set CDK_SPIKE_NETWORK=1 to run")
+	}
+
+	var mnemonic string
+	var wallet *cdk_ffi.Wallet
+	var quoteId string
+
+	// Register wallet teardown on the PARENT test so it survives across all
+	// subtests (registering inside t.Run runs Cleanup when the subtest ends,
+	// which would destroy the wallet before later subtests can use it).
+	t.Cleanup(func() {
+		if wallet != nil {
+			wallet.Destroy()
+		}
+	})
+
+	// a) Generate a fresh mnemonic.
+	t.Run("generate_mnemonic", func(t *testing.T) {
+		m, err := cdk_ffi.GenerateMnemonic()
+		if err != nil {
+			t.Fatalf("GenerateMnemonic failed: %v", err)
+		}
+		if m == "" {
+			t.Fatal("GenerateMnemonic returned empty string")
+		}
+		words := strings.Fields(m)
+		// BIP-39 mnemonics are 12/15/18/21/24 words; accept the common ones.
+		if len(words) != 12 && len(words) != 24 {
+			t.Fatalf("expected 12 or 24 mnemonic words, got %d: %q", len(words), m)
+		}
+		mnemonic = m
+		t.Logf("generated mnemonic (%d words)", len(words))
+	})
+
+	// b) Open a wallet against the testmint with a temp-dir SQLite store.
+	t.Run("create_wallet", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "wallet.sqlite")
+		t.Logf("sqlite store: %s", dbPath)
+		w, err := cdk_ffi.NewWallet(
+			testMintUrl,
+			cdk_ffi.CurrencyUnitSat{},
+			mnemonic,
+			cdk_ffi.WalletStoreSqlite{Path: dbPath},
+			cdk_ffi.WalletConfig{TargetProofCount: nil},
+		)
+		if err != nil {
+			t.Fatalf("NewWallet failed: %v", err)
+		}
+		if w == nil {
+			t.Fatal("NewWallet returned nil wallet")
+		}
+		wallet = w
+		t.Logf("wallet opened against %s", testMintUrl)
+	})
+
+	// Preflight reachability check. cdk-go's FFI does not propagate HTTP
+	// errors as Go errors — when the mint is unreachable the Rust layer
+	// returns an empty buffer and the Go deserializer panics on EOF. Skip
+	// the remaining network subtests cleanly here (after the local FFI
+	// subtests have already passed, exercising the binding) so a down mint
+	// or blocked egress is obvious in the transcript instead of surfacing
+	// as a CGO panic that reads like a code bug.
+	mintHost := mustMintHost(t, testMintUrl)
+	if err := dialCheck(mintHost, 5*time.Second); err != nil {
+		t.Skipf("testmint unreachable from this host (FFI would panic on dead-mint EOF; local cdk-go subtests above already passed): %v", err)
+	}
+
+	// c) Fetch mint info — proves the wallet can reach the mint and parse NUT-06 info.
+	t.Run("fetch_mint_info", func(t *testing.T) {
+		info, err := wallet.FetchMintInfo()
+		if err != nil {
+			t.Fatalf("FetchMintInfo failed: %v", err)
+		}
+		if info == nil {
+			t.Fatal("FetchMintInfo returned nil MintInfo")
+		}
+		if info.Name != nil {
+			t.Logf("mint name: %s", *info.Name)
+		}
+		if info.Description != nil {
+			t.Logf("mint description: %s", *info.Description)
+		}
+		if info.Pubkey != nil {
+			t.Logf("mint pubkey: %s", *info.Pubkey)
+		}
+	})
+
+	// d) Request a mint quote for 1 sat via bolt11. The testmint returns a
+	// bolt11 invoice that it will settle itself.
+	t.Run("request_mint_quote", func(t *testing.T) {
+		amount := cdk_ffi.Amount{Value: 1} // 1 sat
+		quote, err := wallet.MintQuote(cdk_ffi.PaymentMethodBolt11{}, &amount, nil, nil)
+		if err != nil {
+			t.Fatalf("MintQuote failed: %v", err)
+		}
+		if quote.Id == "" {
+			t.Fatal("MintQuote returned empty quote Id")
+		}
+		if quote.Request == "" {
+			t.Fatal("MintQuote returned empty Request (bolt11 invoice)")
+		}
+		quoteId = quote.Id
+		t.Logf("quote id: %s", quoteId)
+		t.Logf("bolt11 request: %s", quote.Request)
+	})
+
+	// e) Poll the mint until the quote is paid. The testmint auto-pays quickly;
+	// we allow up to 30s. QuoteStatePaid (2) means the invoice was settled;
+	// QuoteStateIssued (4) is also acceptable since it implies payment received
+	// and tokens already issued.
+	t.Run("wait_for_quote_paid", func(t *testing.T) {
+		deadline := time.Now().Add(30 * time.Second)
+		var lastState cdk_ffi.QuoteState
+		for time.Now().Before(deadline) {
+			quote, err := wallet.CheckMintQuoteStatus(quoteId)
+			if err != nil {
+				t.Fatalf("CheckMintQuoteStatus failed: %v", err)
+			}
+			lastState = quote.State
+			t.Logf("quote state: %d", quote.State)
+			if quote.State == cdk_ffi.QuoteStatePaid || quote.State == cdk_ffi.QuoteStateIssued {
+				return
+			}
+			time.Sleep(2 * time.Second)
+		}
+		t.Fatalf("quote %s did not reach PAID within 30s (last state=%d)", quoteId, lastState)
+	})
+
+	// f) Mint tokens against the now-paid quote.
+	t.Run("mint_tokens", func(t *testing.T) {
+		proofs, err := wallet.Mint(quoteId, cdk_ffi.SplitTargetNone{}, nil)
+		if err != nil {
+			t.Fatalf("Mint failed: %v", err)
+		}
+		if len(proofs) == 0 {
+			t.Fatal("Mint returned zero proofs")
+		}
+		total, err := cdk_ffi.ProofsTotalAmount(proofs)
+		if err != nil {
+			t.Fatalf("ProofsTotalAmount failed: %v", err)
+		}
+		t.Logf("minted %d proofs totalling %d sats", len(proofs), total.Value)
+	})
+
+	// g) The wallet's total balance must now reflect the minted tokens.
+	t.Run("total_balance_reflects_mint", func(t *testing.T) {
+		balance, err := wallet.TotalBalance()
+		if err != nil {
+			t.Fatalf("TotalBalance failed: %v", err)
+		}
+		t.Logf("wallet total balance: %d sats", balance.Value)
+		if balance.Value < 1 {
+			t.Fatalf("expected balance >= 1 sat after mint, got %d", balance.Value)
+		}
+	})
+}
+
+func mustMintHost(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse mint URL %q: %v", rawURL, err)
+	}
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return host + ":" + port
+}
+
+func dialCheck(addr string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}


### PR DESCRIPTION
## What

Research-only spike that evaluates [cdk-go](https://github.com/cashubtc/cdk-go) (FFI bindings to the Rust Cashu Development Kit) as a possible replacement for the `gonuts-tollgate` wallet library. Adds a standalone Go module under `tests/cdk-go-spike/` that exercises cdk-go's token and wallet APIs on the architectures it supports (linux amd64/arm64).

Tracking issue: #271 (full evaluation, MIPS/armv7 blocker analysis, POC findings, options compared, recommendation).

## Why

We have been bumping the gonuts-tollgate fork repeatedly to patch unrecoverable bugs (#260, #257, #156, #134, PR #266, PR #253). The maintainer TODO at `src/tollwallet/tollwallet.go:49` explicitly states the long-term fix is switching to CDK. Issue #176 previously analyzed the ecosystem and recommended tollgate-rs. cdk-go was just released and this spike establishes concrete evidence about whether it could serve as a Go-only path for the architectures it supports.

## Key findings (full detail in #271)

- **MIPS/armv7 blocker (primary finding):** cdk-go ships prebuilt `libcdk_ffi.so` for linux amd64 + arm64 only. TollGate builds for 6 OpenWrt architectures; 3 of them (arm_cortex-a7, mipsel_24kc, mips_24kc) cannot run cdk-go at all. This is the same option #176 explicitly rejected.
- **Token API is ergonomic:** `TokenDecode` → `Encode` roundtrip, value/mint-URL extraction, and malformed-input handling all pass on the first try with zero glue code.
- **FFI network-error gap:** cdk-go's FFI does NOT propagate network errors as Go errors — unreachable mints cause `panic: EOF` in the deserializer instead of a returned `error`. Consumers must pre-flight reachability. Relevant to TollGate's degraded-mode paths.
- **Manual CGO memory management:** `Wallet.Destroy()` and `*Token.Destroy()` are manually managed. Cleanup registration in Go subtests is a footgun.
- **Verdict:** cdk-go is NOT a drop-in replacement across TollGate's arch matrix. Viable only as an amd64/arm64 wallet path if a per-arch hybrid is pursued. Long-term recommendation from #176 (tollgate-rs) stands.

## Scope

- **Touches only:** `tests/cdk-go-spike/` (new, separate Go module)
- **Does NOT touch:** `src/` production code, any existing `go.mod`/`go.sum`, the gonuts replace directive
- **Cannot break:** any production architecture build (the spike is a separate module outside `src/`'s module graph; `go build ./...` from `src/` is verified clean)

## Verification (per AGENTS.md gate)

From `src/`:
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test -race -count=1 -tags testenv ./...` — all pass
- `gofmt -l .` — the files listed are pre-existing issues in `src/` unrelated to this branch (confirmed: branch only touches `tests/cdk-go-spike/`); per AGENTS.md I did not fix unrelated issues

From `tests/cdk-go-spike/`:
- `go build .` — clean (linux/amd64)
- `go test -v -count=1 ./...` — token tests PASS, wallet test SKIPs (network-gated by `CDK_SPIKE_NETWORK=1`)
- `gofmt -l .` — clean

## What this PR does NOT do

- Does NOT change which wallet library TollGate uses
- Does NOT add cdk-go as a dependency of the main module
- Does NOT remove or modify the gonuts replace directive
- Does NOT validate MIPS or router-hardware behavior — this is a sandbox-amd64 POC only
- Does NOT decide the migration question — that's for maintainers to decide based on #271

## Commits

1. `ba16d6b` — scaffold (separate Go module, build tags, Makefile, README)
2. `e1e2072` — token decode/encode + malformed-input tests (all pass)
3. `0441bd9` — testmint wallet integration scenario (network-gated)
4. `27c4b8d` — commit cdk-go require + go.sum so spike builds from clean checkout
5. `b5ef701` — reference tracking issue #271 in spike README