### PR TITLE
chore: add .omo/ and planning doc patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,15 @@ memory-global
 memory-project/
 reference/
 .opencode/
+.omo/
 
 # Planning docs — internal, not for release
 docs/tmp/
 handover-mint-url-bug.md
-.omo/
+*-plan.md
+PLAN-*.md
+TODO-*.md
+MOCK-*.md
+notepad*.md
+handover*.md
+ulw-*.md


### PR DESCRIPTION
Adds .omo/ and planning doc patterns to .gitignore to prevent future commits of session/planning files.