### PR TITLE
fix: configurable rate limiter via TOLLGATE_RATE_LIMIT_RPM

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -42,7 +42,13 @@ func getIPLimiter(ip string) *rate.Limiter {
 	defer ipLimitersMu.Unlock()
 	limiter, exists := ipLimiters[ip]
 	if !exists {
-		limiter = rate.NewLimiter(rate.Every(time.Minute/10), 10)
+		rpm := 10
+		if v := os.Getenv("TOLLGATE_RATE_LIMIT_RPM"); v != "" {
+			if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+				rpm = parsed
+			}
+		}
+		limiter = rate.NewLimiter(rate.Every(time.Minute/time.Duration(rpm)), rpm)
 		ipLimiters[ip] = limiter
 	}
 	return limiter


### PR DESCRIPTION
## Problem

The rate limiter was hardcoded at 10 requests/minute. This broke local testing — 13 API tests run in 0.3 seconds, exceeding the limit and causing S12 to fail with HTTP 429.

## Fix

Make the rate configurable via `TOLLGATE_RATE_LIMIT_RPM` env var:
- Default: 10 req/min (same as before, safe for production)
- Testing: `TOLLGATE_RATE_LIMIT_RPM=1000` in `local-test.sh`
- Reseller: `TOLLGATE_RATE_LIMIT_RPM=30` for busier deployments

## Test plan

- [x] Build: OK
- [ ] Default behavior unchanged (10 rpm when env var unset)
- [ ] High limit works for testing