### PR TITLE
fix(#324,#325): reject spending-condition-locked tokens + fix Fund() decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Spending condition validation: reject P2PK/HTLC-locked tokens.**
+  `tollwallet.Receive()` now checks each proof's secret for spending
+  conditions before crediting the user. Tokens with P2PK or HTLC locks
+  are rejected with `ErrLockedToken`, preventing an attacker from
+  getting free internet access with tokens the gateway can never spend.
+  Found during cashu-audit Layer 3 audit. Fixes #324.
+
+- **Fund() token decode: use generic DecodeToken instead of V4-only.**
+  `merchant.Fund()` called `cashu.DecodeTokenV4()` (V4-only, no V3
+  fallback). Changed to `cashu.DecodeToken()` which tries V4 then V3.
+  Fixes #325.
+
+### Fixed (pre-existing)
+
 - **Lightning quote persistence: data race + crash-safety fix.**
   `persistLightningQuotes` now deep-copies `lightningQuoteRecord`
   values under the `RLock` instead of sharing pointers — eliminates a

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -1098,7 +1098,7 @@ func (m *Merchant) Fund(cashuToken string) (uint64, error) {
 	}
 	log.Printf("Attempting to decode token (length: %d, preview: %s)", len(cashuToken), tokenPreview)
 
-	parsedToken, err := cashu.DecodeTokenV4(cashuToken)
+	parsedToken, err := cashu.DecodeToken(cashuToken)
 	if err != nil {
 		log.Printf("Failed to decode cashu token (length: %d): %v", len(cashuToken), err)
 		return 0, fmt.Errorf("invalid cashu token format: %w", err)

--- a/src/tollwallet/spending_conditions_test.go
+++ b/src/tollwallet/spending_conditions_test.go
@@ -1,0 +1,57 @@
+package tollwallet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/OpenTollGate/gonuts-tollgate/cashu"
+)
+
+func TestErrLockedToken_IsSentinel(t *testing.T) {
+	if !errors.Is(ErrLockedToken, ErrLockedToken) {
+		t.Fatal("ErrLockedToken should be detectable via errors.Is")
+	}
+}
+
+func TestErrLockedToken_Message(t *testing.T) {
+	if ErrLockedToken.Error() == "" {
+		t.Fatal("ErrLockedToken should have non-empty message")
+	}
+}
+
+func TestHasSpendingCondition_PlainSecret(t *testing.T) {
+	proofs := cashu.Proofs{
+		{Amount: 1, Secret: "just-a-plain-secret", C: "02abc"},
+	}
+	if hasLockedProofs(proofs) {
+		t.Fatal("plain secret should not be detected as locked")
+	}
+}
+
+func TestHasSpendingCondition_P2PKSecret(t *testing.T) {
+	proofs := cashu.Proofs{
+		{Amount: 1, Secret: `["P2PK",{"nonce":"abc123","data":"","tags":[["pubkeys","02abcdef"]]}]`, C: "02abc"},
+	}
+	if !hasLockedProofs(proofs) {
+		t.Fatal("P2PK secret should be detected as locked")
+	}
+}
+
+func TestHasSpendingCondition_HTLCSecret(t *testing.T) {
+	proofs := cashu.Proofs{
+		{Amount: 1, Secret: `["HTLC",{"nonce":"abc123","data":"","tags":[["hash_lock","abcdef"]]}]`, C: "02abc"},
+	}
+	if !hasLockedProofs(proofs) {
+		t.Fatal("HTLC secret should be detected as locked")
+	}
+}
+
+func TestHasSpendingCondition_MixedProofs(t *testing.T) {
+	proofs := cashu.Proofs{
+		{Amount: 1, Secret: "plain", C: "02abc"},
+		{Amount: 2, Secret: `["P2PK",{"nonce":"abc","data":"","tags":[]}]`, C: "02def"},
+	}
+	if !hasLockedProofs(proofs) {
+		t.Fatal("mixed proofs with one P2PK should be detected as locked")
+	}
+}

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -8,13 +8,15 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/OpenTollGate/tollgate-module-basic-go/src/lightning"
 	"github.com/OpenTollGate/gonuts-tollgate/cashu"
 	"github.com/OpenTollGate/gonuts-tollgate/cashu/nuts/nut04"
+	"github.com/OpenTollGate/gonuts-tollgate/cashu/nuts/nut10"
 	"github.com/OpenTollGate/gonuts-tollgate/wallet"
+	"github.com/OpenTollGate/tollgate-module-basic-go/src/lightning"
 )
 
 var ErrTokenAlreadySpent = errors.New("Token already spent")
+var ErrLockedToken = errors.New("token has spending conditions and cannot be spent by the gateway")
 
 // ErrWalletNotInitialized is returned by wallet operations when the underlying
 // cashu wallet has not been initialized (for example on a bare Merchant or in
@@ -116,6 +118,10 @@ func (w *TollWallet) Shutdown() error {
 
 func (w *TollWallet) Receive(token cashu.Token) (uint64, error) {
 	mint := token.Mint()
+
+	if hasLockedProofs(token.Proofs()) {
+		return 0, ErrLockedToken
+	}
 
 	swapToTrusted := false
 
@@ -299,6 +305,16 @@ func MintURLMatches(a, b string) bool {
 	return strings.EqualFold(ua.Host, ub.Host) &&
 		ua.Scheme == ub.Scheme &&
 		normalizePath(ua.Path) == normalizePath(ub.Path)
+}
+
+func hasLockedProofs(proofs cashu.Proofs) bool {
+	for _, proof := range proofs {
+		secret, err := nut10.DeserializeSecret(proof.Secret)
+		if err == nil && secret.Kind != nut10.AnyoneCanSpend {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizePath strips a single trailing slash from the path so that


### PR DESCRIPTION
## What

1. **#324**: Reject Cashu tokens with P2PK/HTLC spending conditions before crediting the user
2. **#325**: Fix Fund() to use generic DecodeToken (V4→V3 fallback) instead of V4-only

## Why #324 (Security — HIGH)

Found during cashu-audit Layer 3 audit (2026-07-28). TollGate accepted ANY Cashu token via POST to :2121/, including tokens with spending conditions (P2PK locks, HTLC hashes). The gateway would credit the user with internet access, but could never actually spend those tokens (no matching private key/preimage).

**Attack**: Attacker creates a P2PK-locked token → pays TollGate → gets internet → TollGate can't spend the token upstream → free internet.

**Fix**: `hasLockedProofs()` checks each proof's secret via `nut10.DeserializeSecret()`. If the kind is P2PK or HTLC (not AnyoneCanSpend), the token is rejected with `ErrLockedToken`.

## Why #325 (Bug — MEDIUM)

`Fund()` called `cashu.DecodeTokenV4()` (V4-only, no V3 fallback). An operator trying to fund with a V3 token (`cashuA...`) via CLI would get a decode error.

**Fix**: Changed to `cashu.DecodeToken()` which tries V4 first, falls back to V3.

## Tests

6 new tests in `spending_conditions_test.go`:
- Plain secret → accepted (no lock)
- P2PK secret → rejected
- HTLC secret → rejected
- Mixed proofs (1 plain + 1 P2PK) → rejected
- Sentinel error `ErrLockedToken` is detectable via `errors.Is`
- Sentinel error has non-empty message

All tollwallet tests pass (15 total). `go build` clean. `gofmt` clean.

## Audit References
- cashu-audit signoff: `signoffs/tollgate-module-basic-go/NUT-10-11-14-20260728-glm52.md`
- Issue #324: spending condition validation
- Issue #325: Fund() decode path

Fixes #324. Fixes #325.
