### PR TITLE
fix(#289): portable WAN detection in NDS enforcement bridge

### DIFF
--- a/packaging/files/etc/nftables.d/20-nds-enforce.nft
+++ b/packaging/files/etc/nftables.d/20-nds-enforce.nft
@@ -27,6 +27,8 @@ chain nds_enforce_forward {
     # Authenticated clients — allowed
     meta nfproto ipv4 iifname "br-lan" meta mark & 0x00030000 == 0x00030000 counter accept
 
-    # Unmarked traffic from br-lan to WAN — reject (captive portal redirect)
-    meta nfproto ipv4 iifname "br-lan" oifname { "eth0", "phy0-sta0" } counter reject with icmp type port-unreachable
+    # Pre-authenticated (unmarked) traffic from LAN to non-LAN — reject
+    # Portable WAN detection: works on all architectures.
+    # Old hardcoded oifname { "eth0", "phy0-sta0" } only matched GL-MT3000.
+    meta nfproto ipv4 iifname "br-lan" oifname != "br-lan" counter reject with icmp type port-unreachable
 }


### PR DESCRIPTION
Replace hardcoded `oifname { "eth0", "phy0-sta0" }` with `oifname != "br-lan"`.

The hardcoded list only matched GL-MT3000 WAN interfaces. Other architectures were not covered:
- ath79 (WAN=eth1)
- x86_64 QEMU (bridge-WAN)
- USB modems (wwan0/usb0)
- PPPoE (pppoe-wan)

On affected architectures, the reject rule for pre-authenticated traffic to WAN never fired — unauthenticated clients had unblocked internet access.

`oifname != "br-lan"` matches any traffic leaving the LAN bridge, covering all multi-interface deployments.

### Verification
Tested on virtual lab (x86_64 QEMU) where the hardcoded version showed 0 enforcement packets.

Closes: #289