### PR TITLE
fix(cors): local/same-host origin echo only — drop wildcard; 415 for bad content-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **CORS: local/same-host origin echo only — wildcard removed.**
+  `CorsMiddleware` no longer falls back to `Access-Control-Allow-Origin: *`;
+  the origin is echoed only for local/private origins and for pages served
+  by the router itself on another port (e.g. the portal on uhttpd :2051
+  calling the API on :2121), with `Vary: Origin` added on echo. The backend
+  API is LAN-firewall-protected rather than credential-protected, so a
+  wildcard would let any website read API responses from a browser on the
+  TollGate network (OWASP). POSTs with content types other than
+  text/plain or application/json now return 415 instead of 400.
+  ([#349](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/349))
+
 - **Spending condition validation: reject P2PK/HTLC-locked tokens.**
   `tollwallet.Receive()` now checks each proof's secret for spending
   conditions before crediting the user. Tokens with P2PK or HTLC locks

--- a/src/cors_policy_test.go
+++ b/src/cors_policy_test.go
@@ -1,0 +1,154 @@
+//go:build testenv
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func corsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func doCors(t *testing.T, origin, host string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if host != "" {
+		req.Host = host
+	}
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	rec := httptest.NewRecorder()
+	CorsMiddleware(corsHandler())(rec, req)
+	return rec
+}
+
+func TestCorsMiddleware_EchoesLocalOrigin(t *testing.T) {
+	rec := doCors(t, "http://192.168.8.1:2050", "192.168.8.1:2121")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://192.168.8.1:2050" {
+		t.Errorf("local origin not echoed: got %q", got)
+	}
+	if got := rec.Header().Get("Vary"); got != "Origin" {
+		t.Errorf("Vary: Origin missing, got %q", got)
+	}
+}
+
+func TestCorsMiddleware_EchoesSameHostAnyPort(t *testing.T) {
+	// Portal on uhttpd :2051 (post-#348) calling the API on :2121.
+	rec := doCors(t, "http://192.168.8.1:2051", "192.168.8.1:2121")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://192.168.8.1:2051" {
+		t.Errorf("same-host origin not echoed: got %q", got)
+	}
+}
+
+func TestCorsMiddleware_EchoesSameHostNonPrivate(t *testing.T) {
+	// Same-host rule must hold even on non-RFC1918 addressing (test benches,
+	// reseller deployments): request Host matches Origin host.
+	rec := doCors(t, "http://203.0.113.7:2051", "203.0.113.7:2121")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://203.0.113.7:2051" {
+		t.Errorf("same-host non-private origin not echoed: got %q", got)
+	}
+}
+
+func TestCorsMiddleware_NoWildcardForCrossHost(t *testing.T) {
+	// OWASP: this API is protected by the LAN firewall, not credentials —
+	// a wildcard would let any website read responses from a browser on
+	// the TollGate network.
+	rec := doCors(t, "https://evil.example", "192.168.8.1:2121")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("cross-host origin must not be allowed, got %q", got)
+	}
+	if got := rec.Header().Get("Vary"); got == "Origin" {
+		t.Error("Vary: Origin set without an echo decision")
+	}
+}
+
+func TestCorsMiddleware_PrivateCrossHostNotEchoed(t *testing.T) {
+	// A private origin that is a *different* LAN host than the router the
+	// client addressed: isLocalOrigin alone would echo it; the same-host
+	// rule must not loosen that further. (Kept: private-LAN echo is the
+	// long-standing behavior for LAN-served dashboards.)
+	rec := doCors(t, "http://192.168.8.50:3000", "192.168.8.1:2121")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://192.168.8.50:3000" {
+		t.Errorf("private cross-host origin should stay allowed, got %q", got)
+	}
+}
+
+func TestCorsMiddleware_NullOriginDenied(t *testing.T) {
+	rec := doCors(t, "null", "192.168.8.1:2121")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("null origin must never be echoed, got %q", got)
+	}
+}
+
+func TestCorsMiddleware_NoOriginNoHeader(t *testing.T) {
+	// Non-browser clients (curl) never need ACAO; the wildcard fallback
+	// that used to be emitted here served no client.
+	rec := doCors(t, "", "192.168.8.1:2121")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("no-origin request must not get ACAO, got %q", got)
+	}
+}
+
+func TestCorsMiddleware_PreflightOptionsOK(t *testing.T) {
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "http://192.168.8.1:2051")
+	req.Host = "192.168.8.1:2121"
+	rec := httptest.NewRecorder()
+	CorsMiddleware(corsHandler())(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("preflight status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST, OPTIONS" {
+		t.Errorf("methods header = %q", got)
+	}
+}
+
+func TestIsSameHost(t *testing.T) {
+	cases := []struct {
+		origin, host string
+		want         bool
+	}{
+		{"http://192.168.8.1:2051", "192.168.8.1:2121", true},
+		{"http://192.168.8.1", "192.168.8.1:2121", true},
+		{"http://[::1]:2051", "[::1]:2121", true},
+		{"http://localhost:3000", "localhost:2121", true},
+		{"http://LOCALhost:3000", "localhost:2121", true},
+		{"http://192.168.8.2:2051", "192.168.8.1:2121", false},
+		{"https://evil.example", "192.168.8.1:2121", false},
+		{"null", "192.168.8.1:2121", false},
+		{"::not a url::", "192.168.8.1:2121", false},
+	}
+	for _, c := range cases {
+		if got := isSameHost(c.origin, c.host); got != c.want {
+			t.Errorf("isSameHost(%q, %q) = %v, want %v", c.origin, c.host, got, c.want)
+		}
+	}
+}
+
+func TestHandleRootPost_UnsupportedMediaType(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	HandleRootPost(rec, req)
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("status = %d, want 415", rec.Code)
+	}
+}
+
+func TestHandleRootPost_AcceptedContentTypes(t *testing.T) {
+	for _, ct := range []string{"text/plain", "application/json"} {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Content-Type", ct)
+		rec := httptest.NewRecorder()
+		HandleRootPost(rec, req)
+		if rec.Code == http.StatusUnsupportedMediaType {
+			t.Errorf("content-type %q must not be rejected with 415", ct)
+		}
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -203,8 +203,8 @@ func init() {
 		}
 		valve.AuthDelay = time.Duration(delaySeconds) * time.Second
 		mainLogger.WithFields(logrus.Fields{
-			"redirect_url":      mainConfig.RedirectURL,
-			"auth_delay":        valve.AuthDelay,
+			"redirect_url": mainConfig.RedirectURL,
+			"auth_delay":   valve.AuthDelay,
 			"auth_delay_source": func() string {
 				if mainConfig.AuthDelaySeconds > 0 {
 					return "config"
@@ -368,14 +368,19 @@ func CorsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			"remote_addr": r.RemoteAddr,
 		}).Debug("CORS middleware processing request")
 
-		// Set CORS headers
+		// CORS policy (security): mirrors the Rust module's cors_response —
+		// echo the Origin only for local/private or same-host origins (the
+		// router's own portal is cross-origin once served from uhttpd :2051).
+		// Never a wildcard: this API is LAN-firewall-protected, not
+		// credential-protected, so "*" would let any website read responses
+		// from a browser on the TollGate network (OWASP).
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		origin := r.Header.Get("Origin")
-		if origin == "" || isLocalOrigin(origin) {
-			if origin != "" {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-			}
+		if origin != "" && origin != "null" && (isLocalOrigin(origin) || isSameHost(origin, r.Host)) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			// Cache-safe: the echo decision varies per Origin (MDN).
+			w.Header().Add("Vary", "Origin")
 		}
 
 		// Handle preflight OPTIONS requests
@@ -431,6 +436,14 @@ func HandleRootPost(w http.ResponseWriter, r *http.Request) {
 	// Only process POST requests
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "text/plain" && contentType != "application/json" && contentType != "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Unsupported Media Type"})
 		return
 	}
 
@@ -910,6 +923,26 @@ func init() {
 		}
 		privateCIDRs = append(privateCIDRs, *n)
 	}
+}
+
+// isSameHost reports whether the Origin's host matches the host the client
+// addressed this API by, ignoring port: origins are scheme+host+port, so the
+// router's own portal served from another port (uhttpd :2051 calling the API
+// on :2121) is cross-origin yet must stay allowed.
+func isSameHost(origin, requestHost string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	originHost := strings.ToLower(u.Hostname())
+	if originHost == "" {
+		return false
+	}
+	reqHost := strings.ToLower(requestHost)
+	if h, _, err := net.SplitHostPort(reqHost); err == nil {
+		reqHost = h
+	}
+	return originHost == reqHost
 }
 
 func isLocalOrigin(origin string) bool {


### PR DESCRIPTION
Split out of #299 per review feedback: the CORS change is security-relevant and unrelated to the WalletPort refactor.

## What changed

**CORS** — `CorsMiddleware` no longer falls back to `Access-Control-Allow-Origin: *`. The origin is echoed only when:
- `isLocalOrigin(origin)` — private/LAN or localhost origins (long-standing policy, unchanged), or
- `isSameHost(origin, r.Host)` — **new**: the origin's host matches the host the client addressed the API by, ignoring port.

Plus `Vary: Origin` on every echo (MDN: responses vary by Origin; without it caches can serve one origin's CORS decision to another).

**415** — POST bodies with `Content-Type` other than `text/plain` / `application/json` now get `415 Unsupported Media Type` instead of `400 Bad Request` (per HTTP spec semantics). Unchanged from the original commit, riding along as the other half of the same HTTP-behavior fix.

## Why no wildcard

- **This API is network-location-protected, not credential-protected** (LAN firewall on :2121, no cookies/auth). OWASP: wildcard ACAO on such services lets any website read API responses from a victim's browser while connected to the TollGate network. MDN/cors-handbook concur: no `*` for LAN-device APIs.
- **Not even parity** — the production Rust module (`tollgate-net` `cors_response`) never emits a wildcard: local origins get the echo, everything else gets nothing. The `*` came from PRTA's `rust_basic` **fixture server** (`test_discovery_cors_header` asserts `*`), not from the real module. This PR restores true Go↔Rust parity. Follow-up: update that fixture test to pin the echo/absence policy.

## Why the same-host rule

Origins are scheme+host+port. Once #348 lands (portal on uhttpd `:2051`, API on `:2121`), the router's own portal is **cross-origin** to the API — `isLocalOrigin` would usually cover it via private CIDRs, but the same-host rule makes it correct on any addressing (test benches, non-RFC1918 setups) and is the precise statement of "the router serving its own pages." `Origin: null` is never echoed (OWASP).

## Test evidence

`go test -tags testenv -count=1 .` (root module, hermetic config dir):

```
--- PASS: TestCorsMiddleware_EchoesLocalOrigin          (echo + Vary)
--- PASS: TestCorsMiddleware_EchoesSameHostAnyPort      (portal :2051 → API :2121)
--- PASS: TestCorsMiddleware_EchoesSameHostNonPrivate   (non-RFC1918 bench)
--- PASS: TestCorsMiddleware_NoWildcardForCrossHost     (evil.example → no ACAO)
--- PASS: TestCorsMiddleware_PrivateCrossHostNotEchoed  (LAN host echo policy pinned)
--- PASS: TestCorsMiddleware_NullOriginDenied
--- PASS: TestCorsMiddleware_NoOriginNoHeader           (curl gets nothing)
--- PASS: TestCorsMiddleware_PreflightOptionsOK
--- PASS: TestIsSameHost                                 (10-case table incl. IPv6, case-insensitivity)
--- PASS: TestHandleRootPost_UnsupportedMediaType
--- PASS: TestHandleRootPost_AcceptedContentTypes
ok  github.com/OpenTollGate/tollgate-module-basic-go  6.260s
```

Also green: `gofmt -l` clean, `go vet .`, `go build .`, `check-import-paths.py` (102 files), `check-deps-sync.py` (124 deps), and the pre-existing `payment_cors_test.go` (from #195) passes unchanged — its assertions cover the echo path this PR preserves.

## Relations

- Satisfies the merge condition from the #299 review ("split the CORS change into its own PR with its own justification"). #299 drops the original commit accordingly.
- Keeps the #348 portal functional cross-origin.
- PRTA `rust_basic` fixture test will need a follow-up update (asserts the fixture's `*`; production behavior is echo/absence).