### PR TITLE
ci: lower BLOSSOM_MIN_SUCCESS to 1

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -15,7 +15,7 @@ env:
   GO_VERSION: "1.25"
   DEBUG: "true"
   BLOSSOM_SERVERS: "https://blossom.primal.net https://blossom.psbt.me https://blossom1.orangesync.tech https://blossom2.orangesync.tech https://drive.cashu.email"
-  BLOSSOM_MIN_SUCCESS: "2"
+  BLOSSOM_MIN_SUCCESS: "1"
   COORDINATION_RELAYS: >-
     wss://relay.damus.io
     wss://nos.lol


### PR DESCRIPTION
Only blossom.primal.net is reliably reachable. 1 mirror is sufficient for artifact availability.