### PR TITLE
docs: correct NDS mark descriptions and fw4 priority diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ and [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **NDS fw4/nftables enforcement bridge.** NDS 5.0.2 inserts enforcement
-  chains in `ip filter FORWARD` (iptables-nft), but OpenWrt 24.10's fw4
-  `inet fw4 forward` chain accepts forwarded traffic at the same priority
-  before the ip filter chain runs — leaving NDS's enforcement chain dead
-  (0 packets). Authenticated clients had mangle marks set correctly but
-  traffic was never actually gated. Added `/etc/nftables.d/20-nds-enforce.nft`
-  include file that hooks into `inet fw4 forward` at priority -1 (before
-  fw4's accept) and enforces NDS marks. Bumped setup version to v0.5.1.
+  chains in `ip filter FORWARD` (iptables-nft) at priority 0. OpenWrt 24.10's
+  fw4 `inet fw4 forward` chain also runs at priority 0 — nftables does not
+  guarantee ordering between base chains at the same priority across
+  families, leaving NDS's enforcement chain dead (0 packets). Authenticated
+  clients had mangle marks set correctly but traffic was never actually
+  gated. Added `/etc/nftables.d/20-nds-enforce.nft` include file that hooks
+  into `inet fw4 forward` at priority -1 (before fw4's forward at priority 0)
+  and enforces NDS marks. Bumped setup version to v0.5.1.
 
 - **V2 keyset swap crash (critical).** Bump `gonuts-tollgate` from v0.7.4
   to v0.7.6 to pick up the fix for the V2 keyset derivation path bug in

--- a/packaging/files/etc/nftables.d/20-nds-enforce.nft
+++ b/packaging/files/etc/nftables.d/20-nds-enforce.nft
@@ -1,16 +1,18 @@
 # NDS fw4/nftables enforcement bridge
 #
 # NDS 5.0.2 inserts enforcement chains in ip filter FORWARD (iptables-nft).
-# On OpenWrt 24.10, fw4's inet fw4 forward chain (priority 0) accepts
-# forwarded traffic before the ip filter FORWARD chain (same priority)
-# ever sees it — leaving NDS's enforcement chain dead (0 packets).
+# Both ip filter FORWARD and fw4's inet fw4 forward chain run at priority 0;
+# nftables does not guarantee ordering between base chains at the same
+# priority across different families, so NDS's enforcement chain may never
+# see forwarded traffic (0 packets).
 #
 # This include hooks into inet fw4 forward at priority -1, BEFORE fw4's
-# accept. It checks marks set by NDS's mangle PREROUTING (priority -150):
-#   0x10000 = pre-authenticated → drop
-#   0x20000 = trusted           → accept
-#   0x30000 = authenticated     → accept
-#   unmarked to WAN             → reject (force captive portal)
+# forward chain at priority 0. It checks marks set by NDS's mangle
+# PREROUTING (priority -150):
+#   0x10000 = blocked (admin)    → drop
+#   0x20000 = trusted            → accept
+#   0x30000 = authenticated      → accept
+#   unmarked (0) = pre-auth      → reject to WAN (force captive portal)
 #
 # Loaded by fw4 on boot and on `fw4 reload` / `/etc/init.d/firewall reload`.
 # Survives NDS restarts (independent of NDS process lifecycle).
@@ -18,15 +20,8 @@
 chain nds_enforce_forward {
     type filter hook forward priority -1; policy accept
 
-    # Pre-authenticated clients — blocked
     meta nfproto ipv4 iifname "br-lan" meta mark & 0x00030000 == 0x00010000 counter drop
-
-    # Trusted clients — allowed
     meta nfproto ipv4 iifname "br-lan" meta mark & 0x00030000 == 0x00020000 counter accept
-
-    # Authenticated clients — allowed
     meta nfproto ipv4 iifname "br-lan" meta mark & 0x00030000 == 0x00030000 counter accept
-
-    # Unmarked traffic from br-lan to WAN — reject (captive portal redirect)
     meta nfproto ipv4 iifname "br-lan" oifname { "eth0", "phy0-sta0" } counter reject with icmp type port-unreachable
 }


### PR DESCRIPTION
Follow-up to #283 (merged). Two comment inaccuracies in the .nft file and CHANGELOG:

1. **`0x10000` is NDS "blocked" (admin-blocked client), not "pre-authenticated".** Pre-authenticated clients are unmarked (mark=0). Verified against nodogsplash source: [`src/conf.h:82`](https://github.com/nodogsplash/nodogsplash/blob/6beb760589da5fdeaa7b5f7c5277e38215811dbf/src/conf.h#L82): `DEFAULT_FW_MARK_BLOCKED 0x10000`.

2. **Diagnosis: nftables ordering at the same priority is undefined, not "inet accepts before ip filter".** Per the [netfilter mailing list](https://www.spinics.net/lists/netfilter/msg60396.html): "If exactly the same priority is used for two chains... order becomes undefined." The fix at priority -1 is correct — it establishes deterministic ordering.

Pure documentation change, zero functional impact.