### PR TITLE
fix: fall back to degraded mode on wallet init failure (#275)

### DIFF
--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -128,7 +128,24 @@ func newFullMerchant(configManager *config_manager.ConfigManager, mintHealthTrac
 	tw, walletErr := tollwallet.New(walletDirPath, mintURLs, false)
 
 	if walletErr != nil {
-		return nil, fmt.Errorf("failed to create wallet: %w", walletErr)
+		log.Printf("WARNING: Wallet initialization failed (%v) — starting in degraded mode", walletErr)
+		deg := NewMerchantDegradedWithWallet(configManager, mintHealthTracker, DefaultWalletFactory, walletDirPath)
+		mintHealthTracker.StartProactiveChecks()
+		mintHealthTracker.SetOnFirstReachableForDegraded(func() {
+			log.Printf("Mint became reachable — attempting to upgrade from degraded mode")
+			if err := deg.Shutdown(); err != nil {
+				log.Printf("ERROR: Failed to shutdown degraded wallet before upgrade: %v", err)
+			}
+			fullMerchant, err := newFullMerchant(configManager, mintHealthTracker)
+			if err != nil {
+				log.Printf("ERROR: Failed to upgrade from degraded mode: %v", err)
+				return
+			}
+			if deg.onUpgrade != nil {
+				deg.onUpgrade(fullMerchant)
+			}
+		})
+		return deg, nil
 	}
 	balance := tw.GetBalance()
 


### PR DESCRIPTION
## Problem

When mint is reachable (probe succeeds) but wallet init fails (e.g., keyset fetch error), `newFullMerchant()` returns an error → `main.go` `Fatal()` → `init.d` restart loop → backend completely offline.

## Fix

Mirror the existing 'no reachable mints' degraded fallback (lines 83-101) for the wallet init failure case. Instead of returning an error, start `MerchantDegradedWithWallet` + proactive checks + upgrade callback.

**Before**: mint reachable + wallet init fails → crash loop → offline
**After**: mint reachable + wallet init fails → `kind:21023` degraded mode → auto-upgrade when mint becomes compatible

## Validation (local KVM)

- Unreachable mint (`http://10.99.99.2:9999`): **kind=21023, 0 crash loops, backend alive** ✅
- Normal mint: **kind=10021, all 10/10 tests pass** ✅
- Binary: gonuts v0.9.0, CGO\_ENABLED=0

## Scope

This is a clean standalone PR extracted from #280. The WalletPort abstraction and cdk-go FFI work from #280 will be separate PRs.

Closes #275. Supersedes #280.