### PR TITLE
fix(#88): trigger NDS session after successful autopay

### DIFF
--- a/src/upstream_session_manager/session.go
+++ b/src/upstream_session_manager/session.go
@@ -402,7 +402,28 @@ func (s *UpstreamSession) sendPayment(steps uint64) (uint64, error) {
 		"allotment": allotment,
 	}).Info("✅ Payment accepted by upstream")
 
+	go s.triggerNdsSession()
+
 	return allotment, nil
+}
+
+func (s *UpstreamSession) triggerNdsSession() {
+	url := fmt.Sprintf("http://%s:80/", s.GatewayIP)
+	client := &http.Client{
+		Timeout:       10 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error { return nil },
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		logger.WithField("gateway", s.GatewayIP).Debug("NDS session trigger failed (non-critical)")
+		return
+	}
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	logger.WithFields(logrus.Fields{
+		"gateway": s.GatewayIP,
+		"status":  resp.StatusCode,
+	}).Info("NDS session triggered post-payment")
 }
 
 // recoverToken attempts to recover a failed payment token


### PR DESCRIPTION
## What

After the downstream router's payment is accepted by the upstream TollGate, the downstream now triggers an HTTP GET to the upstream's port 80. This creates an ndsctl client session so usage tracking works for router-to-router sessions.

## Why

**Root cause** (deep dive posted on #88): NDS only creates client sessions when it sees LAN traffic. Router-to-router payments arrive on port 2121 (backend API), bypassing NDS entirely. Without a port 80 trigger:

- `ndsctl auth <mac>` succeeds (creates auth entry) ✅
- `ndsctl json <mac>` returns `{}` (no session) ❌
- `GetClientStats()` fails silently, returns 0 ❌
- Usage tracking always reads 0 → gate never closes when allotment reached ❌

**Existing workaround**: `TriggerCaptivePortalSession` in `tollgate_prober.go` already does this port 80 trigger, but only runs during the discovery phase. If the NDS session expires before payment, usage tracking breaks.

## Fix

Added `triggerNdsSession()` to `UpstreamSession`, called as a goroutine after successful payment acceptance (after allotment is confirmed). This ensures the NDS session exists regardless of when discovery last ran.

```go
go s.triggerNdsSession()
```

Best-effort: failure is logged at debug level, doesn't block payment flow.

## Verification

- `go build` passes
- `go test` passes
- `gofmt` clean

Fixes #88.
