### PR TITLE
ci: add blossom.psbt.me mirror (blossom1/2 down, drive.cashu.email quota exceeded)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -14,7 +14,7 @@ env:
   PACKAGE_NAME: "tollgate-wrt"
   GO_VERSION: "1.25"
   DEBUG: "true"
-  BLOSSOM_SERVERS: "https://blossom.primal.net https://blossom1.orangesync.tech https://blossom2.orangesync.tech https://drive.cashu.email"
+  BLOSSOM_SERVERS: "https://blossom.primal.net https://blossom.psbt.me https://blossom1.orangesync.tech https://blossom2.orangesync.tech https://drive.cashu.email"
   BLOSSOM_MIN_SUCCESS: "2"
   COORDINATION_RELAYS: >-
     wss://relay.damus.io


### PR DESCRIPTION
Adds blossom.psbt.me as 5th Blossom server. Currently only blossom.primal.net works (1/4). Need 2 for BLOSSOM_MIN_SUCCESS.