### PR TITLE
security(#226): firewall backend API port 2121 to LAN only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Backend API firewall: port 2121 restricted to LAN interfaces.**
+  New nftables include (`30-backend-firewall.nft`) blocks the backend
+  API from non-br-lan interfaces. WiFi clients still reach the payment
+  endpoint via NDS users_to_router rules. WAN-side and upstream clients
+  can no longer directly probe the backend API. Defense-in-depth for
+  #226 — does not change the listen address or payment flow.
+
 ### Fixed
 
 - **Lightning quote persistence: data race + crash-safety fix.**

--- a/packaging/files/etc/nftables.d/30-backend-firewall.nft
+++ b/packaging/files/etc/nftables.d/30-backend-firewall.nft
@@ -12,9 +12,8 @@
 #
 # See: https://github.com/OpenTollGate/tollgate-module-basic-go/issues/226
 
-table inet fw4 {
-	chain backend_input_firewall {
-		type filter hook input priority -1; policy accept;
-		meta nfproto ipv4 iifname != "br-lan" tcp dport 2121 counter drop
-	}
+chain backend_input_firewall {
+	type filter hook input priority -1; policy accept
+
+	meta nfproto ipv4 iifname != { "br-lan", "lo" } tcp dport 2121 counter drop
 }

--- a/packaging/files/etc/nftables.d/30-backend-firewall.nft
+++ b/packaging/files/etc/nftables.d/30-backend-firewall.nft
@@ -1,0 +1,20 @@
+#!/usr/sbin/nft -f
+
+# Restrict backend API (port 2121) to LAN interfaces only.
+#
+# The TollGate backend listens on :2121 for payment processing. WiFi
+# clients on br-lan need access (NDS users_to_router allows tcp 2121).
+# This rule blocks port 2121 from all non-br-lan interfaces, preventing
+# WAN-side / upstream clients from directly probing the API.
+#
+# CLI access is unaffected (uses Unix domain socket, not TCP).
+# Outbound probing of upstream TollGates is unaffected (output, not input).
+#
+# See: https://github.com/OpenTollGate/tollgate-module-basic-go/issues/226
+
+table inet fw4 {
+	chain backend_input_firewall {
+		type filter hook input priority -1; policy accept;
+		meta nfproto ipv4 iifname != "br-lan" tcp dport 2121 counter drop
+	}
+}


### PR DESCRIPTION
## What

New nftables rule (`30-backend-firewall.nft`) blocks TCP port 2121 from non-br-lan interfaces. The backend API is no longer directly reachable from the WAN side.

## Why

The backend listens on `:2121` (all interfaces). Currently, any device that can route to the TollGate's IP — including upstream/WAN clients — can directly probe the payment API. This is a defense-in-depth concern raised in #226.

## Approach: firewall, not listen-address change

Moving the backend to `127.0.0.1:2121` would break the captive portal payment flow — WiFi clients POST to `gateway:2121` directly. Setting up a reverse proxy (uhttpd/nginx) adds significant complexity.

Instead, a single nftables rule provides the same security benefit:
- WiFi clients on br-lan: port 2121 reachable (NDS users_to_router allows it) 
- WAN/upstream clients: port 2121 blocked
- CLI: unaffected (uses Unix domain socket)
- Outbound probing of upstream TollGates: unaffected (output path)

## Verification

The rule is a standard nftables base chain at priority -1 (same pattern as #283's `20-nds-enforce.nft`). Loaded automatically by fw4 on boot/reload.

Fixes #226.
