### PR TITLE
ci(spec): spec-quote drift checking in CI + vacuous-pass fix + drift repair

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,15 @@ jobs:
       - name: Schema lint
         run: node tests/contract/js-schema-lint.mjs
 
+      - name: Spec-quote drift check
+        run: |
+          pip install --user --break-system-packages git+https://github.com/rustyrussell/greatspectations.git >/dev/null 2>&1 || pip install git+https://github.com/rustyrussell/greatspectations.git >/dev/null 2>&1
+          export PATH="$PATH:$HOME/.local/bin"
+          git clone --depth=1 https://github.com/cashubtc/nuts.git nuts
+          FILES=$(find src -name "*.go" -not -name "*_test.go")
+          # Spec drift FAILS the build: quotes verified against spec HEAD.
+          greatspectate check --config specquotes.toml --comment-start "// " --comment-continue "//" $FILES
+
   build-purity:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,14 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Changed / Internal
 
+- **Spec-quote drift checking in CI.** greatspectates quotes are now
+  verified against current cashubtc/nuts HEAD on every push (new step
+  in the contract-lint job; drift fails the build). Fixed one drifted
+  NUT-03 quote (spec added backticks), added a NUT-05 quote at the
+  GonutsWallet melt site, and repaired two comment lines that
+  accidentally parsed as malformed quote markers.
+  ([#357](https://github.com/OpenTollGate/tollgate-module-basic-go/pull/357))
+
 - **Cross-implementation hash_to_curve vectors.** `src/tollwallet` now pins
   NUT-00 `HashToCurve` output byte-for-byte against the canonical
   cross-implementation vector set (gonuts/btcec ↔ cashu-core-lite/k256 ↔

--- a/make/speccheck.sh
+++ b/make/speccheck.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Spec-quote drift check (greatspectations vs cashubtc/nuts).
+# NOTE: --comment-start is "// " (trailing space) — the marker must
+# directly follow the comment start; "//" alone matches nothing and the
+# check passes vacuously (the bug this script version fixes).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v greatspectate >/dev/null 2>&1; then
+    echo "Installing greatspectations..."
+    pip install --user --break-system-packages git+https://github.com/rustyrussell/greatspectations.git >/dev/null 2>&1 || pip install git+https://github.com/rustyrussell/greatspectations.git >/dev/null 2>&1
+    export PATH="$PATH:$HOME/.local/bin"
+fi
+if [ ! -d nuts ]; then
+    echo "Cloning NUT specs..."
+    git clone --depth=1 https://github.com/cashubtc/nuts.git nuts
+fi
+
+echo "Checking spec quote drift..."
+# Drift is a report, never a build failure here: exit 0 either way.
+FILES=$(find src -name "*.go" -not -name "*_test.go")
+greatspectate check --config specquotes.toml --comment-start "// " --comment-continue "//" $FILES || true
+exit 0

--- a/src/merchant/merchant.go
+++ b/src/merchant/merchant.go
@@ -441,7 +441,7 @@ type PurchaseSessionResult struct {
 }
 
 // PurchaseSession processes a payment with cashu token and MAC address, returns either a session event or a notice event
-// NUT-00 verification quote lives above TollWallet.Receive (single source; duplicate quotes flag in speccheck).
+// Spec (NUT 00) verification quote lives above TollWallet.Receive — single source; duplicate quotes flag in speccheck.
 func (m *Merchant) PurchaseSession(cashuToken string, macAddress string) (*nostr.Event, error) {
 	// Validate MAC address
 	if !utils.ValidateMACAddress(macAddress) {

--- a/src/tollwallet/gonuts_wallet.go
+++ b/src/tollwallet/gonuts_wallet.go
@@ -157,6 +157,7 @@ func (w *GonutsWallet) RequestMeltQuote(invoice string, mintUrl string) (*MeltQu
 	return nil, fmt.Errorf("GonutsWallet.RequestMeltQuote: not yet wired; TollWallet uses MeltToLightning at a higher level")
 }
 
+// NUT #05: To request a melt quote, the wallet of `Alice` makes a `POST /v1/melt/quote/{method}` request where `method` is the payment method requested (e.g., `bolt11`, `bolt12`, etc.). `method` **MUST** match `[a-z0-9_-]+`.
 func (w *GonutsWallet) Melt(quoteID string) (*MeltResult, error) {
 	return nil, fmt.Errorf("GonutsWallet.Melt: not yet wired; TollWallet uses MeltToLightning at a higher level")
 }

--- a/src/tollwallet/port.go
+++ b/src/tollwallet/port.go
@@ -59,7 +59,7 @@ const (
 )
 
 // String returns the canonical uppercase string representation per Cashu
-// NUT-04 spec. Note: gonuts returned lowercase "unknown" for Unknown(4);
+// spec (NUT 04). Note: gonuts returned lowercase "unknown" for Unknown(4);
 // this implementation returns uppercase "UNKNOWN" as a spec-compliance
 // cleanup. Task 1.2 characterization test pins gonuts's behavior separately.
 func (s MintQuoteState) String() string {

--- a/src/tollwallet/tollwallet.go
+++ b/src/tollwallet/tollwallet.go
@@ -152,7 +152,7 @@ func (w *TollWallet) Receive(token cashu.Token) (uint64, error) {
 	return amountAfterSwap, nil
 }
 
-// NUT #03: The swap operation is the most important component of the Cashu system. A swap operation consists of multiple inputs (`Proofs`) and outputs (`BlindedMessages`). Mints verify and invalidate the inputs and issue new promises (`BlindSignatures`). These are then used by the wallet to generate new Proofs (see [NUT-00][00]).
+// NUT #03: The swap operation is the most important component of the Cashu system. A swap operation consists of multiple inputs (`Proofs`) and outputs (`BlindedMessages`). Mints verify and invalidate the inputs and issue new promises (`BlindSignatures`). These are then used by the wallet to generate new `Proofs` (see [NUT-00][00]).
 func (w *TollWallet) Send(amount uint64, mintUrl string, includeFees bool) (cashu.Token, error) {
 	log.Printf("TollWallet.Send: attempting to send %d sats from mint %s (includeFees=%t)", amount, mintUrl, includeFees)
 


### PR DESCRIPTION
Wires the greatspectations quote set into CI as a **drift-blocking** check — and fixes two real problems found while doing it.

## Found while wiring

1. **The invocation matters critically:** `--comment-start "//"` (no trailing space) matches **zero** quotes — the marker `NUT` never follows the comment start, so the check exits 0 having verified nothing. `"/ "` is required. The `make/speccheck.sh` carried by open #354 has exactly this bug: it passes vacuously. This PR ships a corrected script (with the trap documented in a comment) and supersedes that copy — worth folding into #354 or dropping theirs.
2. **One genuine spec drift:** the NUT-03 swap quote (from #327) no longer matches cashubtc/nuts HEAD — the spec now writes `` `Proofs` `` with backticks ("generate new Proofs" → "generate new `` `Proofs` ``"). Updated; 9/9 quotes now verify verbatim against current spec.
3. **Two malformed markers aborted whole-repo runs:** comment lines starting `// NUT-00 ...` / `// NUT-04 spec...` (a dedup pointer from #327 and a doc note from #299) parse as broken quote markers — one syntax error makes the tool return empty results. Rephrased both.

## What this adds

- **contract-lint CI step**: install greatspectations, clone nuts HEAD, run the check over all non-test sources. **Drift fails the build** — exit-code semantics verified by test (deliberately drifted quote → exit 1; clean → exit 0).
- **NUT-05 melt quote** at `GonutsWallet.Melt` (the #299 site) — the quote set now covers NUT-00/03/04/05 at their construction sites.
- **`make/speccheck.sh`** (correct version) for local runs: exit 0 always, prints the drift report.

## Verification

- `greatspectate check` over 56 source files: **9/9 quotes pass, 0 syntax errors** against nuts @ `734f60e` (current HEAD)
- Drift-injection test: bad quote → exit 1 (CI would fail); clean → exit 0
- gofmt clean on touched files; import-paths checker green; tollwallet builds + cross-vector test green
- CHANGELOG entry under Changed / Internal