### PR TITLE
fix(#260): retry on mint HTTP 429 with exponential backoff

### DIFF
--- a/src/merchant/go.mod
+++ b/src/merchant/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet v0.0.0
 	github.com/OpenTollGate/tollgate-module-basic-go/src/utils v0.0.0
 	github.com/OpenTollGate/tollgate-module-basic-go/src/valve v0.0.0
-	github.com/nbd-wtf/go-nostr v0.51.11
+	github.com/nbd-wtf/go-nostr v0.51.12
 )
 
 require (
@@ -93,7 +93,6 @@ require (
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nbd-wtf/ln-decodepay v1.13.0 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -14,12 +14,12 @@ import (
 
 	"sync"
 
+	"github.com/OpenTollGate/gonuts-tollgate/cashu"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/lightning"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/utils"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/valve"
-	"github.com/OpenTollGate/gonuts-tollgate/cashu"
 	"github.com/nbd-wtf/go-nostr"
 )
 
@@ -472,7 +472,7 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 	}
 	ch := make(chan receiveResult, 1)
 	go func() {
-		amount, err := m.tollwallet.Receive(paymentCashuToken)
+		amount, err := receiveWithRetry(m.tollwallet, paymentCashuToken)
 		ch <- receiveResult{amount, err}
 	}()
 
@@ -505,6 +505,9 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 		if errors.Is(err, tollwallet.ErrTokenAlreadySpent) {
 			errorCode = "payment-error-token-spent"
 			errorMessage = "Token has already been spent"
+		} else if isRateLimitError(err) {
+			errorCode = "mint-rate-limited"
+			errorMessage = "Mint is rate-limiting requests. Please try again in a moment."
 		} else {
 			errorCode = "payment-processing-failed"
 			errorMessage = fmt.Sprintf("Payment processing failed: %v", err)
@@ -555,6 +558,34 @@ func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr
 	}
 
 	return sessionEvent, nil
+}
+
+const rateLimitMaxRetries = 3
+
+func receiveWithRetry(tw tollwallet.TollWallet, token cashu.Token) (uint64, error) {
+	delay := 2 * time.Second
+	var lastErr error
+	for i := 0; i < rateLimitMaxRetries; i++ {
+		amount, err := tw.Receive(token)
+		if err == nil {
+			return amount, nil
+		}
+		lastErr = err
+		if !isRateLimitError(err) {
+			return 0, err
+		}
+		log.Printf("receiveWithRetry: mint rate-limited, retrying in %v (attempt %d/%d)", delay, i+1, rateLimitMaxRetries)
+		time.Sleep(delay)
+		delay *= 2
+	}
+	return 0, fmt.Errorf("mint rate-limited after %d retries: %w", rateLimitMaxRetries, lastErr)
+}
+
+func isRateLimitError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "429") ||
+		strings.Contains(msg, "rate limit") ||
+		strings.Contains(msg, "too many requests")
 }
 
 func (m *Merchant) GetAdvertisement() string {

--- a/src/merchant/retry_test.go
+++ b/src/merchant/retry_test.go
@@ -1,0 +1,32 @@
+package merchant
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsRateLimitError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"429 status code", errors.New("HTTP 429 Too Many Requests"), true},
+		{"rate limit message", errors.New("rate limit exceeded"), true},
+		{"Too Many Requests", errors.New("Too Many Requests"), true},
+		{"mixed case Rate Limited", errors.New("Rate Limited by server"), true},
+		{"generic error", errors.New("connection refused"), false},
+		{"token spent", errors.New("token already spent"), false},
+		{"network timeout", errors.New("context deadline exceeded"), false},
+		{"empty message", errors.New(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRateLimitError(tt.err)
+			if got != tt.want {
+				t.Errorf("isRateLimitError(%q) = %v, want %v", tt.err.Error(), got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

When a Cashu mint returns 429 (rate limit), payments are now retried up to 3 times with 2s/4s exponential backoff before failing. Previously, any 429 immediately returned `payment-processing-failed`.

## Why

Production mints like coinos.io rate-limit quote polling. Users see "Payment failed" instead of "Mint is busy, try again." With this fix, most 429s are handled transparently — the user never sees an error.

## Changes

- `receiveWithRetry()`: wraps `tollwallet.Receive()` with 429 detection + 3 retries (2s, 4s delays)
- `isRateLimitError()`: checks error string for 429/rate-limit/too-many-requests
- New error code `mint-rate-limited` with user-friendly message: "Mint is rate-limiting requests. Please try again in a moment."
- Existing `payment-processing-failed` still used for non-429 errors

## Why in tollgate-module-basic-go (not gonuts fork)

gonuts-tollgate is being replaced by CDK (#305). Investing in gonuts internals is throwaway. The retry wrapper lives at the merchant layer where we control the error codes and user-facing messages.

## Verification

- `go build` passes
- `go test ./...` passes (105s full suite)
- `gofmt` clean

Fixes #260.
