### PR TITLE
chore: gofmt cleanup — 16 files

### DIFF
--- a/src/cli/merchant_provider_test.go
+++ b/src/cli/merchant_provider_test.go
@@ -22,14 +22,14 @@ func (m *namedMerchant) DrainMint(mintURL string) (string, uint64, error) {
 	return "", 0, nil
 }
 func (m *namedMerchant) GetAcceptedMints() []config_manager.MintConfig { return nil }
-func (m *namedMerchant) GetBalance() uint64                             { return 0 }
-func (m *namedMerchant) GetBalanceByMint(mintURL string) uint64         { return 0 }
-func (m *namedMerchant) GetAllMintBalances() map[string]uint64          { return nil }
+func (m *namedMerchant) GetBalance() uint64                            { return 0 }
+func (m *namedMerchant) GetBalanceByMint(mintURL string) uint64        { return 0 }
+func (m *namedMerchant) GetAllMintBalances() map[string]uint64         { return nil }
 func (m *namedMerchant) PurchaseSession(cashuToken string, macAddress string) (*nostr.Event, error) {
 	return nil, nil
 }
-func (m *namedMerchant) GetAdvertisement() string { return "" }
-func (m *namedMerchant) StartPayoutRoutine()     {}
+func (m *namedMerchant) GetAdvertisement() string  { return "" }
+func (m *namedMerchant) StartPayoutRoutine()       {}
 func (m *namedMerchant) StartDataUsageMonitoring() {}
 func (m *namedMerchant) CreateNoticeEvent(level, code, message, customerPubkey string) (*nostr.Event, error) {
 	return nil, nil

--- a/src/cmd/tollgate-cli/contract_test.go
+++ b/src/cmd/tollgate-cli/contract_test.go
@@ -272,9 +272,9 @@ func TestConfigSetResponseShape(t *testing.T) {
 
 func TestWalletDrainDataShape(t *testing.T) {
 	data := map[string]interface{}{
-		"success":     true,
-		"tokens":      []interface{}{},
-		"total_sats":  uint64(1000),
+		"success":      true,
+		"tokens":       []interface{}{},
+		"total_sats":   uint64(1000),
 		"save_to_file": "drain.txt",
 	}
 

--- a/src/config_manager/config_schema.go
+++ b/src/config_manager/config_schema.go
@@ -1,17 +1,17 @@
 package config_manager
 
 type FieldSchema struct {
-	Name        string            `json:"name"`
-	Type        string            `json:"type"`
-	Description string            `json:"description,omitempty"`
-	Default     interface{}       `json:"default,omitempty"`
-	Required    bool              `json:"required"`
-	Enum        []string          `json:"enum,omitempty"`
-	Min         interface{}       `json:"min,omitempty"`
-	Max         interface{}       `json:"max,omitempty"`
-	Children    []FieldSchema     `json:"children,omitempty"`
-	JSONKey     string            `json:"json_key"`
-	Editable    bool              `json:"editable"`
+	Name        string        `json:"name"`
+	Type        string        `json:"type"`
+	Description string        `json:"description,omitempty"`
+	Default     interface{}   `json:"default,omitempty"`
+	Required    bool          `json:"required"`
+	Enum        []string      `json:"enum,omitempty"`
+	Min         interface{}   `json:"min,omitempty"`
+	Max         interface{}   `json:"max,omitempty"`
+	Children    []FieldSchema `json:"children,omitempty"`
+	JSONKey     string        `json:"json_key"`
+	Editable    bool          `json:"editable"`
 }
 
 func GetConfigSchema() []FieldSchema {
@@ -73,7 +73,7 @@ func GetConfigSchema() []FieldSchema {
 			Name: "ProfitShare", JSONKey: "profit_share", Type: "array",
 			Description: "Profit sharing configuration", Required: true, Editable: true,
 			Children: []FieldSchema{
-			{Name: "Factor", JSONKey: "factor", Type: "float64", Description: "Share ratio (0.0\u20131.0). All factors MUST sum to 1.0. Use 0.79 not 79\u2014this is a ratio, not a percentage.", Required: true, Editable: true, Min: 0.0, Max: 1.0},
+				{Name: "Factor", JSONKey: "factor", Type: "float64", Description: "Share ratio (0.0\u20131.0). All factors MUST sum to 1.0. Use 0.79 not 79\u2014this is a ratio, not a percentage.", Required: true, Editable: true, Min: 0.0, Max: 1.0},
 				{Name: "Identity", JSONKey: "identity", Type: "string", Description: "Identity name from identities.json", Required: true, Editable: true},
 			},
 		},

--- a/src/main.go
+++ b/src/main.go
@@ -203,8 +203,8 @@ func init() {
 		}
 		valve.AuthDelay = time.Duration(delaySeconds) * time.Second
 		mainLogger.WithFields(logrus.Fields{
-			"redirect_url":      mainConfig.RedirectURL,
-			"auth_delay":        valve.AuthDelay,
+			"redirect_url": mainConfig.RedirectURL,
+			"auth_delay":   valve.AuthDelay,
 			"auth_delay_source": func() string {
 				if mainConfig.AuthDelaySeconds > 0 {
 					return "config"

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -177,14 +177,14 @@ func (m *namedMerchant) DrainMint(mintURL string) (string, uint64, error) {
 	return "", 0, nil
 }
 func (m *namedMerchant) GetAcceptedMints() []config_manager.MintConfig { return nil }
-func (m *namedMerchant) GetBalance() uint64                             { return 0 }
-func (m *namedMerchant) GetBalanceByMint(mintURL string) uint64         { return 0 }
-func (m *namedMerchant) GetAllMintBalances() map[string]uint64          { return nil }
+func (m *namedMerchant) GetBalance() uint64                            { return 0 }
+func (m *namedMerchant) GetBalanceByMint(mintURL string) uint64        { return 0 }
+func (m *namedMerchant) GetAllMintBalances() map[string]uint64         { return nil }
 func (m *namedMerchant) PurchaseSession(cashuToken string, macAddress string) (*nostr.Event, error) {
 	return nil, nil
 }
-func (m *namedMerchant) GetAdvertisement() string { return "" }
-func (m *namedMerchant) StartPayoutRoutine()     {}
+func (m *namedMerchant) GetAdvertisement() string  { return "" }
+func (m *namedMerchant) StartPayoutRoutine()       {}
 func (m *namedMerchant) StartDataUsageMonitoring() {}
 func (m *namedMerchant) CreateNoticeEvent(level, code, message, customerPubkey string) (*nostr.Event, error) {
 	return nil, nil
@@ -204,4 +204,4 @@ func (m *namedMerchant) GetLightningInvoiceStatus(quoteID, macAddress string) (*
 	return nil, nil
 }
 func (m *namedMerchant) SetOnReachableSetChanged(func()) {}
-func (m *namedMerchant) Shutdown() error                  { return nil }
+func (m *namedMerchant) Shutdown() error                 { return nil }

--- a/src/merchant/lightning.go
+++ b/src/merchant/lightning.go
@@ -9,9 +9,9 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/OpenTollGate/gonuts-tollgate/cashu/nuts/nut04"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/utils"
 	"github.com/OpenTollGate/tollgate-module-basic-go/src/valve"
-	"github.com/OpenTollGate/gonuts-tollgate/cashu/nuts/nut04"
 )
 
 var ErrQuoteNotFound = errors.New("lightning quote not found")

--- a/src/merchant/merchant_degraded_test.go
+++ b/src/merchant/merchant_degraded_test.go
@@ -451,11 +451,11 @@ func TestOnFirstReachable_FiredAfterSetOnFirstReachableForDegradedReset(t *testi
 }
 
 type mockWallet struct {
-	balance         uint64
-	balanceByMint   map[string]uint64
-	overpaymentErr  error
+	balance           uint64
+	balanceByMint     map[string]uint64
+	overpaymentErr    error
 	overpaymentResult string
-	shutdownCalled  bool
+	shutdownCalled    bool
 }
 
 func (w *mockWallet) GetBalance() uint64 {

--- a/src/merchant/merchant_provider_test.go
+++ b/src/merchant/merchant_provider_test.go
@@ -42,8 +42,8 @@ func (m *mockMerchantForProvider) PurchaseSession(cashuToken string, macAddress 
 	return nil, fmt.Errorf("mock: %s", m.name)
 }
 
-func (m *mockMerchantForProvider) GetAdvertisement() string { return "" }
-func (m *mockMerchantForProvider) StartPayoutRoutine()     {}
+func (m *mockMerchantForProvider) GetAdvertisement() string  { return "" }
+func (m *mockMerchantForProvider) StartPayoutRoutine()       {}
 func (m *mockMerchantForProvider) StartDataUsageMonitoring() {}
 
 func (m *mockMerchantForProvider) CreateNoticeEvent(level, code, message, customerPubkey string) (*nostr.Event, error) {

--- a/src/merchant/mint_health_tracker.go
+++ b/src/merchant/mint_health_tracker.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	defaultRecoveryThreshold uint8 = 3
-	probeTimeout            = 30 * time.Second
-	probeInterval           = 5 * time.Minute
+	probeTimeout                   = 30 * time.Second
+	probeInterval                  = 5 * time.Minute
 
 	// Aggressive retry: when no mints are reachable at startup (e.g. WiFi STA
 	// not yet connected), probe every 15s with immediate recovery (threshold=1)
@@ -29,17 +29,17 @@ type mintConfigProvider interface {
 }
 
 type MintHealthTracker struct {
-	mu                   sync.RWMutex
-	reachableMints       map[string]bool
-	consecutiveSuccesses map[string]uint8
-	httpClient           *http.Client
-	configProvider       mintConfigProvider
-	recoveryThreshold    uint8
-	onFirstReachable     func()
-	hadReachableMint     bool
+	mu                    sync.RWMutex
+	reachableMints        map[string]bool
+	consecutiveSuccesses  map[string]uint8
+	httpClient            *http.Client
+	configProvider        mintConfigProvider
+	recoveryThreshold     uint8
+	onFirstReachable      func()
+	hadReachableMint      bool
 	onReachableSetChanged func()
-	reachableCount       int
-	stopCh               chan struct{}
+	reachableCount        int
+	stopCh                chan struct{}
 }
 
 func NewMintHealthTracker(configProvider mintConfigProvider) *MintHealthTracker {

--- a/src/merchant/offline_wallet_integration_test.go
+++ b/src/merchant/offline_wallet_integration_test.go
@@ -16,11 +16,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager"
-	"github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet"
 	"github.com/OpenTollGate/gonuts-tollgate/cashu"
 	"github.com/OpenTollGate/gonuts-tollgate/cashu/nuts/nut04"
 	"github.com/OpenTollGate/gonuts-tollgate/wallet"
+	"github.com/OpenTollGate/tollgate-module-basic-go/src/config_manager"
+	"github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet"
 )
 
 const testMintTarget = "https://nofee.testnut.cashu.space"

--- a/src/tollgate_protocol/validator.go
+++ b/src/tollgate_protocol/validator.go
@@ -3,8 +3,8 @@ package tollgate_protocol
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"github.com/nbd-wtf/go-nostr"
+	"strconv"
 )
 
 // TollGateAdvertisementKind is the Nostr event kind for TollGate advertisements

--- a/src/tollgate_protocol/validator.go
+++ b/src/tollgate_protocol/validator.go
@@ -3,8 +3,9 @@ package tollgate_protocol
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/nbd-wtf/go-nostr"
 	"strconv"
+
+	"github.com/nbd-wtf/go-nostr"
 )
 
 // TollGateAdvertisementKind is the Nostr event kind for TollGate advertisements

--- a/src/upstream_session_manager/merchant_provider_test.go
+++ b/src/upstream_session_manager/merchant_provider_test.go
@@ -17,7 +17,7 @@ func (m *namedMerchant) CreatePaymentTokenWithOverpayment(mintURL string, amount
 	return "", fmt.Errorf("mock: %s", m.name)
 }
 func (m *namedMerchant) GetAcceptedMints() []config_manager.MintConfig { return nil }
-func (m *namedMerchant) GetBalanceByMint(mintURL string) uint64         { return 0 }
+func (m *namedMerchant) GetBalanceByMint(mintURL string) uint64        { return 0 }
 func (m *namedMerchant) Fund(cashuToken string) (uint64, error) {
 	return 0, fmt.Errorf("mock: %s", m.name)
 }

--- a/src/wireless_gateway_manager/scanner.go
+++ b/src/wireless_gateway_manager/scanner.go
@@ -116,11 +116,11 @@ func (s *Scanner) ParseIwinfoOutput(output []byte, radio string) []NetworkInfo {
 	var networks []NetworkInfo
 
 	var current *struct {
-		bssid    string
-		ssid     string
-		signal   int
-		encrypt  string
-		channel  string
+		bssid     string
+		ssid      string
+		signal    int
+		encrypt   string
+		channel   string
 		hasSignal bool
 	}
 
@@ -139,11 +139,11 @@ func (s *Scanner) ParseIwinfoOutput(output []byte, radio string) []NetworkInfo {
 			}
 			fields := strings.Fields(line)
 			current = &struct {
-				bssid    string
-				ssid     string
-				signal   int
-				encrypt  string
-				channel  string
+				bssid     string
+				ssid      string
+				signal    int
+				encrypt   string
+				channel   string
 				hasSignal bool
 			}{}
 			if len(fields) > 0 {
@@ -293,4 +293,3 @@ func FormatScanResults(networks []NetworkInfo) string {
 func init() {
 	logger.WithField("module", "wireless_gateway_manager").Info("Wireless gateway manager module loaded")
 }
-

--- a/src/wireless_gateway_manager/types.go
+++ b/src/wireless_gateway_manager/types.go
@@ -25,9 +25,9 @@ type UpstreamManagerConfig struct {
 	SwitchCooldown         time.Duration
 	StartupGracePeriod     time.Duration
 	PostSwitchWait         time.Duration
-	StartupSettle         time.Duration
-	StartupRetryInterval  time.Duration
-	StartupScanInterval   time.Duration
+	StartupSettle          time.Duration
+	StartupRetryInterval   time.Duration
+	StartupScanInterval    time.Duration
 }
 
 type Connector struct {

--- a/src/wireless_gateway_manager/upstream_manager.go
+++ b/src/wireless_gateway_manager/upstream_manager.go
@@ -25,19 +25,19 @@ type ResellerModeChecker interface {
 }
 
 type UpstreamManager struct {
-	connector  ConnectorInterface
-	scanner    ScannerInterface
-	reseller   ResellerModeChecker
-	config     UpstreamManagerConfig
-	stopChan   chan struct{}
-	pauseMu    sync.Mutex
-	pauseUntil time.Time
-	blacklist   map[string]time.Time
-	blacklistMu sync.Mutex
-	failMu           sync.Mutex
-	consecutiveFails int
-	cooldownUntil    time.Time
-	connectivityCheckFn func() bool
+	connector            ConnectorInterface
+	scanner              ScannerInterface
+	reseller             ResellerModeChecker
+	config               UpstreamManagerConfig
+	stopChan             chan struct{}
+	pauseMu              sync.Mutex
+	pauseUntil           time.Time
+	blacklist            map[string]time.Time
+	blacklistMu          sync.Mutex
+	failMu               sync.Mutex
+	consecutiveFails     int
+	cooldownUntil        time.Time
+	connectivityCheckFn  func() bool
 	isTollGateConnection bool
 }
 
@@ -58,9 +58,9 @@ func DefaultUpstreamManagerConfig() UpstreamManagerConfig {
 		SwitchCooldown:         10 * time.Minute,
 		StartupGracePeriod:     90 * time.Second,
 		PostSwitchWait:         5 * time.Second,
-		StartupSettle:         15 * time.Second,
-		StartupRetryInterval:  10 * time.Second,
-		StartupScanInterval:   10 * time.Second,
+		StartupSettle:          15 * time.Second,
+		StartupRetryInterval:   10 * time.Second,
+		StartupScanInterval:    10 * time.Second,
 	}
 }
 
@@ -303,7 +303,7 @@ func (um *UpstreamManager) Start(ctx context.Context) {
 				reason = "not-associated"
 			} else {
 				currentSignal, _ = um.getCurrentSignal(staNetdev)
-	connected := um.checkConnectivityForStartup(staNetdev)
+				connected := um.checkConnectivityForStartup(staNetdev)
 				if connected {
 					if lostCount > 0 {
 						logger.WithField("lost_count", lostCount).Info("Connectivity restored")
@@ -314,16 +314,16 @@ func (um *UpstreamManager) Start(ctx context.Context) {
 						shouldScan = true
 						reason = "scheduled"
 					}
-			} else {
-				if um.isPaused() {
-					continue
-				}
-				lostCount++
-				lostThreshold := um.config.LostThreshold
-				if um.isTollGateConnection {
-					lostThreshold = um.config.TollGateLostThreshold
-				}
-				logger.WithField("lost_count", lostCount).Info("Connectivity lost")
+				} else {
+					if um.isPaused() {
+						continue
+					}
+					lostCount++
+					lostThreshold := um.config.LostThreshold
+					if um.isTollGateConnection {
+						lostThreshold = um.config.TollGateLostThreshold
+					}
+					logger.WithField("lost_count", lostCount).Info("Connectivity lost")
 					if lostCount >= lostThreshold {
 						if err := um.connector.CleanupStaleSTAs(); err != nil {
 							logger.WithError(err).Warn("Failed to cleanup stale STAs during emergency")
@@ -391,7 +391,7 @@ func (um *UpstreamManager) recordSwitchFailure() {
 	if um.consecutiveFails >= um.config.MaxConsecutiveFailures {
 		um.cooldownUntil = time.Now().Add(um.config.SwitchCooldown)
 		logger.WithFields(logrus.Fields{
-			"failures":        um.consecutiveFails,
+			"failures":         um.consecutiveFails,
 			"cooldown_minutes": um.config.SwitchCooldown.Minutes(),
 		}).Warn("Circuit breaker triggered: entering cooldown")
 	}


### PR DESCRIPTION
Pure formatting. `gofmt -l .` now returns empty on all source files.