### PR TITLE
deps: bump gonuts-tollgate from v0.7.4 to v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,36 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- **Cashu wallet swap-counter race (critical).** Bump `gonuts-tollgate`
-  from v0.7.1 to v0.7.4 to pick up the fix for an unrecoverable
-  "blinded message already signed" error (NUT-02 code 10002). In v0.7.1
-  the keyset counter was incremented only after a successful swap, so
-  a transient mint failure (timeout, DNS hiccup, 5xx) left the counter
-  stuck — every retry reused the same counter, the mint rejected with
-  10002, and the wallet bricked permanently with no self-recovery.
-  v0.7.4 increments the counter before the swap call and adds a
-  `swapWithRetry` path that regenerates fresh blinded messages on
-  retry.
+- **Cashu wallet swap-counter race, URL normalization, and DLEQ
+  keyset lookup (critical).** Bump `gonuts-tollgate`
+  from v0.7.4 to v0.7.5, picking up three additional fixes:
+
+  1. *Swap-counter race* — the keyset counter was incremented only
+     after a successful swap, so a transient mint failure left it
+     stuck. Every retry reused the same counter, the mint rejected
+     with "blinded message already signed" (NUT-02 code 10002), and
+     the wallet bricked permanently. The counter now increments
+     before the swap, and `swapWithRetry` regenerates fresh blinded
+     messages on retry.
+
+  2. *Mint URL trailing-slash crash-loop* — a trailing slash in a
+     configured mint URL caused gonuts to construct double-slash
+     paths (`//v1/keysets`) which CDK V2 mints reject with 404,
+     sending the backend into a crash-loop instead of degraded mode.
+     gonuts now trims trailing slashes before all path construction
+     ([#275](https://github.com/OpenTollGate/tollgate-module-basic-go/issues/275)).
+
+  3. *DLEQ verification with rotated keysets* — DLEQ proof
+     verification now looks up the correct historical keyset per
+     proof (by `proof.Id`) instead of always using the active
+     keyset. Tokens minted under a since-rotated keyset no longer
+     fail DLEQ verification.
+
+### Changed / Internal
+
+- **Mint response size limits.** All `io.ReadAll` calls on mint HTTP
+  responses in gonuts are now capped at 1 MB via `io.LimitReader`,
+  preventing OOM from malicious or buggy mints.
 
 - **Mint URL fuzzy matching in `calculateAllotment()`.** The mint URL
   from Cashu tokens was compared against configured accepted mints

--- a/src/go.mod
+++ b/src/go.mod
@@ -29,7 +29,7 @@ replace (
 	github.com/OpenTollGate/tollgate-module-basic-go/src/utils => ./utils
 	github.com/OpenTollGate/tollgate-module-basic-go/src/valve => ./valve
 	github.com/OpenTollGate/tollgate-module-basic-go/src/wireless_gateway_manager => ./wireless_gateway_manager
-	github.com/Origami74/gonuts-tollgate => github.com/OpenTollGate/gonuts-tollgate v0.7.4
+	github.com/Origami74/gonuts-tollgate => github.com/OpenTollGate/gonuts-tollgate v0.7.5
 )
 
 require (

--- a/src/go.sum
+++ b/src/go.sum
@@ -8,8 +8,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenTollGate/gonuts-tollgate v0.7.4 h1:dMA6BCcstKhrLSfFWhr45H5U0aMMkRm66Efn/NHp3aw=
-github.com/OpenTollGate/gonuts-tollgate v0.7.4/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
+github.com/OpenTollGate/gonuts-tollgate v0.7.5 h1:DMpqea953CSgwz5XokijsCE41gRM0nrgE/9PG6FTp/k=
+github.com/OpenTollGate/gonuts-tollgate v0.7.5/go.mod h1:2OmCckSDd1YpVTmoeCUYEXWNhN9h3ggeqeQXlqscssY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=


### PR DESCRIPTION
## Summary

Bumps `gonuts-tollgate` from v0.7.4 to v0.7.5, picking up three fixes from [OpenTollGate/gonuts-tollgate](https://github.com/OpenTollGate/gonuts-tollgate) PRs #2, #3, and #4.

## Fixes included

### 1. Mint URL trailing-slash crash-loop (#275)
A trailing slash in a configured mint URL (e.g. `http://mint.example.com/`) caused gonuts to construct double-slash paths (`//v1/keysets`) which CDK V2 mints reject with 404, sending the backend into a crash-loop instead of degraded mode. gonuts now trims trailing slashes before all path construction via `normalizeMintURL()`.

### 2. DLEQ verification with rotated keysets
DLEQ proof verification now looks up the correct historical keyset per proof (by `proof.Id`) instead of always using the active keyset. Tokens minted under a since-rotated keyset no longer fail DLEQ verification.

### 3. Mint response size limits
All `io.ReadAll` calls on mint HTTP responses in gonuts are now capped at 1 MB via `io.LimitReader`, preventing OOM from malicious or buggy mints.

## Changes

```
CHANGELOG.md | 33 ++++++++++++++++++++++++++++-----
src/go.mod   |  2 +-
src/go.sum   |  4 ++--
```

Only the root `go.mod` replace directive is changed (matching the pattern from #266). Sub-module `go.mod` files are not touched — the root replace directive takes precedence.

## Verification

```
go build ./...   # OK
go vet ./...     # OK
go test -race -count=1 -tags testenv ./...   # ok 5.409s
```

## gonuts-tollgate PRs merged in v0.7.5

- [#2](https://github.com/OpenTollGate/gonuts-tollgate/pull/2) — normalize mint URL and cap response reads at 1MB
- [#3](https://github.com/OpenTollGate/gonuts-tollgate/pull/3) — increment keyset counter before swap to prevent already-signed errors
- [#4](https://github.com/OpenTollGate/gonuts-tollgate/pull/4) — use proof.Id for DLEQ verification instead of active keyset

Supersedes #278 (closed due to stale base).
