### PR TITLE
fix: sat standardization + advertisement fix + config migration

### DIFF
--- a/src/config_manager/buildinfo_test.go
+++ b/src/config_manager/buildinfo_test.go
@@ -120,7 +120,7 @@ func TestDefaultTestMint(t *testing.T) {
 	if mint.PricePerStep != 1 {
 		t.Errorf("expected PricePerStep=1, got %d", mint.PricePerStep)
 	}
-	if mint.PriceUnit != "sats" {
+	if mint.PriceUnit != "sat" {
 		t.Errorf("expected PriceUnit=sats, got %s", mint.PriceUnit)
 	}
 }

--- a/src/config_manager/buildinfo_test.go
+++ b/src/config_manager/buildinfo_test.go
@@ -121,7 +121,7 @@ func TestDefaultTestMint(t *testing.T) {
 		t.Errorf("expected PricePerStep=1, got %d", mint.PricePerStep)
 	}
 	if mint.PriceUnit != "sat" {
-		t.Errorf("expected PriceUnit=sats, got %s", mint.PriceUnit)
+		t.Errorf("expected PriceUnit=sat, got %s", mint.PriceUnit)
 	}
 }
 

--- a/src/config_manager/config_manager_config.go
+++ b/src/config_manager/config_manager_config.go
@@ -175,7 +175,7 @@ func defaultProductionMints() []MintConfig {
 			PayoutIntervalSeconds:   60,
 			MinPayoutAmount:         128,
 			PricePerStep:            1,
-			PriceUnit:               "sats",
+			PriceUnit:               "sat",
 			MinPurchaseSteps:        0,
 		},
 		{
@@ -185,7 +185,7 @@ func defaultProductionMints() []MintConfig {
 			PayoutIntervalSeconds:   60,
 			MinPayoutAmount:         128,
 			PricePerStep:            1,
-			PriceUnit:               "sats",
+			PriceUnit:               "sat",
 			MinPurchaseSteps:        0,
 		},
 	}
@@ -199,7 +199,7 @@ func defaultTestMint() MintConfig {
 		PayoutIntervalSeconds:   999999,
 		MinPayoutAmount:         999999,
 		PricePerStep:            1,
-		PriceUnit:               "sats",
+		PriceUnit:               "sat",
 		MinPurchaseSteps:        0,
 	}
 }
@@ -340,4 +340,10 @@ func migrateConfig(config *Config, defaults *Config) {
 		log.Printf("INFO: Populated UpstreamWifi defaults (was missing in v%s)", config.ConfigVersion)
 	}
 	config.ConfigVersion = defaults.ConfigVersion
+    for i := range config.AcceptedMints {
+        if config.AcceptedMints[i].PriceUnit == "sats" {
+            config.AcceptedMints[i].PriceUnit = "sat"
+            log.Printf("INFO: Migrated price_unit sats to sat for mint %s", config.AcceptedMints[i].URL)
+        }
+    }
 }

--- a/src/config_manager/config_manager_config.go
+++ b/src/config_manager/config_manager_config.go
@@ -320,7 +320,6 @@ func EnsureDefaultConfig(filePath string) (*Config, error) {
 	if profitShareErr != nil {
 		log.Printf("WARNING: Invalid profit_share, resetting to defaults: %v", profitShareErr)
 		config.ProfitShare = defaultConfig.ProfitShare
-		return &config, SaveConfig(filePath, &config)
 	}
 	if config.ConfigVersion != defaultConfig.ConfigVersion {
 		log.Printf("INFO: Config version %s → %s, migrating (preserving user settings)", config.ConfigVersion, defaultConfig.ConfigVersion)
@@ -328,6 +327,9 @@ func EnsureDefaultConfig(filePath string) (*Config, error) {
 			log.Printf("WARN: Failed to backup config before migration (continuing): %v", backupErr)
 		}
 		migrateConfig(&config, defaultConfig)
+		return &config, SaveConfig(filePath, &config)
+	}
+	if profitShareErr != nil {
 		return &config, SaveConfig(filePath, &config)
 	}
 

--- a/src/config_manager/config_migration_test.go
+++ b/src/config_manager/config_migration_test.go
@@ -27,7 +27,7 @@ func TestConfigMigration_v007_to_v008(t *testing.T) {
 				"payout_interval_seconds": 120,
 				"min_payout_amount": 50,
 				"price_per_step": 2,
-				"price_unit": "sats",
+				"price_unit": "sat",
 				"purchase_min_steps": 1
 			}
 		],

--- a/src/config_manager/config_migration_test.go
+++ b/src/config_manager/config_migration_test.go
@@ -122,3 +122,33 @@ func TestConfigMigration_alreadyCurrent(t *testing.T) {
 		t.Errorf("config_version changed: got %s, want %s", loaded.ConfigVersion, defaults.ConfigVersion)
 	}
 }
+
+func TestConfigMigration_sats_to_sat(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	oldConfigJSON := `{
+		"config_version": "v0.0.7",
+		"accepted_mints": [
+			{"url": "https://mint-a.example.com", "price_per_step": 1, "price_unit": "sats"},
+			{"url": "https://mint-b.example.com", "price_per_step": 2, "price_unit": "sat"}
+		]
+	}`
+
+	if err := os.WriteFile(configPath, []byte(oldConfigJSON), 0644); err != nil {
+		t.Fatalf("failed to write old config: %v", err)
+	}
+
+	migrated, err := EnsureDefaultConfig(configPath)
+	if err != nil {
+		t.Fatalf("EnsureDefaultConfig failed: %v", err)
+	}
+
+	if migrated.AcceptedMints[0].PriceUnit != "sat" {
+		t.Errorf("mint A price_unit: got %s, want sat (migrated from sats)", migrated.AcceptedMints[0].PriceUnit)
+	}
+
+	if migrated.AcceptedMints[1].PriceUnit != "sat" {
+		t.Errorf("mint B price_unit: got %s, want sat (already correct)", migrated.AcceptedMints[1].PriceUnit)
+	}
+}

--- a/src/config_manager/config_schema.go
+++ b/src/config_manager/config_schema.go
@@ -65,7 +65,7 @@ func GetConfigSchema() []FieldSchema {
 				{Name: "PayoutIntervalSeconds", JSONKey: "payout_interval_seconds", Type: "uint64", Description: "Seconds between payout rounds", Default: uint64(60), Required: true, Editable: true},
 				{Name: "MinPayoutAmount", JSONKey: "min_payout_amount", Type: "uint64", Description: "Minimum payout amount in sats", Default: uint64(128), Required: true, Editable: true},
 				{Name: "PricePerStep", JSONKey: "price_per_step", Type: "uint64", Description: "Price per step in sats", Default: uint64(1), Required: true, Editable: true, Min: uint64(1)},
-				{Name: "PriceUnit", JSONKey: "price_unit", Type: "string", Description: "Price unit", Default: "sats", Required: true, Editable: true},
+				{Name: "PriceUnit", JSONKey: "price_unit", Type: "string", Description: "Price unit", Default: "sat", Required: true, Editable: true},
 				{Name: "MinPurchaseSteps", JSONKey: "purchase_min_steps", Type: "uint64", Description: "Minimum number of steps per purchase", Default: uint64(0), Required: true, Editable: true},
 			},
 		},

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -554,7 +554,7 @@ func CreateAdvertisement(configManager *config_manager.ConfigManager, tracker *M
 		return "", fmt.Errorf("main config is nil")
 	}
 
-	reachableMints := tracker.GetReachableMintConfigs()
+	reachableMints := tracker.GetAllConfiguredMintConfigs()
 
 	advertisementEvent := nostr.Event{
 		Kind: 10021,

--- a/src/merchant/merchant_degraded_test.go
+++ b/src/merchant/merchant_degraded_test.go
@@ -211,7 +211,7 @@ func TestMerchantDegraded_CreateNoticeEvent_NoMerchantIdentity(t *testing.T) {
 
 	tracker := newTestTracker(&config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srvFail.URL, PricePerStep: 1, PriceUnit: "sats"},
+			{URL: srvFail.URL, PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}, nil)
 
@@ -343,7 +343,7 @@ func TestNew_ReturnsDegradedWhenNoMintsReachable(t *testing.T) {
 
 	cfg := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sats"},
+			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}
 
@@ -464,7 +464,7 @@ func (w *mockWallet) Shutdown() error {
 func newDegradedMerchantWithMockWallet(t *testing.T, wallet Wallet, walletFactoryErr error) (*MerchantDegraded, *config_manager.ConfigManager, *MintHealthTracker) {
 	t.Helper()
 	ds, _ := newDegradedSetupWithServer(t, []config_manager.MintConfig{
-		{URL: "https://mint2.test", PricePerStep: 2, PriceUnit: "sats"},
+		{URL: "https://mint2.test", PricePerStep: 2, PriceUnit: "sat"},
 	})
 	deg := ds.DegradedWithWallet(wallet, walletFactoryErr)
 	return deg, ds.CM, ds.Tracker
@@ -623,7 +623,7 @@ func TestKickstart_WalletFactoryReceivesAllConfiguredMintURLs(t *testing.T) {
 	var receivedURLs []string
 
 	ds, _ := newDegradedSetupWithServer(t, []config_manager.MintConfig{
-		{URL: "https://mint2.test", PricePerStep: 2, PriceUnit: "sats"},
+		{URL: "https://mint2.test", PricePerStep: 2, PriceUnit: "sat"},
 	})
 
 	factory := func(walletPath string, mintURLs []string) (Wallet, error) {
@@ -728,7 +728,7 @@ func TestKickstart_Integration_DegradedToFullUpgrade(t *testing.T) {
 	provider := ds.Tracker.configProvider.(*mockConfigProvider)
 	provider.config = &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sats"},
+			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}
 
@@ -751,8 +751,8 @@ func TestKickstart_EndToEnd_OfflineKickstartWithWalletBalance(t *testing.T) {
 	srvDown := newUnreachableServer(t)
 
 	ds := newDegradedSetup(t, []config_manager.MintConfig{
-		{URL: srvDown.URL, PricePerStep: 1, PriceUnit: "sats"},
-		{URL: "https://mint2.example.com", PricePerStep: 2, PriceUnit: "sats"},
+		{URL: srvDown.URL, PricePerStep: 1, PriceUnit: "sat"},
+		{URL: "https://mint2.example.com", PricePerStep: 2, PriceUnit: "sat"},
 	})
 
 	mw := &mockWallet{
@@ -864,8 +864,8 @@ func TestGetAllConfiguredMintConfigs(t *testing.T) {
 
 	config := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sats"},
-			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sats"},
+			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sat"},
+			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sat"},
 		},
 	}
 
@@ -1032,7 +1032,7 @@ func TestKickstart_Integration_ShutdownBeforeUpgrade(t *testing.T) {
 	provider := ds.Tracker.configProvider.(*mockConfigProvider)
 	provider.config = &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sats"},
+			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}
 
@@ -1097,7 +1097,7 @@ func TestKickstart_Integration_UpgradeSwapsMerchantViaProvider(t *testing.T) {
 	configProvider := ds.Tracker.configProvider.(*mockConfigProvider)
 	configProvider.config = &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sats"},
+			{URL: srv.URL, PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}
 
@@ -1165,7 +1165,7 @@ func TestE2E_BoltDBLock_DegradedShutdownThenReopen(t *testing.T) {
 	shortClient := &http.Client{Timeout: 1 * time.Second}
 	cfg := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: "http://127.0.0.1:1", PricePerStep: 1, PriceUnit: "sats"},
+			{URL: "http://127.0.0.1:1", PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}
 
@@ -1231,7 +1231,7 @@ func TestMerchantDegraded_SetOnReachableSetChanged(t *testing.T) {
 
 func TestMerchantDegraded_GetMintHealthTracker(t *testing.T) {
 	ds := newDegradedSetup(t, []config_manager.MintConfig{
-		{URL: "https://mint.test", PricePerStep: 1, PriceUnit: "sats"},
+		{URL: "https://mint.test", PricePerStep: 1, PriceUnit: "sat"},
 	})
 
 	deg := NewMerchantDegradedFromFull(ds.CM, ds.Tracker)

--- a/src/merchant/merchant_health_test.go
+++ b/src/merchant/merchant_health_test.go
@@ -100,7 +100,7 @@ func TestSetOnFirstReachableForDegraded_FiresOnRecovery(t *testing.T) {
 
 	cfg := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: reachableSrv.URL, PricePerStep: 1, PriceUnit: "sats"},
+			{URL: reachableSrv.URL, PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}
 	tracker.configProvider = &mockConfigProvider{config: cfg}
@@ -137,7 +137,7 @@ func TestSetOnFirstReachableForDegraded_NotFiredOnSecondRecovery(t *testing.T) {
 
 	cfg := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: reachableSrv.URL, PricePerStep: 1, PriceUnit: "sats"},
+			{URL: reachableSrv.URL, PricePerStep: 1, PriceUnit: "sat"},
 		},
 	}
 	tracker.configProvider = &mockConfigProvider{config: cfg}
@@ -170,8 +170,8 @@ func TestGetAllConfiguredMintConfigs_ReturnsAll(t *testing.T) {
 
 	config := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sats"},
-			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sats"},
+			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sat"},
+			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sat"},
 		},
 	}
 
@@ -228,8 +228,8 @@ func TestMerchant_GetAcceptedMints_ReturnsOnlyReachable(t *testing.T) {
 
 	config := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sats"},
-			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sats"},
+			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sat"},
+			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sat"},
 		},
 	}
 

--- a/src/merchant/mint_health_tracker_test.go
+++ b/src/merchant/mint_health_tracker_test.go
@@ -24,7 +24,7 @@ func mintConfigWithURLs(urls ...string) *config_manager.Config {
 		mints[i] = config_manager.MintConfig{
 			URL:          url,
 			PricePerStep: 1,
-			PriceUnit:    "sats",
+			PriceUnit:    "sat",
 		}
 	}
 	return &config_manager.Config{
@@ -399,8 +399,8 @@ func TestEndToEnd_FullLifecycle(t *testing.T) {
 
 	config := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: mintA.URL, PricePerStep: 1, PriceUnit: "sats", MinPurchaseSteps: 1},
-			{URL: mintB.URL, PricePerStep: 2, PriceUnit: "sats", MinPurchaseSteps: 2},
+			{URL: mintA.URL, PricePerStep: 1, PriceUnit: "sat", MinPurchaseSteps: 1},
+			{URL: mintB.URL, PricePerStep: 2, PriceUnit: "sat", MinPurchaseSteps: 2},
 		},
 		Metric:   "milliseconds",
 		StepSize: 1000,
@@ -459,8 +459,8 @@ func TestEndToEnd_FullLifecycle(t *testing.T) {
 	// Update config to use the failing mint A
 	tracker.configProvider.(*mockConfigProvider).config = &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: mintAFail.URL, PricePerStep: 1, PriceUnit: "sats", MinPurchaseSteps: 1},
-			{URL: mintB.URL, PricePerStep: 2, PriceUnit: "sats", MinPurchaseSteps: 2},
+			{URL: mintAFail.URL, PricePerStep: 1, PriceUnit: "sat", MinPurchaseSteps: 1},
+			{URL: mintB.URL, PricePerStep: 2, PriceUnit: "sat", MinPurchaseSteps: 2},
 		},
 		Metric:   "milliseconds",
 		StepSize: 1000,
@@ -489,8 +489,8 @@ func TestEndToEnd_AllMintsDown_NoReachableConfigs(t *testing.T) {
 
 	config := &config_manager.Config{
 		AcceptedMints: []config_manager.MintConfig{
-			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sats"},
-			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sats"},
+			{URL: srvA.URL, PricePerStep: 1, PriceUnit: "sat"},
+			{URL: srvB.URL, PricePerStep: 2, PriceUnit: "sat"},
 		},
 	}
 

--- a/src/merchant/offline_wallet_integration_test.go
+++ b/src/merchant/offline_wallet_integration_test.go
@@ -177,7 +177,7 @@ func TestIntegration_FirstBootOffline(t *testing.T) {
 	cm, _ := setupTestConfigManager(t)
 	cfg := cm.GetConfig()
 	cfg.AcceptedMints = []config_manager.MintConfig{
-		{URL: unreachableMint, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: unreachableMint, PricePerStep: 1, PriceUnit: "sat"},
 	}
 
 	tracker := NewMintHealthTracker(cm)
@@ -369,7 +369,7 @@ func TestIntegration_DegradedMerchantOffline(t *testing.T) {
 	cm, _ := setupTestConfigManager(t)
 	cfg := cm.GetConfig()
 	cfg.AcceptedMints = []config_manager.MintConfig{
-		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sat"},
 	}
 
 	tracker := NewMintHealthTracker(cm)
@@ -472,7 +472,7 @@ func TestIntegration_RecoveryAndUpgrade(t *testing.T) {
 	}
 	cmCfg := cm.GetConfig()
 	cmCfg.AcceptedMints = []config_manager.MintConfig{
-		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sat"},
 	}
 
 	// Fund wallet in the same directory as config (newFullMerchant looks here)
@@ -828,7 +828,7 @@ func TestIntegration_FullMerchantDowngradeOnAllMintsDown(t *testing.T) {
 	}
 	cmCfg := cm.GetConfig()
 	cmCfg.AcceptedMints = []config_manager.MintConfig{
-		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sat"},
 	}
 
 	fundWallet(t, proxyURL, testDir)
@@ -910,7 +910,7 @@ func TestIntegration_DegradedRecoveryWithSetChangedCallback(t *testing.T) {
 	}
 	cmCfg := cm.GetConfig()
 	cmCfg.AcceptedMints = []config_manager.MintConfig{
-		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sat"},
 	}
 
 	fundWallet(t, proxyURL, testDir)
@@ -994,7 +994,7 @@ func TestIntegration_FullMerchantShutdownReleasesBoltDB(t *testing.T) {
 	}
 	cmCfg := cm.GetConfig()
 	cmCfg.AcceptedMints = []config_manager.MintConfig{
-		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: proxyURL, PricePerStep: 1, PriceUnit: "sat"},
 	}
 
 	fundWallet(t, proxyURL, testDir)

--- a/src/merchant/test_helpers_test.go
+++ b/src/merchant/test_helpers_test.go
@@ -56,7 +56,7 @@ func newDegradedSetupWithServer(t *testing.T, extraMints []config_manager.MintCo
 	t.Helper()
 	srv := newUnreachableServer(t)
 	mints := []config_manager.MintConfig{
-		{URL: srv.URL, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: srv.URL, PricePerStep: 1, PriceUnit: "sat"},
 	}
 	mints = append(mints, extraMints...)
 	ds := newDegradedSetup(t, mints)
@@ -91,7 +91,7 @@ func (ds *degradedSetup) DegradedWithCustomFactory(factory WalletFactory) *Merch
 
 func simpleMintConfig(url string) []config_manager.MintConfig {
 	return []config_manager.MintConfig{
-		{URL: url, PricePerStep: 1, PriceUnit: "sats"},
+		{URL: url, PricePerStep: 1, PriceUnit: "sat"},
 	}
 }
 


### PR DESCRIPTION
## Three changes (all addressing reviewer feedback from #301)

### 1. Standardize price_unit 'sats' → 'sat' (NUT-00)
NUT-00 defines unit as 'sat'. Backend was the only component using 'sats'.
Caused CU109 unit mismatch in captive portal.

### 2. Config migration for existing routers
`migrateConfig()` normalizes persisted 'sats' values to 'sat' on load.
Existing deployed routers with 'sats' in their config will be migrated
automatically on next restart.

### 3. Advertisement includes all configured mints
`GetReachableMintConfigs()` → `GetAllConfiguredMintConfigs()`.
Prevents price_per_step tags from disappearing when mints are temporarily
unreachable.

No captive portal assets, no debug artifacts. Pure Go code changes only.