### PR TITLE
fix(#325): use DecodeToken instead of DecodeTokenV4 in Fund()

### DIFF
--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -1098,7 +1098,7 @@ func (m *Merchant) Fund(cashuToken string) (uint64, error) {
 	}
 	log.Printf("Attempting to decode token (length: %d, preview: %s)", len(cashuToken), tokenPreview)
 
-	parsedToken, err := cashu.DecodeTokenV4(cashuToken)
+	parsedToken, err := cashu.DecodeToken(cashuToken)
 	if err != nil {
 		log.Printf("Failed to decode cashu token (length: %d): %v", len(cashuToken), err)
 		return 0, fmt.Errorf("invalid cashu token format: %w", err)


### PR DESCRIPTION
## Fix for #325

### Root cause

`Fund()` at `merchant.go:1101` called `cashu.DecodeTokenV4()` directly instead of the dispatch function `cashu.DecodeToken()`.

`DecodeTokenV4` expects `"cashuB"` prefix (V4/CBOR). V3 tokens have `"cashuA"` prefix → `ErrInvalidTokenV4` → Fund fails.

### Fix

One-line change: `DecodeTokenV4` → `DecodeToken`.

`DecodeToken` tries V4 first, falls back to V3. Same pattern already used at line 457.

### Test plan

- [x] Build: OK
- [ ] Go unit tests pass in CI
- [ ] Local API tests (9/9) with mock mint