### PR TITLE
test(tollwallet): NUT-00 hash_to_curve cross-implementation vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,14 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Changed / Internal
 
+- **Cross-implementation hash_to_curve vectors.** `src/tollwallet` now pins
+  NUT-00 `HashToCurve` output byte-for-byte against the canonical
+  cross-implementation vector set (gonuts/btcec ↔ cashu-core-lite/k256 ↔
+  coincurve/Python), including the hex-looking-secret trap. Y is what
+  NUT-07 checkstate keys on — divergence silently reports spent proofs as
+  unspent (the bug class found twice in prta #86 review).
+  ([#351](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/351))
+
 - **Safe exec wrapper package.** New `src/sysexec/` package providing a
   testable `Runner` interface with context, timeout, structured logging,
   and retry support for `exec.Command` calls. Foundation for refactoring

--- a/src/tollwallet/cross_vectors_test.go
+++ b/src/tollwallet/cross_vectors_test.go
@@ -1,0 +1,37 @@
+package tollwallet
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/OpenTollGate/gonuts-tollgate/crypto"
+)
+
+// NUT-00 hash_to_curve cross-implementation vectors (canonical set lives in
+// the workspace as cashu-cross-vectors.json). The same secrets must produce
+// byte-identical Ys in gonuts (btcec), cashu-core-lite (k256), and the
+// coincurve Python port — Y is the value NUT-07 checkstate keys on, so any
+// divergence silently reports spent proofs as unspent. The third secret is a
+// valid hex string that MUST be hashed as its 64 ASCII characters verbatim;
+// hashing the decoded bytes instead yields a plausible-but-wrong Y — a
+// divergence that shipped in two independent implementations to date.
+func TestHashToCurveCrossVectors(t *testing.T) {
+	vectors := []struct {
+		secret string
+		yHex   string
+	}{
+		{"test-secret-01", "0279110ffdbbaccf1f96e0641dd8794fb206e8f95eb52c0fa001487b070cb5f7b1"},
+		{"a", "029794c59a5d9b910a18e50e10623c864b77c7edf4552f8652b0c85d30ac0498f0"},
+		{"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "0244d4bdec44e84725e2b6d9d7a2896df8bc27b482e84e0cb2144272d318375bc3"},
+	}
+	for _, v := range vectors {
+		y, err := crypto.HashToCurve([]byte(v.secret))
+		if err != nil {
+			t.Fatalf("HashToCurve(%q): %v", v.secret, err)
+		}
+		got := hex.EncodeToString(y.SerializeCompressed())
+		if got != v.yHex {
+			t.Errorf("HashToCurve(%q) = %s, want %s (cross-implementation divergence: gonuts vs k256/coincurve)", v.secret, got, v.yHex)
+		}
+	}
+}


### PR DESCRIPTION
Pins `crypto.HashToCurve` to byte-identical output across the three Cashu implementations we run in production paths: **gonuts (btcec/Go)**, **cashu-core-lite (k256/Rust)**, and the **coincurve Python port** (prta recovery tooling).

## Why this is load-bearing, not coverage filler

`Y = hash_to_curve(secret)` is the value NUT-07 checkstate keys on. Any divergence between implementations silently reports **spent proofs as unspent** — no error, just wrong recovery decisions. This exact bug class shipped twice in one week:

1. prta #86's original `compute_proof_y` returned the proof's `C` (blind signature) as Y — every token read UNSPENT, `--recover` would resubmit spent tokens.
2. The first patch draft (mine) hex-decoded hex-*looking* secrets before hashing; the mint hashes the secret string's UTF-8 bytes verbatim (`mint/mint.go:492`). Plausible-looking wrong Y.

The third vector in this test is precisely that trap: a valid 64-char hex string that MUST be hashed as its 64 ASCII characters.

## Scope

- This PR: `HashToCurve` only, in `src/tollwallet` (direct gonuts dependency — zero go.mod churn, untagged so the CI matrix picks it up everywhere).
- The full DHKE + NUT-12 DLEQ leg (generated on k256, verified by gonuts `crypto.VerifyDLEQ`/`Verify`) is pinned as `tests/cross_vectors.rs` in cashu-core-lite — commit Amperstrand/micronuts@125e8bc — since the deterministic generation harness naturally lives there.
- Canonical vector set lives in the workspace as `cashu-cross-vectors.json` (extend-only policy: add vectors, never edit).

## Test evidence

```
=== RUN   TestHashToCurveCrossVectors
--- PASS: TestHashToCurveCrossVectors (0.00s)
ok  github.com/OpenTollGate/tollgate-module-basic-go/src/tollwallet  5.231s
```

Contract checks green: import-paths (103 files), deps-sync (124 deps). Test-only diff — one file, +43 lines.