### PR TITLE
chore: add gofmt check to pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -13,9 +13,10 @@ if git diff --cached --name-only | grep -q '\.go$'; then
     python3 tests/contract/check-import-paths.py
 fi
 
-# Check gofmt on staged Go files
+# Check gofmt on staged Go files (--diff-filter=d: gofmt cannot read
+# deleted files; xargs -I{} keeps one file per line, spaces-safe)
 if git diff --cached --name-only | grep -q '\.go$'; then
-    unformatted=$(gofmt -l $(git diff --cached --name-only -- '*.go'))
+    unformatted=$(git diff --cached --name-only --diff-filter=d -- '*.go' | xargs -I{} gofmt -l -- {})
     if [ -n "$unformatted" ]; then
         echo "❌ gofmt found unformatted files:"
         echo "$unformatted"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -12,3 +12,15 @@ if git diff --cached --name-only | grep -q '\.go$'; then
     echo "🔍 Checking for stale import paths..."
     python3 tests/contract/check-import-paths.py
 fi
+
+# Check gofmt on staged Go files
+if git diff --cached --name-only | grep -q '\.go$'; then
+    unformatted=$(gofmt -l $(git diff --cached --name-only -- '*.go'))
+    if [ -n "$unformatted" ]; then
+        echo "❌ gofmt found unformatted files:"
+        echo "$unformatted"
+        echo ""
+        echo "Run: gofmt -w <files>"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
Extends `hooks/pre-commit` to also check `gofmt -l` on staged `.go` files. Prevents the 16-file gofmt cleanup situation from recurring.

Combined with the existing dependency sync check, the pre-commit hook now catches:
1. Dependency version drift across go.mod files
2. Unformatted Go source files

Install: `git config core.hooksPath hooks`

Also recommend adding gofmt to CI (test.yml):
```yaml
  gofmt-check:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v6
      - uses: actions/setup-go@v6
        with:
          go-version-file: src/go.mod
      - name: gofmt check
        run: |
          cd src
          if [ -n "$(gofmt -l .)" ]; then
            echo "::error::gofmt found unformatted files"
            gofmt -l .
            exit 1
          fi
```