### PR TITLE
docs: fix stale SSID format comment

### DIFF
--- a/src/wireless_gateway_manager/vendor_element_manager.go
+++ b/src/wireless_gateway_manager/vendor_element_manager.go
@@ -65,7 +65,7 @@ func (v *VendorElementProcessor) parseVendorElements(rawIEs []byte) (map[string]
 func (v *VendorElementProcessor) calculateScore(ni NetworkInfo, vendorElements map[string]interface{}) int {
 	score := ni.Signal
 
-	// Check for the TollGate prefix, e.g., "TollGate-ABCD-2.4GHz-1"
+	// Check for the TollGate prefix, e.g., "TollGate-A1B2"
 	if strings.HasPrefix(ni.SSID, "TollGate-") {
 		// Assign a higher score for TollGate networks for prioritization
 		score += 100 // Arbitrary boost, as per user's requirement for captive portal


### PR DESCRIPTION
One-line comment fix. References #229 (closed — format already implemented in code).