### PR TITLE
fix: portable WAN detection for NDS enforcement chain (#289)

### DIFF
--- a/packaging/files/etc/nftables.d/20-nds-enforce.nft
+++ b/packaging/files/etc/nftables.d/20-nds-enforce.nft
@@ -10,7 +10,7 @@
 #   0x10000 = pre-authenticated → drop
 #   0x20000 = trusted           → accept
 #   0x30000 = authenticated     → accept
-#   unmarked to WAN             → reject (force captive portal)
+#   unmarked (0) = pre-auth      → reject to WAN (force captive portal)
 #
 # Loaded by fw4 on boot and on `fw4 reload` / `/etc/init.d/firewall reload`.
 # Survives NDS restarts (independent of NDS process lifecycle).
@@ -28,5 +28,5 @@ chain nds_enforce_forward {
     meta nfproto ipv4 iifname "br-lan" meta mark & 0x00030000 == 0x00030000 counter accept
 
     # Unmarked traffic from br-lan to WAN — reject (captive portal redirect)
-    meta nfproto ipv4 iifname "br-lan" oifname { "eth0", "phy0-sta0" } counter reject with icmp type port-unreachable
+    meta nfproto ipv4 iifname "br-lan" fib daddr oif != "br-lan" counter reject with icmp type port-unreachable
 }


### PR DESCRIPTION
Replaces hardcoded `oifname { "eth0", "phy0-sta0" }` with `fib daddr oif != "br-lan"` — uses the kernel routing table instead of interface names.

**Before:** The reject rule for pre-auth traffic was GL-MT3000-specific. On mips_24kc (WAN on eth1), PPPoE (pppoe-wan), USB modems (wwan0), or any non-eth0 WAN, the rule was dead — pre-auth traffic to the internet was never rejected, so the OS captive portal detector never triggered.

**After:** The `fib daddr oif` lookup asks the kernel "what interface would this packet exit?" at evaluation time. If it's not br-lan (i.e., traffic is going to the internet), reject. Works on every architecture, every topology, every WAN type — now and in the future.

Verified: 12/12 PRTA NDS fw4 tests pass on OpenWrt 24.10.1 QEMU VM.

Closes #289.