### PR TITLE
fix: return 200 instead of 500 on /usage when no session

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -522,7 +522,7 @@ func HandleUsage(w http.ResponseWriter, r *http.Request) {
 	macAddress, err := getMacAddress(ip)
 	if err != nil {
 		mainLogger.WithError(err).Error("Error getting MAC address for /usage")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "-1/-1")
 		return
 	}
@@ -532,7 +532,7 @@ func HandleUsage(w http.ResponseWriter, r *http.Request) {
 			"mac":   macAddress,
 			"error": err,
 		}).Error("Error getting usage")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "-1/-1")
 		return
 	}


### PR DESCRIPTION
## Problem

The `/usage` endpoint returns HTTP 500 when no active session exists. Spec HTTP #3 requires HTTP 200 with `-1/-1`.

## Fix

Change two `http.StatusInternalServerError` → `http.StatusOK` in `HandleUsage` (src/main.go lines 525 and 535).

## Evidence

PRTA parity test `test_parity_usage_status`:
```
Go   = 500  ← bug
Rust = 200  ← correct per spec
Body identical: -1/-1
```

The Rust implementation (tollgate-module-basic-rust) already returns 200 correctly.